### PR TITLE
Stop logging SOCKS usernames

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -23,7 +23,10 @@ Line wrap the file at 100 chars.                                              Th
 
 ## UNRELEASED
 ### Add
-- Add support for connecting over IPv6
+- Add support for connecting over IPv6.
+
+### Fixed
+- Stop logging access method credentials in logs.
 
 ## [2026.2 - 2026-04-21]
 ### Add

--- a/talpid-types/src/net/proxy.rs
+++ b/talpid-types/src/net/proxy.rs
@@ -198,7 +198,7 @@ pub struct Socks5Remote {
 /// RFC 1929: <https://datatracker.ietf.org/doc/html/rfc1929>.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct SocksAuth {
-    username: String,
+    username: Sensitive<String>,
     password: Sensitive<String>,
 }
 
@@ -260,7 +260,7 @@ impl SocksAuth {
         }
 
         Ok(SocksAuth {
-            username,
+            username: username.into(),
             password: password.into(),
         })
     }


### PR DESCRIPTION
Much like the last one, we came to the conclusion that we shouldn't be logging SOCKS usernames either.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10479)
<!-- Reviewable:end -->
