### PR TITLE
Update logic for determining exit and entry exclusion in location list

### DIFF
--- a/ios/MullvadMockData/MullvadREST/RelaySelectorStub.swift
+++ b/ios/MullvadMockData/MullvadREST/RelaySelectorStub.swift
@@ -36,7 +36,8 @@ public final class RelaySelectorStub: @unchecked Sendable, RelaySelectorProtocol
     }
 
     public func findCandidates(
-        tunnelSettings: LatestTunnelSettings
+        tunnelSettings: LatestTunnelSettings,
+        includeInactive: Bool
     ) throws -> RelayCandidates {
         return try candidatesResult?() ?? RelayCandidates(entryRelays: [], exitRelays: [])
     }

--- a/ios/MullvadREST/Relay/RelaySelectorProtocol.swift
+++ b/ios/MullvadREST/Relay/RelaySelectorProtocol.swift
@@ -12,13 +12,15 @@ import MullvadTypes
 /// Protocol describing a type that can select a relay.
 public protocol RelaySelectorProtocol: Sendable {
     var relayCache: RelayCacheProtocol { get }
+
     func selectRelays(
         tunnelSettings: LatestTunnelSettings,
         connectionAttemptCount: UInt
     ) throws -> SelectedRelays
 
     func findCandidates(
-        tunnelSettings: LatestTunnelSettings
+        tunnelSettings: LatestTunnelSettings,
+        includeInactive: Bool
     ) throws -> RelayCandidates
 }
 

--- a/ios/MullvadREST/Relay/RelaySelectorWrapper.swift
+++ b/ios/MullvadREST/Relay/RelaySelectorWrapper.swift
@@ -39,9 +39,9 @@ public final class RelaySelectorWrapper: RelaySelectorProtocol, Sendable {
         }
     }
 
-    /// This function is expected to be used by the UI to list all available servers, even the inactive ones.
+    /// This function is expected to be used by the UI to query available servers.
     /// For the purposes of creating a relay connection, we should use `selectRelays` instead.
-    public func findCandidates(tunnelSettings: LatestTunnelSettings) throws -> RelayCandidates {
+    public func findCandidates(tunnelSettings: LatestTunnelSettings, includeInactive: Bool) throws -> RelayCandidates {
         let relays = try relayCache.read().relays
 
         let obfuscation = try RelayObfuscator(
@@ -52,15 +52,15 @@ public final class RelaySelectorWrapper: RelaySelectorProtocol, Sendable {
         ).obfuscate()
 
         let findCandidates:
-            (REST.ServerRelaysResponse, Bool, RelayConstraint, RelayObfuscation?) throws
-                -> [RelayWithLocation<REST.ServerRelay>] = { relays, daitaEnabled, filter, obfuscation in
+            (REST.ServerRelaysResponse, Bool, RelayConstraint, RelayConstraint, RelayObfuscation?) throws
+                -> [RelayWithLocation<REST.ServerRelay>] = { relays, daitaEnabled, locations, filter, obfuscation in
                     try RelaySelector.WireGuard.findCandidates(
-                        by: .any,
+                        by: locations,
                         in: relays,
                         filterConstraint: filter,
                         daitaEnabled: daitaEnabled,
                         obfuscation: obfuscation,
-                        includeInactive: true
+                        includeInactive: includeInactive
                     )
                 }
 
@@ -69,12 +69,14 @@ public final class RelaySelectorWrapper: RelaySelectorProtocol, Sendable {
                 entryRelays: try findCandidates(
                     relays,
                     tunnelSettings.daita.isEnabled,
+                    tunnelSettings.relayConstraints.entryLocations,
                     tunnelSettings.relayConstraints.entryFilter,
                     obfuscation
                 ),
                 exitRelays: try findCandidates(
                     relays,
                     false,
+                    tunnelSettings.relayConstraints.exitLocations,
                     tunnelSettings.relayConstraints.exitFilter,
                     nil
                 )
@@ -84,12 +86,14 @@ public final class RelaySelectorWrapper: RelaySelectorProtocol, Sendable {
                 entryRelays: try findCandidates(
                     relays,
                     tunnelSettings.daita.isEnabled,
+                    tunnelSettings.relayConstraints.entryLocations,
                     tunnelSettings.relayConstraints.entryFilter,
                     obfuscation
                 ),
                 exitRelays: try findCandidates(
                     relays,
                     false,
+                    tunnelSettings.relayConstraints.exitLocations,
                     tunnelSettings.relayConstraints.exitFilter,
                     nil
                 )
@@ -100,6 +104,7 @@ public final class RelaySelectorWrapper: RelaySelectorProtocol, Sendable {
                 exitRelays: try findCandidates(
                     relays,
                     tunnelSettings.daita.isEnabled,
+                    tunnelSettings.relayConstraints.exitLocations,
                     tunnelSettings.relayConstraints.exitFilter,
                     obfuscation
                 )

--- a/ios/MullvadSettings/TunnelSettingsV8.swift
+++ b/ios/MullvadSettings/TunnelSettingsV8.swift
@@ -39,6 +39,13 @@ public struct TunnelSettingsV8: Codable, Equatable, TunnelSettings, Sendable {
             || (tunnelMultihopState == .always && relayConstraints.entryLocations == .any)
     }
 
+    public var withAnyLocation: Self {
+        var copy = self
+        copy.relayConstraints.entryLocations = .any
+        copy.relayConstraints.exitLocations = .any
+        return copy
+    }
+
     public init(
         relayConstraints: RelayConstraints = RelayConstraints(),
         dnsSettings: DNSSettings = DNSSettings(),

--- a/ios/MullvadTypes/RelayLocation.swift
+++ b/ios/MullvadTypes/RelayLocation.swift
@@ -101,8 +101,8 @@ public enum RelayLocation: Codable, Hashable, CustomDebugStringConvertible, Send
             return country
         case let .city(country, city):
             return "\(country)-\(city)"
-        case let .hostname(country, city, host):
-            return "\(country)-\(city)-\(host)"
+        case let .hostname(_, _, host):
+            return host
         }
     }
 }

--- a/ios/MullvadVPN/View controllers/RelayFilter/RelayFilterViewModel.swift
+++ b/ios/MullvadVPN/View controllers/RelayFilter/RelayFilterViewModel.swift
@@ -26,7 +26,7 @@ final class RelayFilterViewModel {
         multihopContext: MultihopContext
     ) {
         self.settings = settings
-        var settingsCopy = settings
+        var settingsCopy = settings.withAnyLocation
 
         self.relaySelectorWrapper = relaySelectorWrapper
         self.multihopContext = multihopContext
@@ -44,7 +44,10 @@ final class RelayFilterViewModel {
         // This constraint ensures that the selected relays are associated with the current tunnel settings
         // and serve as the primary source of truth for subsequent filtering operations.
         // Further filtering will be applied based on specific criteria such as `ownership` or `provider`.
-        if let relayCandidatesForAny = try? relaySelectorWrapper.findCandidates(tunnelSettings: settingsCopy) {
+        if let relayCandidatesForAny = try? relaySelectorWrapper.findCandidates(
+            tunnelSettings: settingsCopy,
+            includeInactive: false
+        ) {
             self.relayCandidatesForAny = relayCandidatesForAny
         } else {
             relayCandidatesForAny = RelayCandidates(entryRelays: nil, exitRelays: [])

--- a/ios/MullvadVPN/View controllers/SelectLocation/DataSource/LocationDataSourceProtocol.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/DataSource/LocationDataSourceProtocol.swift
@@ -146,33 +146,18 @@ extension LocationDataSourceProtocol {
         }
     }
 
-    /// Excludeds nodes from being selectable. A node gets excluded if the selection only allows for one possible relay.
-    /// This is used in multihop to make sure that the during relay selection entry and exit can different.
+    /// Excludes nodes from being selectable. A node gets excluded if the selection only allows for one possible relay.
+    /// This is used in multihop to make sure that during relay selection entry and exit can be different.
     /// It prevent the user from making a selection that would lead to the blocked state.
     /// - Parameters:
-    ///   - constraint: The selection that should be checked for exclusion.
-    func setExcludedNode(constraint: RelayConstraint<UserSelectedRelays>?) {
+    ///   - hostname: The selection that should be checked for exclusion.
+    func setExcludedNode(hostname: String?) {
         nodes.forEachNode { node in
             node.isExcluded = false
 
-            guard let selectedRelayLocations = constraint?.value?.locations else {
-                return
-            }
-
-            guard selectedRelayLocations.count == 1,
-                let selectedRelayLocation = selectedRelayLocations.first
-            else {
-                return
-            }
-
-            let locations = Set((node.flattened + [node]).flatMap { $0.locations })
-            if locations
-                .contains(selectedRelayLocation) && node.activeRelayNodes.count == 1
-            {
+            let nodeHosts = node.activeRelayNodes
+            if (nodeHosts.count == 1) && (nodeHosts.first?.name == hostname) {
                 node.isExcluded = true
-                node.forEachDescendant { child in
-                    child.isExcluded = true
-                }
             }
         }
     }

--- a/ios/MullvadVPN/View controllers/SelectLocation/SelectLocationViewModel.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/SelectLocationViewModel.swift
@@ -382,12 +382,14 @@ class SelectLocationViewModelImpl: SelectLocationViewModel {
 
     private func fetchLocations() {
         relaysCandidates = try? relaySelectorWrapper.findCandidates(
-            tunnelSettings: tunnelManager.settings
+            tunnelSettings: tunnelManager.settings.withAnyLocation,
+            includeInactive: true
         )
         if let allRelaysCandidates = try? relaySelectorWrapper.findCandidates(
             tunnelSettings: .init(
                 tunnelMultihopState: tunnelManager.settings.tunnelMultihopState
-            )
+            ),
+            includeInactive: true
         ) {
             entryContext.totalRelayCount = allRelaysCandidates.entryRelays?.count ?? 0
             exitContext.totalRelayCount = allRelaysCandidates.exitRelays.count
@@ -454,40 +456,56 @@ class SelectLocationViewModelImpl: SelectLocationViewModel {
     }
 
     private func updateSelections() {
-        let selectedEntryConstraint = tunnelManager.settings.relayConstraints.entryLocations
-        let selectedExitConstraint = tunnelManager.settings.relayConstraints.exitLocations
-
-        let updateRecentsDataSources:
-            (
-                LocationDataSourceProtocol,
-                RelayConstraint<UserSelectedRelays>
-            ) -> Void = { dataSource, selected in
-                dataSource.setSelectedNode(constraint: selected)
-            }
+        let exclusionCandidates = try? relaySelectorWrapper.findCandidates(
+            tunnelSettings: tunnelManager.settings,
+            includeInactive: false
+        )
 
         let updateLocationsDataSources:
             (
                 [LocationDataSourceProtocol],
                 RelayConstraint<UserSelectedRelays>,
-                RelayConstraint<UserSelectedRelays>
-            ) -> Void = { dataSources, selected, excluded in
+                MultihopContext
+            ) -> Void = { dataSources, selected, context in
                 dataSources.forEach {
                     $0.setSelectedNode(constraint: selected)
                     $0.expandSelection()
 
-                    if self.isMultihopActive {
-                        $0.setExcludedNode(constraint: excluded)
+                    // When multihopping, the UI should show what servers cannot be selected based on what was
+                    // selected in the "other" hop. For each hop, either entry or exit, do:
+                    // 1. Get the other hop's relays that match the current hop.
+                    // 2. If there's only one match, that means - by deduction - that this is the same relay
+                    //    that was selected in the current hop.
+                    // 3. Update the matching node to be excluded in its data source.
+                    if self.multihopState.isAlways {
+                        switch context {
+                        case .entry:
+                            if let candidates = exclusionCandidates?.exitRelays, candidates.count == 1,
+                                let relay = candidates.first?.relay
+                            {
+                                $0.setExcludedNode(hostname: relay.hostname)
+                            }
+                        case .exit:
+                            if let candidates = exclusionCandidates?.entryRelays, candidates.count == 1,
+                                let relay = candidates.first?.relay
+                            {
+                                $0.setExcludedNode(hostname: relay.hostname)
+                            }
+                        }
                     }
                 }
             }
 
         updateLocationsDataSources(
-            [entryCustomListsDataSource, entryLocationsDataSource], selectedEntryConstraint, selectedExitConstraint)
+            [entryRecentsDataSource, entryCustomListsDataSource, entryLocationsDataSource],
+            tunnelManager.settings.relayConstraints.entryLocations,
+            .entry
+        )
         updateLocationsDataSources(
-            [exitCustomListsDataSource, exitLocationsDataSource], selectedExitConstraint, selectedEntryConstraint)
-
-        updateRecentsDataSources(entryRecentsDataSource, selectedEntryConstraint)
-        updateRecentsDataSources(exitRecentsDataSource, selectedExitConstraint)
+            [exitRecentsDataSource, exitCustomListsDataSource, exitLocationsDataSource],
+            tunnelManager.settings.relayConstraints.exitLocations,
+            .exit
+        )
 
         exitContext.selectedLocation =
             [exitRecentsDataSource, exitCustomListsDataSource, exitLocationsDataSource].firstSelectedNode

--- a/ios/MullvadVPN/View controllers/SelectLocation/Views/ExitLocationView.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/Views/ExitLocationView.swift
@@ -142,6 +142,7 @@ struct ExitLocationView<ViewModel: SelectLocationViewModel>: View {
             if !$context.recents.isEmpty {
                 RecentLocationsListView(
                     locations: $context.recents,
+                    multihopContext: viewModel.multihopContext,
                     onSelectLocation: { location in
                         if viewModel.filtersWillBeOverridden(location) {
                             multihopWarningAlert = getMultihopFilterOverrideWarningAlert(node: location)

--- a/ios/MullvadVPN/View controllers/SelectLocation/Views/ListItemFactory.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/Views/ListItemFactory.swift
@@ -12,7 +12,7 @@ import SwiftUI
 struct ListItemFactory {
     enum Label {
         case location(node: LocationNode, context: MultihopContext, level: Int)
-        case recent(node: LocationNode)
+        case recent(node: LocationNode, context: MultihopContext)
         case setting(title: String, subtitle: String? = nil, level: Int = 0, selected: Bool = false)
     }
 
@@ -34,8 +34,8 @@ struct ListItemFactory {
         switch label {
         case .location(let node, let context, let level):
             LocationItemView(node: node, multihopContext: context, level: level)
-        case .recent(let node):
-            RecentItemView(node: node)
+        case .recent(let node, let context):
+            RecentItemView(node: node, multihopContext: context)
         case .setting(let title, let subtitle, let level, let selected):
             ListItem(
                 title: title,

--- a/ios/MullvadVPN/View controllers/SelectLocation/Views/RecentItemView.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/Views/RecentItemView.swift
@@ -6,13 +6,31 @@
 //  Copyright © 2026 Mullvad VPN AB. All rights reserved.
 //
 
+import MullvadTypes
 import SwiftUI
 
 struct RecentItemView: View {
     let node: LocationNode
+    let multihopContext: MultihopContext
 
-    var isDisabled: Bool {
-        !node.isActive || node.isExcluded
+    var title: String {
+        if node.isExcluded {
+            switch multihopContext {
+            case .entry:
+                return """
+                    \(node.name) (\(String(localized:
+                    String
+                    .LocalizationValue(MultihopContext.exit.description))))
+                    """
+            case .exit:
+                return """
+                    \(node.name) (\(String(localized:
+                    String
+                    .LocalizationValue(MultihopContext.entry.description))))
+                    """
+            }
+        }
+        return "\(node.name)"
     }
 
     var subtitle: String? {
@@ -41,13 +59,13 @@ struct RecentItemView: View {
 
     var body: some View {
         ListItem(
-            title: node.name,
+            title: title,
             subtitle: subtitle,
             level: 0,
             selected: node.isSelected,
             statusIndicator: { statusIndicator }
         )
-        .disabled(isDisabled)
+        .disabled(node.isExcluded)
     }
 }
 
@@ -57,6 +75,7 @@ struct RecentItemView: View {
             name: "A great location",
             code: "a-great-location",
             isSelected: true
-        )
+        ),
+        multihopContext: .exit
     )
 }

--- a/ios/MullvadVPN/View controllers/SelectLocation/Views/RecentLocationListItem.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/Views/RecentLocationListItem.swift
@@ -14,6 +14,7 @@ struct RecentLocationListItem<ContextMenu>: View where ContextMenu: View {
     private let itemFactory = ListItemFactory()
 
     @Binding var location: LocationNode
+    let multihopContext: MultihopContext
     let onSelect: (LocationNode) -> Void
     let contextMenu: (LocationNode) -> ContextMenu
 
@@ -28,10 +29,11 @@ struct RecentLocationListItem<ContextMenu>: View where ContextMenu: View {
     @ViewBuilder
     var recentLocationListItem: some View {
         SegmentedListItem(
+            isDisabled: location.isExcluded,
             accessibilityIdentifier: .recentListItem(location.name),
             accessibilityLabel: location.name,
             label: {
-                itemFactory.label(for: .recent(node: location))
+                itemFactory.label(for: .recent(node: location, context: multihopContext))
             },
             segment: {},
             groupedContent: {},

--- a/ios/MullvadVPN/View controllers/SelectLocation/Views/RecentLocationsListView.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/Views/RecentLocationsListView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct RecentLocationsListView<ContextMenu>: View where ContextMenu: View {
     @Binding var locations: [LocationNode]
+    let multihopContext: MultihopContext
     let onSelectLocation: (LocationNode) -> Void
     let contextMenu: (LocationNode) -> ContextMenu
 
@@ -17,6 +18,7 @@ struct RecentLocationsListView<ContextMenu>: View where ContextMenu: View {
         ForEach($locations, id: \.self) { location in
             RecentLocationListItem(
                 location: location,
+                multihopContext: multihopContext,
                 onSelect: onSelectLocation,
                 contextMenu: { location in contextMenu(location) },
             )

--- a/ios/MullvadVPNTests/MullvadREST/Relay/MultihopValidatorTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/MultihopValidatorTests.swift
@@ -53,7 +53,7 @@ class MultihopValidatorTests: XCTestCase {
             relayConstraints: multihopWithFiltersConstraints,
             tunnelMultihopState: .whenNeeded
         )
-        
+
         let validator = MultihopValidator(tunnelSettings: settings, relaySelector: relaySelector)
         XCTAssertFalse(validator.stateWillOverrideFilters(.whenNeeded))
     }

--- a/ios/MullvadVPNTests/MullvadVPN/View controllers/SelectLocation/AllLocationsDataSourceTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/View controllers/SelectLocation/AllLocationsDataSourceTests.swift
@@ -228,7 +228,7 @@ class AllLocationsDataSourceTests: XCTestCase {
 
     func testExcludeLocation() throws {
         let excludedRelays = UserSelectedRelays(locations: [.hostname("se", "sto", "se2-wireguard")])
-        dataSource.setExcludedNode(constraint: .only(excludedRelays))
+        dataSource.setExcludedNode(hostname: "se2-wireguard")
         let excludedNode = dataSource.node(by: .only(excludedRelays))!
 
         XCTAssertTrue(excludedNode.isExcluded)
@@ -251,13 +251,13 @@ class AllLocationsDataSourceTests: XCTestCase {
         let entryRelays = UserSelectedRelays(locations: [.hostname("jp", "tyo", "jp1-wireguard")])
 
         // Simulate multihop: exclusion is applied, Japan is excluded.
-        dataSource.setExcludedNode(constraint: .only(entryRelays))
+        dataSource.setExcludedNode(hostname: "jp1-wireguard")
         let jpNode = dataSource.node(by: .only(entryRelays))!
         XCTAssertTrue(jpNode.isExcluded)
 
         // Simulate switching to singlehop: the view model should pass nil
         // to clear exclusions rather than passing the entry relay.
-        dataSource.setExcludedNode(constraint: nil)
+        dataSource.setExcludedNode(hostname: nil)
 
         // In singlehop, Japan should NOT be excluded
         XCTAssertFalse(jpNode.isExcluded)
@@ -268,7 +268,7 @@ class AllLocationsDataSourceTests: XCTestCase {
 
     func testExcludeLocationIncludesAncestors() throws {
         let excludedRelays = UserSelectedRelays(locations: [.hostname("jp", "tyo", "jp1-wireguard")])
-        dataSource.setExcludedNode(constraint: .only(excludedRelays))
+        dataSource.setExcludedNode(hostname: "jp1-wireguard")
         let excludedNode = dataSource.node(by: .only(excludedRelays))!
 
         XCTAssertTrue(excludedNode.isExcluded)


### PR DESCRIPTION
**What is being observed?**

If a location only has one available server due to constraints, it shows "(Exit)" as a suffix even though selecting it wouldn't block the user. This behaviour was added to show that the reason you cannot pick this location is so that you cannot attempt connecting to the same server for both entry and exit. If the lone available selection is explicitly selected as your exit, all three levels of the list item shows the (Exit) suffix.

**Reproduction steps**

- Enable DAITA and LWO
- Set Multihop to Always
- Select Germany as your exit
- Select anything other than Germany as your Entry
- Germany should now be shown with the (Exit) suffix in the Entry selection

This is somewhat inconsistent, you have to change the location once for entry in order for this bug to appear

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10483)
<!-- Reviewable:end -->
