### PR TITLE
Fix omitted IP version coerced to IPv4 when calling `partiton_relays`

### DIFF
--- a/desktop/packages/management-interface/dist/relay_selector_pb.d.ts
+++ b/desktop/packages/management-interface/dist/relay_selector_pb.d.ts
@@ -75,7 +75,10 @@ export class EntryConstraints extends jspb.Message {
     clearDaitaSettings(): void;
     getDaitaSettings(): management_interface_pb.DaitaSettings | undefined;
     setDaitaSettings(value?: management_interface_pb.DaitaSettings): EntryConstraints;
-    getIpVersion(): management_interface_pb.IpVersion;
+
+    hasIpVersion(): boolean;
+    clearIpVersion(): void;
+    getIpVersion(): management_interface_pb.IpVersion | undefined;
     setIpVersion(value: management_interface_pb.IpVersion): EntryConstraints;
 
     serializeBinary(): Uint8Array;
@@ -93,7 +96,7 @@ export namespace EntryConstraints {
         generalConstraints?: ExitConstraints.AsObject,
         obfuscationSettings?: management_interface_pb.ObfuscationSettings.AsObject,
         daitaSettings?: management_interface_pb.DaitaSettings.AsObject,
-        ipVersion: management_interface_pb.IpVersion,
+        ipVersion?: management_interface_pb.IpVersion,
     }
 }
 

--- a/desktop/packages/management-interface/dist/relay_selector_pb.js
+++ b/desktop/packages/management-interface/dist/relay_selector_pb.js
@@ -698,8 +698,8 @@ proto.mullvad_daemon.relay_selector.EntryConstraints.serializeBinaryToWriter = f
       management_interface_pb.DaitaSettings.serializeBinaryToWriter
     );
   }
-  f = message.getIpVersion();
-  if (f !== 0.0) {
+  f = /** @type {!proto.mullvad_daemon.management_interface.IpVersion} */ (jspb.Message.getField(message, 4));
+  if (f != null) {
     writer.writeEnum(
       4,
       f
@@ -833,7 +833,25 @@ proto.mullvad_daemon.relay_selector.EntryConstraints.prototype.getIpVersion = fu
  * @return {!proto.mullvad_daemon.relay_selector.EntryConstraints} returns this
  */
 proto.mullvad_daemon.relay_selector.EntryConstraints.prototype.setIpVersion = function(value) {
-  return jspb.Message.setProto3EnumField(this, 4, value);
+  return jspb.Message.setField(this, 4, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.mullvad_daemon.relay_selector.EntryConstraints} returns this
+ */
+proto.mullvad_daemon.relay_selector.EntryConstraints.prototype.clearIpVersion = function() {
+  return jspb.Message.setField(this, 4, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.mullvad_daemon.relay_selector.EntryConstraints.prototype.hasIpVersion = function() {
+  return jspb.Message.getField(this, 4) != null;
 };
 
 

--- a/mullvad-management-interface/proto/relay_selector.proto
+++ b/mullvad-management-interface/proto/relay_selector.proto
@@ -53,7 +53,7 @@ message EntryConstraints {
   // -- Entry specific constraints --
   management_interface.ObfuscationSettings obfuscation_settings = 2;
   management_interface.DaitaSettings daita_settings = 3;
-  management_interface.IpVersion ip_version = 4;
+  optional management_interface.IpVersion ip_version = 4;
 }
 
 // Constraints that apply to the second hop in a multihop configuration.

--- a/mullvad-management-interface/src/types/conversions/relay_selector.rs
+++ b/mullvad-management-interface/src/types/conversions/relay_selector.rs
@@ -69,10 +69,15 @@ impl TryFrom<proto::EntryConstraints> for EntryConstraints {
             .transpose()?
             .unwrap_or_default();
 
-        let ip_version: Constraint<_> = IpVersion::try_from(ip_version)
-            .map_err(|_| FromProtobufTypeError::invalid_argument("invalid IP protocol version"))
-            .map(talpid_types::net::IpVersion::from)?
-            .into();
+        let ip_version = Constraint::from(
+            ip_version
+                .map(IpVersion::try_from)
+                .transpose()
+                .map_err(|_| {
+                    FromProtobufTypeError::invalid_argument("invalid IP protocol version")
+                })?
+                .map(talpid_types::net::IpVersion::from),
+        );
 
         let obfuscation_settings = obfuscation_settings
             .map(mullvad_types::relay_constraints::ObfuscationSettings::try_from)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10476)
<!-- Reviewable:end -->
