### PR TITLE
Show the `isPostQuantum` and `isDaita` information when available

### DIFF
--- a/ios/MullvadVPN/TunnelManager/TunnelState.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelState.swift
@@ -174,7 +174,8 @@ enum TunnelState: Equatable, CustomStringConvertible, Sendable {
         switch self {
         case let .connecting(_, isPostQuantum: isPostQuantum, isDaita: _),
             let .connected(_, isPostQuantum: isPostQuantum, isDaita: _),
-            let .reconnecting(_, isPostQuantum: isPostQuantum, isDaita: _):
+            let .reconnecting(_, isPostQuantum: isPostQuantum, isDaita: _),
+            let .negotiatingEphemeralPeer(_, _, isPostQuantum: isPostQuantum, isDaita: _):
             isPostQuantum
         default:
             nil
@@ -185,7 +186,8 @@ enum TunnelState: Equatable, CustomStringConvertible, Sendable {
         switch self {
         case let .connecting(_, isPostQuantum: _, isDaita: isDaita),
             let .connected(_, isPostQuantum: _, isDaita: isDaita),
-            let .reconnecting(_, isPostQuantum: _, isDaita: isDaita):
+            let .reconnecting(_, isPostQuantum: _, isDaita: isDaita),
+            let .negotiatingEphemeralPeer(_, _, isPostQuantum: _, isDaita: isDaita):
             isDaita
         default:
             nil


### PR DESCRIPTION
When in the `negotiatingEphemeralPeer` state we returned `nil` for the abovementioned properties.
Returning and thus visualising this stage aligns with Desktop and informs the user as quickly as possible.

Steps to verify:
1. Open the connect/disconnect screen
2. Disable any chips/pills currently displayed
3. Enable Quantum Resistance
4. Connect
5. Ensure the chip "Quantum Resistance" chip does not disappear at any point during the connection/connected process

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10502)
<!-- Reviewable:end -->
