### PR TITLE
Enforce pinact action cooldown via min_age config

### DIFF
--- a/.github/pinact.yml
+++ b/.github/pinact.yml
@@ -1,7 +1,15 @@
 # pinact run           # pin any new unpinned actions
-# pinact run -u        # bump all pins to latest
+# pinact run -u        # bump all pins to latest (skips releases <7 days old)
 # pinact run -u <path> # bump one file only
+#
+# min_age below is a 7-day cooldown skipping action releases younger than 7
+# days. `value` filters new versions when bumping with -u. `always: true` makes
+# every run (incl. `pinact run --check` in workflow-check.yml) also verify that
+# already-pinned actions meet the cooldown, so CI enforces it too.
 version: 3
+min_age:
+  value: 7
+  always: true
 files:
   - pattern: .github/workflows/android-*.yml
 separator: "  # "

--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - '**'
-      - '!.github/workflows/**'
+      - '!.github/**'
       - '.github/workflows/android-app.yml'
       - '!.github/CODEOWNERS'
       - '!audits/**'

--- a/.github/workflows/workflow-check.yml
+++ b/.github/workflows/workflow-check.yml
@@ -11,7 +11,7 @@ on:
 permissions: {}
 
 env:
-  PINACT_VERSION: v3.9.0
+  PINACT_VERSION: v4.0.0
   PINACT_BASE_URL: https://github.com/suzuki-shunsuke/pinact/releases/download
 
 jobs:
@@ -34,10 +34,12 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: pinact run --check
 
+      # --check (= -fix=false) makes this fail instead of auto-correcting,
+      # which is what v4's --verify-comment does in the default fix mode.
       - name: Verify tags against SHAs
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: pinact run --verify
+        run: pinact run --check --verify-comment
 
       # Reject "<sha> #vX.Y" (no space); pinact silently ignores that form.
       - name: Check version comment format


### PR DESCRIPTION
We want to avoid pulling in too new dependencies. With the recent release of pinact 4.0.0 they added good support for a cooldown / min-age blocker, stopping it from pulling in too new github actions.

Pin the 7-day cooldown in pinact.yml with `always: true` so workflow-check.yml's `pinact run --check` also fails on already-pinned actions younger than 7 days, not just when bumping with -u.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10527)
<!-- Reviewable:end -->
