### PR TITLE
Apply entry filter in UI for automatic multihop

### DIFF
--- a/ios/MullvadREST/Relay/RelayPicking/MultihopPicker.swift
+++ b/ios/MullvadREST/Relay/RelayPicking/MultihopPicker.swift
@@ -53,7 +53,7 @@ public struct MultihopPicker: RelayPicking {
         let exitCandidates = try RelaySelector.WireGuard.findCandidates(
             by: constraints.exitLocations,
             in: relays,
-            filterConstraint: tunnelSettings.automaticMultihopIsEnabled ? .any : constraints.exitFilter,
+            filterConstraint: constraints.exitFilter,
             daitaEnabled: false,
             obfuscation: nil
         )

--- a/ios/MullvadREST/Relay/RelaySelectorWrapper.swift
+++ b/ios/MullvadREST/Relay/RelaySelectorWrapper.swift
@@ -69,7 +69,7 @@ public final class RelaySelectorWrapper: RelaySelectorProtocol, Sendable {
                 entryRelays: try findCandidates(
                     relays,
                     tunnelSettings.daita.isEnabled,
-                    .any,
+                    tunnelSettings.relayConstraints.entryFilter,
                     obfuscation
                 ),
                 exitRelays: try findCandidates(


### PR DESCRIPTION
**What is being observed?**

When Automatic entry selection is overriding set filters for its server selection, the server also overrides user set filters - making it highly likely that the user blocks their connection. As in the video below, you are able to pick Canada and Mexico as they have servers that have DAITA+LWO, but are not owned. As soon as you select them, Owned becomes a restraint so they are no longer part of the list - hence, you're blocked.

This seems to be happening for exit as well.

**Reproduction steps**

- Set any entry filters along with required settings such as DAITA + LWO
- Pick automatic
- Your server list now contains all entries that have DAITA + LWO
- Pick anything other than automatic

Your server list now contains all entries that have DAITA + LWO + your filters

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10484)
<!-- Reviewable:end -->
