### PR TITLE
Remove/update FIXME comment regarding shutdown detection on macOS

### DIFF
--- a/mullvad-daemon/src/shutdown.rs
+++ b/mullvad-daemon/src/shutdown.rs
@@ -27,8 +27,16 @@ pub fn is_shutdown_user_initiated() -> bool {
 }
 
 /// Currently returns false all of the time to ensure that no leaks occur during shutdown.
-// FIXME: implement shutdown detection - the current implementation will always block network
-// traffic when the daemon is shut down.
+// !!! Read before you think of implementing shutdown detection.
+//
+// I've tried using the IOKit API for this, but the launch daemon seemingly only receives a SIGTERM
+// during shutdown/reboot.
+//
+// If you're thinking, "Ah, then I will attempt to use the undocumented BSD notification
+// `com.apple.system.loginwindow.shutdownInitiated`": No. Same issue.
+//
+// It might be that I'm missing something, but neither of these two methods appears to work. You
+// have been warned.
 #[cfg(target_os = "macos")]
 pub fn is_shutdown_user_initiated() -> bool {
     false


### PR DESCRIPTION
Tried to implement shutdown detection for the launch daemon so it doesn't block if manually unloaded (branch name `macos-detect-shutdown` if it still exists). Can't find a non-hacky way to detect this, so I've just updated the comment.

Closes DES-2978.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10482)
<!-- Reviewable:end -->
