### PR TITLE
Update changelog with 2026.3-beta2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+
+
+## [2026.3-beta2] - 2026-06-01
 ### Fixed
 #### Linux
 - Fix page size issue in `2026.3-beta1` on some ARM64 systems.


### PR DESCRIPTION
I accidentally dropped the commit which updated the changelog before merging https://github.com/mullvad/mullvadvpn-app/pull/10500 ..

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10506)
<!-- Reviewable:end -->
