### PR TITLE
Fix e2e tests not being able to close select location menus

### DIFF
--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/select-location/select-location.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/select-location/select-location.spec.ts
@@ -295,8 +295,10 @@ test.describe('Select location', () => {
       const addToNewCustomListButton =
         routes.selectLocation.getAddToNewCustomListButton(firstRecentName);
       await expect(addToNewCustomListButton).toBeVisible();
+      // Make sure menu transition has finished before clicking outside to close it
+      await page.waitForTimeout(200);
 
-      await page.locator('body').click(); // Click outside to close menu
+      await page.mouse.click(0, 0); // Click outside to close menu
       await expect(addToCustomListButton).not.toBeVisible();
     });
 
@@ -323,8 +325,10 @@ test.describe('Select location', () => {
 
       const deleteCustomListButton = routes.selectLocation.getDeleteCustomListButton();
       await expect(deleteCustomListButton).toBeVisible();
+      // Make sure menu transition has finished before clicking outside to close it
+      await page.waitForTimeout(200);
 
-      await page.locator('body').click(); // Click outside to close menu
+      await page.mouse.click(0, 0); // Click outside to close menu
       await expect(deleteCustomListButton).not.toBeVisible();
     });
   });


### PR DESCRIPTION
Fixes race condition when closing menus in e2e tests making them flaky. Issue occurs when we try to close the menu too early in the transition.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10523)
<!-- Reviewable:end -->
