### PR TITLE
Use architecture-specific updates on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Line wrap the file at 100 chars.                                              Th
 - Update `wireguard-nt` to version 1.1. This retires the Mullvad fork at
   <https://github.com/mullvad/wireguard-nt>.
 
+#### macOS
+- Use arch-specific installers to deliver updates. This makes updates around 50% smaller.
+
 ### Fixed
 - Align ciphers for custom shadowsocks API access methods between clients and `mullvad-daemon`. Any
   existing, invalid access method is removed with a settings migration.

--- a/build.sh
+++ b/build.sh
@@ -513,14 +513,17 @@ fi
 
 # notarize installer on macOS
 if [[ "$NOTARIZE" == "true" && "$(uname -s)" == "Darwin" ]]; then
-    log_info "Notarizing pkg"
-    xcrun notarytool submit dist/*"$PRODUCT_VERSION"*.pkg \
-        --keychain "$NOTARIZE_KEYCHAIN" \
-        --keychain-profile "$NOTARIZE_KEYCHAIN_PROFILE" \
-        --wait
+    for pkg in dist/*"$PRODUCT_VERSION"*.pkg; do
+        log_info "Notarizing $pkg"
 
-    log_info "Stapling pkg"
-    xcrun stapler staple dist/*"$PRODUCT_VERSION"*.pkg
+        xcrun notarytool submit "$pkg" \
+            --keychain "$NOTARIZE_KEYCHAIN" \
+            --keychain-profile "$NOTARIZE_KEYCHAIN_PROFILE" \
+            --wait
+
+        log_info "Stapling $pkg"
+        xcrun stapler staple "$pkg"
+    done
 fi
 
 log_success "**********************************"

--- a/desktop/packages/mullvad-vpn/tasks/distribution.cjs
+++ b/desktop/packages/mullvad-vpn/tasks/distribution.cjs
@@ -313,28 +313,47 @@ async function packWin() {
   });
 }
 
-function packMac() {
+async function packMac() {
   const appOutDirs = [];
-  const config = newConfig();
 
-  return builder.build({
-    targets: builder.Platform.MAC.createTarget(),
-    config: {
+  function prepareMacConfig(arch, artifactName) {
+    const config = newConfig();
+    // For a universal build, electron-builder packs an x64 and an arm64 sub-app and then merges
+    // them with @electron/universal. Both sub-packs run beforeBuild/beforePack with a concrete
+    // arch (x64/arm64).
+    const isUniversal = arch === 'universal';
+    return {
       ...config,
+      mac: {
+        ...config.mac,
+        target: {
+          target: 'pkg',
+          arch,
+        },
+        artifactName,
+      },
       asarUnpack: ['**/*.node'],
       beforeBuild: async (options) => {
         switch (options.arch) {
           case 'x64':
             process.env.TARGET_TRIPLE = 'x86_64-apple-darwin';
-            execFileSync('npm', ['-w', 'nseventforwarder', 'run', 'build-x86']);
             break;
           case 'arm64':
             process.env.TARGET_TRIPLE = 'aarch64-apple-darwin';
-            execFileSync('npm', ['-w', 'nseventforwarder', 'run', 'build-arm']);
             break;
           default:
             delete process.env.TARGET_TRIPLE;
             break;
+        }
+
+        // For a universal build, @electron/universal requires the module for *both* architectures
+        // to be present in *both* sub-packs (it leaves them un-merged via mac.x64ArchFiles), so
+        // build both here. A single-arch build only needs its own.
+        if (isUniversal || options.arch === 'x64') {
+          execFileSync('npm', ['-w', 'nseventforwarder', 'run', 'build-x86']);
+        }
+        if (isUniversal || options.arch === 'arm64') {
+          execFileSync('npm', ['-w', 'nseventforwarder', 'run', 'build-arm']);
         }
 
         process.env.BINARIES_PATH =
@@ -343,7 +362,7 @@ function packMac() {
         return true;
       },
       beforePack: async (context) => {
-        if (!universal) {
+        if (!isUniversal) {
           // Ensure we don't pack native modules for other architectures.
           // These will exist if the app has been built for other architectures before.
           await removeNseventforwarderNativeModules();
@@ -375,7 +394,25 @@ function packMac() {
         const appOutDir = context.appOutDir;
         appOutDirs.push(appOutDir);
       },
-    },
+    };
+  }
+
+  if (universal) {
+    // In addition to the universal installer, produce single-architecture pkgs. The binaries
+    // for both architectures have already been built by build.sh.
+    await builder.build({
+      targets: builder.Platform.MAC.createTarget(),
+      config: prepareMacConfig('x64', 'MullvadVPN-${version}_x86_64.${ext}'),
+    });
+    await builder.build({
+      targets: builder.Platform.MAC.createTarget(),
+      config: prepareMacConfig('arm64', 'MullvadVPN-${version}_arm64.${ext}'),
+    });
+  }
+
+  return builder.build({
+    targets: builder.Platform.MAC.createTarget(),
+    config: prepareMacConfig(getMacArch(), 'MullvadVPN-${version}.${ext}'),
   });
 }
 

--- a/desktop/scripts/release/2-create-and-push-tag
+++ b/desktop/scripts/release/2-create-and-push-tag
@@ -42,7 +42,7 @@ function push_tag {
 
 function wait_for_build {
   log_header "Checking availability of release artifacts"
-  for ext in .exe _arm64.exe _x64.exe _amd64.deb _arm64.deb _x86_64.rpm _aarch64.rpm .pkg; do
+  for ext in .exe _arm64.exe _x64.exe _amd64.deb _arm64.deb _x86_64.rpm _aarch64.rpm .pkg _x86_64.pkg _arm64.pkg; do
     pkg_filename="MullvadVPN-${PRODUCT_VERSION}${ext}"
     url="$BASE_URL/$pkg_filename"
 

--- a/desktop/scripts/release/download-release-artifacts
+++ b/desktop/scripts/release/download-release-artifacts
@@ -30,7 +30,7 @@ mkdir -p "$ARTIFACT_DIR"
 fingerprint_in_file=$(sq keyring list "$MULLVAD_CODE_SIGNING_KEY_PATH" | awk '{print $2}')
 test "$fingerprint_in_file" = "$MULLVAD_CODE_SIGNING_KEY_FINGERPRINT"
 
-for ext in .exe _arm64.exe _x64.exe _amd64.deb _arm64.deb _x86_64.rpm _aarch64.rpm .pkg; do
+for ext in .exe _arm64.exe _x64.exe _amd64.deb _arm64.deb _x86_64.rpm _aarch64.rpm .pkg _x86_64.pkg _arm64.pkg; do
     pkg_filename="MullvadVPN-${PRODUCT_VERSION}${ext}"
     pkg_path="$ARTIFACT_DIR/$pkg_filename"
     url="$URL_BASE/$PRODUCT_VERSION/$pkg_filename"

--- a/mullvad-update/mullvad-release/src/platform.rs
+++ b/mullvad-update/mullvad-release/src/platform.rs
@@ -95,8 +95,10 @@ impl Platform {
                 arm64_artifacts: vec![],
             },
             Platform::Macos => Artifacts {
-                x86_artifacts: vec![artifacts_dir.join(format!("MullvadVPN-{version}.pkg"))],
-                arm64_artifacts: vec![artifacts_dir.join(format!("MullvadVPN-{version}.pkg"))],
+                x86_artifacts: vec![artifacts_dir.join(format!("MullvadVPN-{version}_x86_64.pkg"))],
+                arm64_artifacts: vec![
+                    artifacts_dir.join(format!("MullvadVPN-{version}_arm64.pkg")),
+                ],
             },
         }
     }


### PR DESCRIPTION
This adds CPU architecture-specific installers for macOS, along with the universal ones, and makes use of them for updates. This makes updates a lot smaller.

The architecture-specific installers are around 45% smaller (~130M vs. 230M). The installed app is also around 40% smaller.

Fix DES-2962

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10487)
<!-- Reviewable:end -->
