### PR TITLE
Reconnect if relay list is updated in some blocked states

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -482,6 +482,8 @@ pub(crate) enum InternalDaemonEvent {
     TriggerShutdown(bool),
     /// The background job fetching new `AppVersionInfo`s got a new info object.
     NewAppVersionInfo(AppVersionInfo),
+    /// The relay list was updated.
+    NewRelayList,
     /// Sent when a device is updated in any way (key rotation, login, logout, etc.).
     DeviceEvent(AccountEvent),
     /// Sent when access methods are changed in any way (new active access method).
@@ -980,6 +982,7 @@ impl Daemon {
             let _ = internal_event_tx_clone.send(InternalDaemonEvent::Command(
                 DaemonCommand::UpdateDefaultLocationCountry(tx),
             ));
+            let _ = internal_event_tx_clone.send(InternalDaemonEvent::NewRelayList);
         };
 
         let mut relay_list_updater = RelayListUpdater::spawn(
@@ -1212,6 +1215,16 @@ impl Daemon {
             }
             NewAppVersionInfo(app_version_info) => {
                 self.handle_new_app_version_info(app_version_info);
+            }
+            NewRelayList => {
+                if let TunnelState::Error(err) = &self.tunnel_state
+                    && let ErrorStateCause::TunnelParameterError(_) = err.cause()
+                {
+                    log::debug!(
+                        "Reconnecting due to receiving new relay list when blocked by tunnel parameters"
+                    );
+                    self.reconnect_tunnel();
+                }
             }
             DeviceEvent(event) => self.handle_device_event(event).await,
             AccessMethodEvent {


### PR DESCRIPTION
Dev builds would often fail to connect early on if auto-connect was enabled since they no longer include a relay list.

Fix DES-3012.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10496)
<!-- Reviewable:end -->
