### PR TITLE
Add previous DAITA setting to multihop migration

### DIFF
--- a/desktop/packages/management-interface/dist/management_interface_pb.d.ts
+++ b/desktop/packages/management-interface/dist/management_interface_pb.d.ts
@@ -3437,8 +3437,8 @@ export class SplitFilterMigration extends jspb.Message {
     setMultihopMigration(value: SplitFilterMigration.MultihopMigrationState): SplitFilterMigration;
     getFiltersSet(): boolean;
     setFiltersSet(value: boolean): SplitFilterMigration;
-    getRemovedDaitaDirectOnly(): boolean;
-    setRemovedDaitaDirectOnly(value: boolean): SplitFilterMigration;
+    getDaitaMigration(): SplitFilterMigration.PreviousDaitaState;
+    setDaitaMigration(value: SplitFilterMigration.PreviousDaitaState): SplitFilterMigration;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): SplitFilterMigration.AsObject;
@@ -3454,7 +3454,7 @@ export namespace SplitFilterMigration {
     export type AsObject = {
         multihopMigration: SplitFilterMigration.MultihopMigrationState,
         filtersSet: boolean,
-        removedDaitaDirectOnly: boolean,
+        daitaMigration: SplitFilterMigration.PreviousDaitaState,
     }
 
     export enum MultihopMigrationState {
@@ -3462,6 +3462,12 @@ export namespace SplitFilterMigration {
     OFF_TO_NEVER = 1,
     OFF_TO_WHEN_NEEDED = 2,
     OFF_TO_ALWAYS = 3,
+    }
+
+    export enum PreviousDaitaState {
+    ON = 0,
+    DIRECT_ONLY = 1,
+    OFF = 2,
     }
 
 }

--- a/desktop/packages/management-interface/dist/management_interface_pb.js
+++ b/desktop/packages/management-interface/dist/management_interface_pb.js
@@ -144,6 +144,7 @@ goog.exportSymbol('proto.mullvad_daemon.management_interface.Socks5Remote', null
 goog.exportSymbol('proto.mullvad_daemon.management_interface.SocksAuth', null, global);
 goog.exportSymbol('proto.mullvad_daemon.management_interface.SplitFilterMigration', null, global);
 goog.exportSymbol('proto.mullvad_daemon.management_interface.SplitFilterMigration.MultihopMigrationState', null, global);
+goog.exportSymbol('proto.mullvad_daemon.management_interface.SplitFilterMigration.PreviousDaitaState', null, global);
 goog.exportSymbol('proto.mullvad_daemon.management_interface.SplitTunnelSettings', null, global);
 goog.exportSymbol('proto.mullvad_daemon.management_interface.SuggestedUpgrade', null, global);
 goog.exportSymbol('proto.mullvad_daemon.management_interface.TransportPort', null, global);
@@ -26412,7 +26413,7 @@ proto.mullvad_daemon.management_interface.SplitFilterMigration.toObject = functi
   var f, obj = {
     multihopMigration: jspb.Message.getFieldWithDefault(msg, 1, 0),
     filtersSet: jspb.Message.getBooleanFieldWithDefault(msg, 2, false),
-    removedDaitaDirectOnly: jspb.Message.getBooleanFieldWithDefault(msg, 3, false)
+    daitaMigration: jspb.Message.getFieldWithDefault(msg, 3, 0)
   };
 
   if (includeInstance) {
@@ -26458,8 +26459,8 @@ proto.mullvad_daemon.management_interface.SplitFilterMigration.deserializeBinary
       msg.setFiltersSet(value);
       break;
     case 3:
-      var value = /** @type {boolean} */ (reader.readBool());
-      msg.setRemovedDaitaDirectOnly(value);
+      var value = /** @type {!proto.mullvad_daemon.management_interface.SplitFilterMigration.PreviousDaitaState} */ (reader.readEnum());
+      msg.setDaitaMigration(value);
       break;
     default:
       reader.skipField();
@@ -26504,9 +26505,9 @@ proto.mullvad_daemon.management_interface.SplitFilterMigration.serializeBinaryTo
       f
     );
   }
-  f = message.getRemovedDaitaDirectOnly();
-  if (f) {
-    writer.writeBool(
+  f = message.getDaitaMigration();
+  if (f !== 0.0) {
+    writer.writeEnum(
       3,
       f
     );
@@ -26522,6 +26523,15 @@ proto.mullvad_daemon.management_interface.SplitFilterMigration.MultihopMigration
   OFF_TO_NEVER: 1,
   OFF_TO_WHEN_NEEDED: 2,
   OFF_TO_ALWAYS: 3
+};
+
+/**
+ * @enum {number}
+ */
+proto.mullvad_daemon.management_interface.SplitFilterMigration.PreviousDaitaState = {
+  ON: 0,
+  DIRECT_ONLY: 1,
+  OFF: 2
 };
 
 /**
@@ -26561,20 +26571,20 @@ proto.mullvad_daemon.management_interface.SplitFilterMigration.prototype.setFilt
 
 
 /**
- * optional bool removed_daita_direct_only = 3;
- * @return {boolean}
+ * optional PreviousDaitaState daita_migration = 3;
+ * @return {!proto.mullvad_daemon.management_interface.SplitFilterMigration.PreviousDaitaState}
  */
-proto.mullvad_daemon.management_interface.SplitFilterMigration.prototype.getRemovedDaitaDirectOnly = function() {
-  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 3, false));
+proto.mullvad_daemon.management_interface.SplitFilterMigration.prototype.getDaitaMigration = function() {
+  return /** @type {!proto.mullvad_daemon.management_interface.SplitFilterMigration.PreviousDaitaState} */ (jspb.Message.getFieldWithDefault(this, 3, 0));
 };
 
 
 /**
- * @param {boolean} value
+ * @param {!proto.mullvad_daemon.management_interface.SplitFilterMigration.PreviousDaitaState} value
  * @return {!proto.mullvad_daemon.management_interface.SplitFilterMigration} returns this
  */
-proto.mullvad_daemon.management_interface.SplitFilterMigration.prototype.setRemovedDaitaDirectOnly = function(value) {
-  return jspb.Message.setProto3BooleanField(this, 3, value);
+proto.mullvad_daemon.management_interface.SplitFilterMigration.prototype.setDaitaMigration = function(value) {
+  return jspb.Message.setProto3EnumField(this, 3, value);
 };
 
 

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -906,10 +906,9 @@ message SplitFilterMigration {
   // false: No previous filters were set, no filters are set for either entry or exit.
   bool filters_set = 2;
   // "Daita: Directy only" does not exist anymore, but it is relevant to know if it was enabled.
-  //
-  // true: "Daita: direct only" was previoiusly enabled.
-  // false: "Daita: direct only" was previoiusly disabled.
-  bool removed_daita_direct_only = 3;
+  // If Daita was turned off, it is still off. Otherwise Daita is enabled.
+  PreviousDaitaState daita_migration = 3;
+
   // This enum value defines all valid transitions from the previous state to the new tri-state,
   // which necessarily depend on additional settings beyond Multihop.
   enum MultihopMigrationState {
@@ -921,5 +920,16 @@ message SplitFilterMigration {
     off_to_when_needed = 2;
     // "Magic multihop" - one leaf node in the giga-migration tree.
     off_to_always = 3;
+  }
+
+  // This enum value defines all previous Daita states (tri-state) which is mapped to either on or
+  // off post-migration.
+  enum PreviousDaitaState {
+    // Daita was previoiusly enabled without "direct only"
+    on = 0;
+    // Daita was previoiusly enabled with "direct only"
+    direct_only = 1;
+    // Daita was previously off.
+    off = 2;
   }
 }


### PR DESCRIPTION
For the upcoming multihop migration there are scenarios where knowing the previous DAITA setting is relevant to present the correct post-migration wizard.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10499)
<!-- Reviewable:end -->
