### PR TITLE
windows: add NlaSvc to prevent boot race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+#### Windows
+- Fix race condition where daemon applies WFP blocking rules before physical network adapters are
+  ready on boot, leaving the machine fully blocked until Mullvad processes are manually restarted
+
 ### Changed
 #### Windows
 - Update `wireguard-nt` to version 1.1. This retires the Mullvad fork at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,10 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+### **Changed**
 #### Windows
 - Fix race condition where daemon applies WFP blocking rules before physical network adapters are
-  ready on boot, leaving the machine fully blocked until Mullvad processes are manually restarted
+  ready on boot, leaving the machine fully blocked until Mullvad processes are manually restarted.
 
 ### Changed
 #### Windows

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -375,6 +375,10 @@ fn get_service_info() -> ServiceInfo {
             // Network Store Interface Service
             // This service delivers network notifications (e.g. interface addition/deleting etc).
             ServiceDependency::Service(OsString::from("NSI")),
+            // Network Location Awareness
+            // Defers startup until Windows has assigned a network profile to at least one
+            // interface, so the daemon never writes WFP blocking rules against an empty stack.
+            ServiceDependency::Service(OsString::from("NlaSvc")),
         ],
         account_name: None, // run as System
         account_password: None,


### PR DESCRIPTION
**Problem**: On machines where physical network adapters initialize slowly examples being USB adapters Ethernet and some older WIFI cards or simply slow hardware, `Mullvad-daemon` can and will start before any adapters are ready. This daemon applies WFP blocking rules on startup causing a race condition. when the adapter comes up after the `Mullvad-daemon` it falls under these rules with no tunnel. _Mullvad_ must be fully restarted to fix this on the users end using task manager.

**Fix**: Add **NlaSvc** this service allows _Mullvad_ to wait the proper time for an adapter to come online ensuring no race condition, and that the connection will be established.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10489)
<!-- Reviewable:end -->
