### PR TITLE
Fix misleading error in offline state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ Line wrap the file at 100 chars.                                              Th
 - Align ciphers for custom shadowsocks API access methods between clients and `mullvad-daemon`. Any
   existing, invalid access method is removed with a settings migration.
 
+#### Windows
+- Fix misleading "split tunneling" error when offline.
+
 ### Security
 - Linux and macOS: Fix management interface socket being created with less restrictive permissions
   when using `MULLVAD_MANAGEMENT_SOCKET_GROUP`. This addresses the advisory `GHSA-p9rr-wc9m-qmwg`.

--- a/desktop/packages/mullvad-vpn/locales/messages.pot
+++ b/desktop/packages/mullvad-vpn/locales/messages.pot
@@ -1897,7 +1897,6 @@ msgstr ""
 
 #. Label for the system notification when the app encountered an error
 #. and will block network traffic until the error is resolved.
-#. Label for the in-app banner when the app encountered an error
 msgctxt "notifications"
 msgid "Failed to start %(splitTunneling)s. To unblock network traffic, disable %(splitTunneling)s."
 msgstr ""
@@ -1956,10 +1955,6 @@ msgstr ""
 
 msgctxt "notifications"
 msgid "Unable to block all network traffic. Try updating your kernel or send a problem report."
-msgstr ""
-
-msgctxt "notifications"
-msgid "Unable to communicate with Mullvad kernel driver. Try reconnecting or send a problem report."
 msgstr ""
 
 msgctxt "notifications"

--- a/desktop/packages/mullvad-vpn/src/shared/notifications/error.tsx
+++ b/desktop/packages/mullvad-vpn/src/shared/notifications/error.tsx
@@ -38,26 +38,19 @@ export class ErrorNotificationProvider
   public getSystemNotification(): SystemNotification | undefined {
     if (this.context.tunnelState.state === 'error') {
       let message = this.getMessage(this.context.tunnelState.details);
-      if (!this.context.tunnelState.details.blockingError && this.context.hasExcludedApps) {
-        if (!this.context.splitTunnelingSupported) {
-          message = sprintf(
-            // TRANSLATORS: Label for the system notification when the app encountered an error
-            // TRANSLATORS: and will block network traffic until the error is resolved.
-            messages.pgettext(
-              'notifications',
-              'Failed to start %(splitTunneling)s. To unblock network traffic, disable %(splitTunneling)s.',
-            ),
-            { splitTunneling: strings.splitTunneling.toLowerCase() },
-          );
-        } else {
-          message = `${message} ${sprintf(
-            messages.pgettext(
-              'notifications',
-              'The apps excluded with %(splitTunneling)s might not work properly right now.',
-            ),
-            { splitTunneling: strings.splitTunneling.toLowerCase() },
-          )}`;
-        }
+      if (
+        !this.context.tunnelState.details.blockingError &&
+        this.context.tunnelState.details.cause !== ErrorStateCause.splitTunnelError &&
+        this.context.hasExcludedApps &&
+        this.context.splitTunnelingSupported
+      ) {
+        message = `${message} ${sprintf(
+          messages.pgettext(
+            'notifications',
+            'The apps excluded with %(splitTunneling)s might not work properly right now.',
+          ),
+          { splitTunneling: strings.splitTunneling.toLowerCase() },
+        )}`;
       }
 
       return {
@@ -76,36 +69,19 @@ export class ErrorNotificationProvider
   public getInAppNotification(): InAppNotification | undefined {
     if (this.context.tunnelState.state === 'error') {
       let subtitle = this.getMessage(this.context.tunnelState.details);
-      if (!this.context.tunnelState.details.blockingError && this.context.hasExcludedApps) {
-        if (!this.context.splitTunnelingSupported) {
-          return {
-            indicator: 'error',
-            title: messages.pgettext('in-app-notifications', 'BLOCKING INTERNET'),
-            subtitle: [
-              {
-                key: 'split-tunneling-failed-subtitle',
-                content: sprintf(
-                  // TRANSLATORS: Label for the in-app banner when the app encountered an error
-                  // TRANSLATORS: and will block network traffic until the error is resolved.
-                  messages.pgettext(
-                    'notifications',
-                    'Failed to start %(splitTunneling)s. To unblock network traffic, disable %(splitTunneling)s.',
-                  ),
-                  { splitTunneling: strings.splitTunneling.toLowerCase() },
-                ),
-              },
-            ],
-            action: this.getActions(this.context.tunnelState.details) ?? undefined,
-          };
-        } else {
-          subtitle = `${subtitle} ${sprintf(
-            messages.pgettext(
-              'notifications',
-              'The apps excluded with %(splitTunneling)s might not work properly right now.',
-            ),
-            { splitTunneling: strings.splitTunneling.toLowerCase() },
-          )}`;
-        }
+      if (
+        !this.context.tunnelState.details.blockingError &&
+        this.context.tunnelState.details.cause !== ErrorStateCause.splitTunnelError &&
+        this.context.hasExcludedApps &&
+        this.context.splitTunnelingSupported
+      ) {
+        subtitle = `${subtitle} ${sprintf(
+          messages.pgettext(
+            'notifications',
+            'The apps excluded with %(splitTunneling)s might not work properly right now.',
+          ),
+          { splitTunneling: strings.splitTunneling.toLowerCase() },
+        )}`;
       }
 
       return {
@@ -230,9 +206,14 @@ export class ErrorNotificationProvider
                 'Failed to enable split tunneling. Please try reconnecting or disable split tunneling.',
               );
             default:
-              return messages.pgettext(
-                'notifications',
-                'Unable to communicate with Mullvad kernel driver. Try reconnecting or send a problem report.',
+              return sprintf(
+                // TRANSLATORS: Label for the system notification when the app encountered an error
+                // TRANSLATORS: and will block network traffic until the error is resolved.
+                messages.pgettext(
+                  'notifications',
+                  'Failed to start %(splitTunneling)s. To unblock network traffic, disable %(splitTunneling)s.',
+                ),
+                { splitTunneling: strings.splitTunneling.toLowerCase() },
               );
           }
       }


### PR DESCRIPTION
Only show split tunneling error when it is the actual tunnel state error, not whenever split tunneling is unavailable.

Fix DES-3015

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10504)
<!-- Reviewable:end -->
