### PR TITLE
Add F-Droid publish compat check

### DIFF
--- a/ci/android/build-server/run.sh
+++ b/ci/android/build-server/run.sh
@@ -68,7 +68,8 @@ function stage_for_publishing {
 
     (cd "$artifact_dir" && stage_cdn_upload "$version") || return 1
 
-    if [[ $version != *"-dev-"* ]]; then
+    # Metadata file check for backwards compat.
+    if [[ -f "$BUILD_DIR/ci/android/build-server/fdroid/net.mullvad.mullvadvpn.yml" && $version != *"-dev-"* ]]; then
         "$SCRIPT_DIR/fdroid.sh" stage development "$version" "$artifact_dir" || return 1
     fi
 }
@@ -192,7 +193,8 @@ function build_sign_and_publish_ref {
     PLAY_CREDENTIALS_PATH="$PLAY_CREDENTIALS_PATH" \
     "$SCRIPT_DIR/upload-play.sh" "$artifact_dir" "$version" || echo "Failed to upload bundle $version"
 
-    if [[ $version != *"-dev-"* ]]; then
+    # Metadata file check for backwards compat.
+    if [[  -f "$BUILD_DIR/ci/android/build-server/fdroid/net.mullvad.mullvadvpn.yml" && $version != *"-dev-"* ]]; then
         publish_fdroid_repo development
     fi
 


### PR DESCRIPTION
F-Droid publishing requires both a minimum container image as well as a containerized-sigh.sh revision that allows for arbitrary commands. Therefor we use the F-Droid metadata file, which was introduced in the same PR that enabled F-Droid publishing, to determine whether the deployed run.sh script should attempt publishing our F-Droid repository.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10522)
<!-- Reviewable:end -->
