### PR TITLE
Fix typos in code comments

### DIFF
--- a/mullvad-api/src/lib.rs
+++ b/mullvad-api/src/lib.rs
@@ -71,13 +71,13 @@ use mullvad_api_constants::*;
 /// A hostname and socketaddr to reach the Mullvad REST API over.
 #[derive(Debug, Clone)]
 pub struct ApiEndpoint {
-    /// An overriden API hostname. Initialized with the value of the environment
+    /// An overridden API hostname. Initialized with the value of the environment
     /// variable `MULLVAD_API_HOST` if it has been set.
     ///
     /// Use the associated function [`Self::host`] to read this value with a
     /// default fallback if `MULLVAD_API_HOST` was not set.
     pub host: Option<String>,
-    /// An overriden API address. Initialized with the value of the environment
+    /// An overridden API address. Initialized with the value of the environment
     /// variable `MULLVAD_API_ADDR` if it has been set.
     ///
     /// Use the associated function [`Self::address`] to read this value with

--- a/mullvad-daemon/src/geoip.rs
+++ b/mullvad-daemon/src/geoip.rs
@@ -13,7 +13,7 @@ use crate::DaemonEventSender;
 // Define the Mullvad connection checking api endpoint.
 //
 // In a development build the host name for the connection checking endpoint can
-// be overriden by defining the env variable `MULLVAD_CONNCHECK_HOST`.
+// be overridden by defining the env variable `MULLVAD_CONNCHECK_HOST`.
 //
 // If `MULLVAD_CONNCHECK_HOST` is set when running `mullvad-daemon` in a
 // production build, a warning will be logged and the env variable *won´t* have

--- a/mullvad-management-interface/src/types/conversions/settings.rs
+++ b/mullvad-management-interface/src/types/conversions/settings.rs
@@ -177,8 +177,8 @@ impl TryFrom<proto::Settings> for mullvad_types::settings::Settings {
             )?,
             recents: Some(vec![]),
             update_default_location: settings.update_default_location,
-            // HACK: The deamon should never read this random settings blob from a random client.
-            // We should look into separating the serializable settings object that pass accross
+            // HACK: The daemon should never read this random settings blob from a random client.
+            // We should look into separating the serializable settings object that pass across
             // gRPC from the daemon's trusted settings. There are multiple fields that would not be
             // included in the serializable settings, such as the below value.
             #[cfg(not(target_os = "android"))]

--- a/test/test-manager/src/tests/split_tunnel.rs
+++ b/test/test-manager/src/tests/split_tunnel.rs
@@ -90,7 +90,7 @@ pub async fn test_split_tunnel(
 /// The property we're testing for here is that toggling ST respects the list of split apps, and
 /// vice-versa.
 ///
-/// NOTE: This will not work with Linux split tunneling, since there is no persistant list of split
+/// NOTE: This will not work with Linux split tunneling, since there is no persistent list of split
 /// apps(yet!).
 #[test_function(target_os = "macos", target_os = "windows")]
 pub async fn test_split_tunnel_toggle(


### PR DESCRIPTION
Correct a handful of spelling mistakes in Rust comments and doc comments (deamon, accross, overriden, persistant). Comment-only changes with no behavioral impact.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10493)
<!-- Reviewable:end -->
