### PR TITLE
Scroll to the bottom when enabling custom dns

### DIFF
--- a/android/lib/feature/dns/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/dns/impl/DnsSettingsScreen.kt
+++ b/android/lib/feature/dns/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/dns/impl/DnsSettingsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -189,6 +190,15 @@ fun DnsSettingsScreen(
         },
     ) { modifier ->
         val lazyListState = rememberLazyListState()
+
+        if (state is Lc.Content) {
+            LaunchedEffect(state.value.customDnsEnabled) {
+                if (state.value.customDnsEnabled) {
+                    lazyListState.requestScrollToItem(lazyListState.layoutInfo.totalItemsCount - 1)
+                }
+            }
+        }
+
         LazyColumn(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier =


### PR DESCRIPTION
This will also scroll to the bottom when opening the screen and custom dns is enabled. If we do not want this we can remove this.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10514)
<!-- Reviewable:end -->
