### PR TITLE
Fix custom dns switch being stuck

### DIFF
--- a/android/lib/feature/dns/api/src/main/kotlin/net/mullvad/mullvadvpn/feature/dns/api/CustomDnsNavKey.kt
+++ b/android/lib/feature/dns/api/src/main/kotlin/net/mullvad/mullvadvpn/feature/dns/api/CustomDnsNavKey.kt
@@ -7,8 +7,9 @@ import net.mullvad.mullvadvpn.core.NavResult
 @Parcelize
 data class CustomDnsNavKey(val index: Int? = null, val initialValue: String? = null) : NavKey2
 
+@Parcelize
 sealed interface CustomDnsNavResult : NavResult {
-    @Parcelize data class Success(val isDnsListEmpty: Boolean) : CustomDnsNavResult
+    data class Success(val isDnsListEmpty: Boolean) : CustomDnsNavResult
 
-    @Parcelize data object Error : CustomDnsNavResult
+    data object Error : CustomDnsNavResult
 }

--- a/android/lib/feature/dns/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/dns/impl/CustomDnsDialog.kt
+++ b/android/lib/feature/dns/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/dns/impl/CustomDnsDialog.kt
@@ -74,12 +74,14 @@ fun CustomDns(navArgs: CustomDnsNavKey, navigator: Navigator) {
     val viewModel = koinViewModel<CustomDnsDialogViewModel> { parametersOf(navArgs) }
 
     CollectSideEffectWithLifecycle(viewModel.uiSideEffect) {
-        when (it) {
-            is CustomDnsDialogSideEffect.Complete ->
-                navigator.goBack(result = CustomDnsNavResult.Success(it.isDnsListEmpty))
-
-            CustomDnsDialogSideEffect.Error -> navigator.goBack(result = CustomDnsNavResult.Error)
-        }
+        navigator.goBack(
+            result =
+                when (it) {
+                    is CustomDnsDialogSideEffect.Complete ->
+                        CustomDnsNavResult.Success(it.isDnsListEmpty)
+                    CustomDnsDialogSideEffect.Error -> CustomDnsNavResult.Error
+                }
+        )
     }
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 

--- a/android/lib/feature/dns/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/dns/impl/DnsSettingsScreen.kt
+++ b/android/lib/feature/dns/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/dns/impl/DnsSettingsScreen.kt
@@ -103,13 +103,17 @@ fun SharedTransitionScope.DnsSettings(
     navArgs: DnsSettingsNavKey,
     animatedVisibilityScope: AnimatedVisibilityScope,
 ) {
-    val resultStore = LocalResultStore.current
     val vm = koinViewModel<DnsSettingsViewModel> { parametersOf(navArgs.isModal) }
     val snackbarHostState = remember { SnackbarHostState() }
 
-    resultStore.consumeResult<CustomDnsNavResult> { result ->
-        if (result == CustomDnsNavResult.Error) {
-            vm.showGenericErrorToast()
+    LocalResultStore.current.consumeResult<CustomDnsNavResult> { result ->
+        when (result) {
+            is CustomDnsNavResult.Success -> {
+                if (!result.isDnsListEmpty) {
+                    vm.onCustomDnsDialogSuccess()
+                }
+            }
+            CustomDnsNavResult.Error -> vm.showGenericErrorToast()
         }
     }
 

--- a/android/lib/feature/dns/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/dns/impl/DnsSettingsViewModel.kt
+++ b/android/lib/feature/dns/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/dns/impl/DnsSettingsViewModel.kt
@@ -5,8 +5,10 @@ import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import java.net.Inet6Address
 import java.net.InetAddress
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
@@ -135,6 +137,14 @@ class DnsSettingsViewModel(
         _uiSideEffect.send(DnsSettingsSideEffect.ShowToast.GenericError)
     }
 
+    fun onCustomDnsDialogSuccess() = viewModelScope.launch {
+        // This is to fix an ui issue where the switch gets stuck due to animations starting at the
+        // same time. This is likely to be fixed in the next stable version of material 3.
+        // Reverting this hack is tracked here: DROID-2734
+        delay(SHORT_DELAY)
+        settingsRepository.setDnsState(DnsState.Custom).onLeft { showGenericErrorToast() }
+    }
+
     private fun updateContentBlockersAndNotify(update: (DefaultDnsOptions) -> DefaultDnsOptions) =
         viewModelScope.launch(dispatcher) {
             settingsRepository.updateContentBlockers(update).onLeft {
@@ -152,4 +162,8 @@ class DnsSettingsViewModel(
     }
 
     private fun InetAddress.isLocalAddress(): Boolean = isLinkLocalAddress || isSiteLocalAddress
+
+    companion object {
+        private val SHORT_DELAY = 5.milliseconds
+    }
 }

--- a/android/lib/feature/vpnsettings/api/src/main/kotlin/net/mullvad/mullvadvpn/feature/vpnsettings/api/CustomDnsInfoNavKey.kt
+++ b/android/lib/feature/vpnsettings/api/src/main/kotlin/net/mullvad/mullvadvpn/feature/vpnsettings/api/CustomDnsInfoNavKey.kt
@@ -1,6 +1,0 @@
-package net.mullvad.mullvadvpn.feature.vpnsettings.api
-
-import kotlinx.parcelize.Parcelize
-import net.mullvad.mullvadvpn.core.NavKey2
-
-@Parcelize data object CustomDnsInfoNavKey : NavKey2

--- a/android/lib/grpc/src/main/kotlin/net/mullvad/mullvadvpn/lib/grpc/ManagementService.kt
+++ b/android/lib/grpc/src/main/kotlin/net/mullvad/mullvadvpn/lib/grpc/ManagementService.kt
@@ -516,10 +516,7 @@ class ManagementService(
                 val updatedDnsOptions = currentDnsOptions.copy {
                     DnsOptions.customOptions.addresses set
                         currentDnsOptions.customOptions.addresses + address
-                    // If it is the first address, then turn on Custom Dns
-                    DnsOptions.state set
-                        if (currentDnsOptions.customOptions.addresses.isEmpty()) DnsState.Custom
-                        else currentDnsOptions.state
+                    DnsOptions.state set currentDnsOptions.state
                 }
                 grpc.setDnsOptions(updatedDnsOptions.fromDomain())
                 updatedDnsOptions.customOptions.addresses.lastIndex


### PR DESCRIPTION
This PR does the following:
1. Separate the adding of a new dns server and the enabling of custom dns.
2. This is done to enable a short delay so that the adding of a dns server and the enabling of custom dns is not done in the same state update. This is a work-around for a bug with the switch animation which is fixed on the current alpha of the material 3 library.
3. Fixes a bug with nav result for custom dns dialog that due to implicit types caused the nav result to not trigger any callback in the dns settings screen.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10478)
<!-- Reviewable:end -->
