### PR TITLE
Remove language from FAQ URL

### DIFF
--- a/ios/MullvadVPN/Coordinators/Settings/SettingsCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/SettingsCoordinator.swift
@@ -129,9 +129,7 @@ final class SettingsCoordinator: Coordinator, Presentable, Presenting, SettingsV
 
             logger.debug("Show modal \(route)")
 
-            let safariCoordinator = SafariCoordinator(
-                url: ApplicationConfiguration.faqAndGuidesURL(for: ApplicationLanguage.currentLanguage.id))
-
+            let safariCoordinator = SafariCoordinator(url: ApplicationConfiguration.faqAndGuidesURL())
             safariCoordinator.didFinish = { [weak self] in
                 self?.modalRoute = nil
             }

--- a/ios/Shared/ApplicationConfiguration.swift
+++ b/ios/Shared/ApplicationConfiguration.swift
@@ -73,8 +73,8 @@ enum ApplicationConfiguration {
     }
 
     /// FAQ & Guides URL.
-    static func faqAndGuidesURL(for language: String) -> URL {
-        URL(string: "https://\(Self.hostName)/\(language)/help/tag/mullvad-app/")!
+    static func faqAndGuidesURL() -> URL {
+        URL(string: "https://\(Self.hostName)/help/tag/mullvad-app/")!
     }
 
     /// Maximum number of devices per account.


### PR DESCRIPTION
By not adding the language ourself we leverage the browser/webserver to redirect to the device's language.
This also seems to be what both [Android](https://github.com/mullvad/mullvadvpn-app/blob/main/android/lib/ui/resource/src/main/res/values/strings_non_translatable.xml#L6C3-L7C111) and [Desktop](https://github.com/mullvad/mullvadvpn-app/blob/main/desktop/packages/mullvad-vpn/src/shared/constants/urls.ts#L5) do.

**How to test**:

For a variety of languages:

1. Switch your phone to a different language. I tested:

    - Swedish
    - German
    - French
    - Cantonese
    - Mandarin
    - English
    - Dutch
 
3. Click on the FAQ menu entry
4. Observe the webpage with the correct language header (content is still in English)

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10526)
<!-- Reviewable:end -->
