### PR TITLE
Fix logs not flusing properly in `installer-downloader`

### DIFF
--- a/installer-downloader/src/log.rs
+++ b/installer-downloader/src/log.rs
@@ -12,6 +12,7 @@ pub fn init() -> Option<tracing_appender::non_blocking::WorkerGuard> {
 
     tracing_subscriber::fmt()
         .with_max_level(LevelFilter::DEBUG)
+        .with_ansi(false)
         .with_writer(non_blocking_file_appender)
         .with_timer(tracing_subscriber::fmt::time::ChronoUtc::new(
             DATE_TIME_FORMAT_STR.to_string(),

--- a/installer-downloader/src/log.rs
+++ b/installer-downloader/src/log.rs
@@ -3,12 +3,11 @@ use tracing_subscriber::filter::LevelFilter;
 const LOG_FILENAME: &str = "mullvad-loader.log";
 const DATE_TIME_FORMAT_STR: &str = "[%Y-%m-%d %H:%M:%S%.3f]";
 
-pub fn init() {
-    let Ok(log_dir) = mullvad_paths::frontend_log_dir() else {
-        return;
-    };
+pub fn init() -> Option<tracing_appender::non_blocking::WorkerGuard> {
+    let log_dir = mullvad_paths::frontend_log_dir().ok()?;
+
     let file_appender = tracing_appender::rolling::never(log_dir, LOG_FILENAME);
-    let (non_blocking_file_appender, _file_appender_guard) =
+    let (non_blocking_file_appender, file_appender_guard) =
         tracing_appender::non_blocking(file_appender);
 
     tracing_subscriber::fmt()
@@ -17,5 +16,7 @@ pub fn init() {
         .with_timer(tracing_subscriber::fmt::time::ChronoUtc::new(
             DATE_TIME_FORMAT_STR.to_string(),
         ))
-        .init()
+        .init();
+
+    Some(file_appender_guard)
 }

--- a/installer-downloader/src/main.rs
+++ b/installer-downloader/src/main.rs
@@ -14,7 +14,9 @@ mod inner {
     pub use installer_downloader::resource;
 
     pub fn run() {
-        log::init();
+        // Independently if log::init() succeed or fails, this value should be dropped last to
+        // ensure that every log statement is flushed.
+        let _log_flush_guard = log::init();
 
         ::log::debug!("Installer downloader version: {}", resource::VERSION);
 


### PR DESCRIPTION
This PR fixes an issue with the logging in `installer-downloader`, where the associated [WorkerGuard](https://docs.rs/tracing-appender/latest/tracing_appender/non_blocking/struct.WorkerGuard.html) of the [log writer](https://docs.rs/tracing-appender/latest/tracing_appender/non_blocking/struct.NonBlocking.html) would be dropped immediately upon creation. Buffered logs would not be guaranteed to be flushed upon program termination.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10521)
<!-- Reviewable:end -->
