### PR TITLE
Fix e2e localnetworksharing test

### DIFF
--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/LocalNetworkSharingPage.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/LocalNetworkSharingPage.kt
@@ -1,0 +1,19 @@
+package net.mullvad.mullvadvpn.test.common.page
+
+import androidx.test.uiautomator.By
+import net.mullvad.mullvadvpn.lib.ui.tag.LOCAL_NETWORK_SHARING_SCREEN_TEST_TAG
+import net.mullvad.mullvadvpn.lib.ui.tag.SWITCH_TEST_TAG
+import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
+
+class LocalNetworkSharingPage internal constructor() : Page() {
+    private val localNetworkSharingSelector = By.res(LOCAL_NETWORK_SHARING_SCREEN_TEST_TAG)
+
+    override fun assertIsDisplayed() {
+        uiDevice.findObjectWithTimeout(localNetworkSharingSelector)
+    }
+
+    fun toggleSwitch() {
+        val switch = uiDevice.findObjectWithTimeout(By.res(SWITCH_TEST_TAG))
+        switch.click()
+    }
+}

--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/Story.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/Story.kt
@@ -63,8 +63,9 @@ fun ConnectPage.enableMultihopStory() {
 fun ConnectPage.enableLocalNetworkSharingStory() {
     clickSettings()
     on<SettingsPage> { clickVpnSettings() }
-    on<VpnSettingsPage> { clickLocalNetworkSharingSwitch() }
-    uiDevice.pressBackTwice()
+    on<VpnSettingsPage> { clickLocalNetworkSharing() }
+    on<LocalNetworkSharingPage> { toggleSwitch() }
+    repeat(3) { uiDevice.pressBack() }
 }
 
 fun ConnectPage.toggleInTunnelIpv6Story() {

--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/VpnSettingsPage.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/VpnSettingsPage.kt
@@ -36,13 +36,11 @@ class VpnSettingsPage internal constructor() : Page() {
         assert(postQuantumSwitch.isChecked == enabled)
     }
 
-    fun clickLocalNetworkSharingSwitch() {
+    fun clickLocalNetworkSharing() {
         val localNetworkSharingCell =
             uiDevice.findObjectWithTimeout(localNetworkSharingSelector).parent
-        val localNetworkSharingSwitch =
-            localNetworkSharingCell.findObjectWithTimeout(By.res(SWITCH_TEST_TAG))
 
-        localNetworkSharingSwitch.click()
+        localNetworkSharingCell.click()
     }
 
     fun clickInTunnelIpv6Switch() {

--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/VpnSettingsPage.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/VpnSettingsPage.kt
@@ -6,16 +6,10 @@ import androidx.test.uiautomator.Until
 import net.mullvad.mullvadvpn.lib.ui.tag.LAZY_LIST_ANTI_CENSORSHIP_SETTINGS_TEST_TAG
 import net.mullvad.mullvadvpn.lib.ui.tag.LAZY_LIST_QUANTUM_ITEM_TEST_TAG
 import net.mullvad.mullvadvpn.lib.ui.tag.LAZY_LIST_VPN_SETTINGS_TEST_TAG
-import net.mullvad.mullvadvpn.lib.ui.tag.LAZY_LIST_WIREGUARD_CUSTOM_PORT_NUMBER_TEST_TAG
 import net.mullvad.mullvadvpn.lib.ui.tag.SERVER_IP_OVERRIDE_BUTTON_TEST_TAG
 import net.mullvad.mullvadvpn.lib.ui.tag.SWITCH_TEST_TAG
 import net.mullvad.mullvadvpn.lib.ui.tag.WIREGUARD_DEVICE_IP_IPV4_CELL_TEST_TAG
 import net.mullvad.mullvadvpn.lib.ui.tag.WIREGUARD_DEVICE_IP_IPV6_CELL_TEST_TAG
-import net.mullvad.mullvadvpn.lib.ui.tag.WIREGUARD_OBFUSCATION_LWO_CELL_TEST_TAG
-import net.mullvad.mullvadvpn.lib.ui.tag.WIREGUARD_OBFUSCATION_OFF_CELL_TEST_TAG
-import net.mullvad.mullvadvpn.lib.ui.tag.WIREGUARD_OBFUSCATION_QUIC_CELL_TEST_TAG
-import net.mullvad.mullvadvpn.lib.ui.tag.WIREGUARD_OBFUSCATION_SHADOWSOCKS_CELL_TEST_TAG
-import net.mullvad.mullvadvpn.lib.ui.tag.WIREGUARD_OBFUSCATION_UDP_OVER_TCP_CELL_TEST_TAG
 import net.mullvad.mullvadvpn.test.common.extension.clickObjectAwaitIsChecked
 import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
 
@@ -50,32 +44,8 @@ class VpnSettingsPage internal constructor() : Page() {
         inTunnelIpv6Switch.click()
     }
 
-    fun scrollUntilWireGuardObfuscationUdpOverTcpCell() {
-        scrollUntilCell(WIREGUARD_OBFUSCATION_UDP_OVER_TCP_CELL_TEST_TAG)
-    }
-
-    fun scrollUntilWireGuardObfuscationQuicCell() {
-        scrollUntilCell(WIREGUARD_OBFUSCATION_QUIC_CELL_TEST_TAG)
-    }
-
-    fun scrollUntilWireGuardObfuscationLwoCell() {
-        scrollUntilCell(WIREGUARD_OBFUSCATION_LWO_CELL_TEST_TAG)
-    }
-
-    fun scrollUntilWireGuardObfuscationOffCell() {
-        scrollUntilCell(WIREGUARD_OBFUSCATION_OFF_CELL_TEST_TAG)
-    }
-
     fun scrollUntilPostQuantumCell() {
         scrollUntilCell(LAZY_LIST_QUANTUM_ITEM_TEST_TAG)
-    }
-
-    fun scrollUntilWireGuardObfuscationShadowsocksCell() {
-        scrollUntilCell(WIREGUARD_OBFUSCATION_SHADOWSOCKS_CELL_TEST_TAG)
-    }
-
-    fun scrollUntilWireGuardCustomPort() {
-        scrollUntilCell(LAZY_LIST_WIREGUARD_CUSTOM_PORT_NUMBER_TEST_TAG)
     }
 
     fun scrollUntilServerIpOverride() {
@@ -84,22 +54,6 @@ class VpnSettingsPage internal constructor() : Page() {
 
     fun scrollUntilDeviceIpVersionCell() {
         scrollUntilCell(WIREGUARD_DEVICE_IP_IPV6_CELL_TEST_TAG)
-    }
-
-    fun clickWireguardObfuscationUdpOverTcpCell() {
-        uiDevice.clickObjectAwaitIsChecked(By.res(WIREGUARD_OBFUSCATION_UDP_OVER_TCP_CELL_TEST_TAG))
-    }
-
-    fun clickWireguardObfuscationQuicCell() {
-        uiDevice.clickObjectAwaitIsChecked(By.res(WIREGUARD_OBFUSCATION_QUIC_CELL_TEST_TAG))
-    }
-
-    fun clickWireguardObfuscationLwoCell() {
-        uiDevice.clickObjectAwaitIsChecked(By.res(WIREGUARD_OBFUSCATION_LWO_CELL_TEST_TAG))
-    }
-
-    fun clickWireGuardObfuscationOffCell() {
-        uiDevice.clickObjectAwaitIsChecked(By.res(WIREGUARD_OBFUSCATION_OFF_CELL_TEST_TAG))
     }
 
     fun scrollUntilAntiCensorshipCell() {


### PR DESCRIPTION
After moving Local Network Sharing to separate page it was missed to update the E2E test.

E2E run:
https://github.com/mullvad/mullvadvpn-app/actions/runs/26625588130/job/78461903398

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10491)
<!-- Reviewable:end -->
