### PR TITLE
Fix screenshot tests

### DIFF
--- a/.github/workflows/ios-end-to-end-tests.yml
+++ b/.github/workflows/ios-end-to-end-tests.yml
@@ -169,7 +169,7 @@ jobs:
 
   notify-on-failure:
     if: failure() && github.event_name == 'pull_request'
-    name: Notify team on failure(if PR related)
+    name: Notify team on failure (if PR related)
     runs-on: [self-hosted, macOS, ios-test]
     needs: test
     timeout-minutes: 5

--- a/.github/workflows/ios-screenshot-tests-notification.yml
+++ b/.github/workflows/ios-screenshot-tests-notification.yml
@@ -1,0 +1,31 @@
+---
+name: iOS screenshot tests monitor
+on:
+  # https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_run
+  workflow_run:
+    workflows: ["iOS test screenshots"]
+    types:
+      - completed
+
+permissions: {}
+
+jobs:
+  notify-on-failed-workflow:
+    # Payload of workflow_run:
+    # https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2026-03-10#get-a-workflow-run
+    #
+    # Valid values for conclusion are listed on:
+    # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks#check-statuses-and-conclusions
+    if: "${{ github.event.workflow_run.conclusion != 'success' }}"
+    name: Notify team on screenshot tests failure
+    runs-on: [ubuntu-latest]
+    timeout-minutes: 5
+    steps:
+      - name: Send custom event details to a Slack workflow
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.IOS_SLACK_SCREENSHOT_TESTS_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          # workflow_run.html_url returns the full url of the workflow we're responding too.
+          payload: |
+            run_url: "${{ github.event.workflow_run.html_url }}"

--- a/ios/MullvadVPNUITests/Screenshots/ScreenshotTests.swift
+++ b/ios/MullvadVPNUITests/Screenshots/ScreenshotTests.swift
@@ -86,7 +86,7 @@ class ScreenshotTests: LoggedInWithTimeUITestCase {
             .tapSelectLocationButton()
 
         SelectLocationPage(app)
-            .tapEntryFilterButton()
+            .tapExitFilterButton()
 
         snapshot("RelayFilter")
     }


### PR DESCRIPTION
**What is being observed?**

https://github.com/mullvad/mullvadvpn-app/actions/runs/25170502300

The screenshot tests are failing to find the entry filter button.
This seems to have been broken after https://github.com/mullvad/mullvadvpn-app/pull/10093 was merged.

https://github.com/mullvad/mullvadvpn-app/actions/workflows/ios-screenshots-tests.yml

**Reproduction steps**

Reproduces on every run of the screenshot test action since it got broken.

**What needs to be done to fix this?**

- Adjust screenshot automation to find the correct button.
- Notify team on slack when the screenshot tests fail after a merge

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10486)
<!-- Reviewable:end -->
