### PR TITLE
Set stricter initial permissions on UDS socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ Line wrap the file at 100 chars.                                              Th
 - Fix timeout when loading split tunnel driver during boot.
 - Fix race condition in `2026-3.beta1` that could result in inability to create tunnel interface.
 
+### Security
+- Linux and macOS: Fix management interface socket being create with less restrictive permissions
+  when using `MULLVAD_MANAGEMENT_SOCKET_GROUP`. This addresses the advisory `GHSA-p9rr-wc9m-qmwg`.
+
 
 ## [2026.3-beta1] - 2026-05-19
 ### Added

--- a/mullvad-management-interface/src/lib.rs
+++ b/mullvad-management-interface/src/lib.rs
@@ -211,6 +211,15 @@ pub fn spawn_rpc_server(
 fn create_endpoint(rpc_socket_path: PathBuf) -> Result<IpcEndpoint, Error> {
     let endpoint = IpcEndpoint::new(rpc_socket_path, tipsy::OnConflict::Error)
         .map_err(Error::StartServerError)?;
+    #[cfg(unix)]
+    if MULLVAD_MANAGEMENT_SOCKET_GROUP.is_some() {
+        // Explicitly start with strict permissions (`0o600`, root) before applying less restrictive
+        // permissions.
+        let attr = tipsy::SecurityAttributes::empty()
+            .mode(0o600)
+            .map_err(Error::PermissionsError)?;
+        return Ok(endpoint.security_attributes(attr));
+    }
     let endpoint = endpoint.security_attributes(
         tipsy::SecurityAttributes::allow_everyone_create()
             .map_err(Error::SecurityAttributes)?


### PR DESCRIPTION
When using `MULLVAD_MANAGEMENT_SOCKET_GROUP`. See commit message for details.

Fix DES-3060

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10510)
<!-- Reviewable:end -->
