### PR TITLE
Redact download path from `installer-downloader` logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,6 +2392,7 @@ dependencies = [
  "native-windows-gui",
  "objc_id",
  "rand 0.9.4",
+ "safelog",
  "serde",
  "talpid-platform-metadata",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ license = "GPL-3.0-or-later"
 
 [workspace.dependencies]
 anyhow = "1.0"
+async-trait = "0.1"
 bytes = "1.11.1"
 chrono = { version = "0.4.26", default-features = false }
 clap = { version = "4.4.18", features = ["cargo", "derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ reqwest = { version = "0.12.23", default-features = false, features = [
 rtnetlink = "0.21.0"
 rustls = { version = "0.23", default-features = false }
 rustls-pki-types = "1.13.1"
+safelog = "0.8.2"
 serde = "1.0.204"
 serde_json = "1.0.122"
 sha2 = "0.10"

--- a/installer-downloader/CHANGELOG.md
+++ b/installer-downloader/CHANGELOG.md
@@ -22,6 +22,7 @@ Line wrap the file at 100 chars.                                              Th
 ## [Unreleased]
 ### Changed
 - Write logs to `mullvad_paths::logs::frontend_log_dir` instead of a temporary directory.
+- Redact working directory from logs.
 
 
 ## [1.2.0] - 2025-09-30

--- a/installer-downloader/Cargo.toml
+++ b/installer-downloader/Cargo.toml
@@ -28,6 +28,7 @@ mullvad-paths = { path = "../mullvad-paths" }
 mullvad-update = { path = "../mullvad-update", features = ["client"] }
 mullvad-version = { path = "../mullvad-version" }
 rand = { workspace = true }
+safelog = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 talpid-platform-metadata = { path = "../talpid-platform-metadata" }
 tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }

--- a/installer-downloader/Cargo.toml
+++ b/installer-downloader/Cargo.toml
@@ -22,7 +22,7 @@ winres = "0.1"
 
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
 anyhow = { workspace = true }
-async-trait = "0.1"
+async-trait = { workspace = true }
 log = { workspace = true }
 mullvad-paths = { path = "../mullvad-paths" }
 mullvad-update = { path = "../mullvad-update", features = ["client"] }

--- a/installer-downloader/src/controller.rs
+++ b/installer-downloader/src/controller.rs
@@ -16,7 +16,11 @@ use mullvad_update::{
     version_provider::VersionInfoProvider,
 };
 use rand::seq::IndexedRandom;
-use std::{cmp::Ordering, path::PathBuf};
+use safelog::{Sensitive, sensitive};
+use std::{
+    cmp::Ordering,
+    path::{Path, PathBuf},
+};
 use tokio::{
     sync::{mpsc, oneshot},
     task::JoinHandle,
@@ -33,14 +37,27 @@ enum TaskMessage {
 /// See the [module-level docs](self).
 pub struct AppController {}
 
+/// The directory where installer-downloader caches downloaded artifacts.
 struct WorkingDirectory {
-    pub directory: PathBuf,
+    directory: Sensitive<PathBuf>,
 }
 
 impl WorkingDirectory {
     pub async fn new<D: DirectoryProvider>() -> anyhow::Result<WorkingDirectory> {
         let directory = D::create_download_dir().await?;
+        let directory = Sensitive::new(directory);
         Ok(Self { directory })
+    }
+
+    /// Return a reference to the working directory.
+    pub fn directory(&self) -> &Path {
+        self.directory.as_path()
+    }
+}
+
+impl std::fmt::Display for WorkingDirectory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", sensitive(self.directory.display()))
     }
 }
 
@@ -238,7 +255,7 @@ where
 
         // Check if we've already downloaded an installer.
         // If so, the user will be given the option to run it.
-        let cache = Cache::new(working_directory.directory.clone(), version_params);
+        let cache = Cache::new(working_directory.directory().to_path_buf(), version_params);
         // Present the 'first' available installer. In this case, we will always present
         // the latest app version installer available, as we suspect that this is the app
         // version the user wants to install. This could be made more dynamic (i.e. a user
@@ -486,8 +503,8 @@ impl<D: AppDelegate + 'static, A: From<UiAppDownloaderParameters<D>> + AppDownlo
             });
         });
 
-        let download_dir = self.working_directory.directory.clone();
-        log::debug!("Download directory: {}", download_dir.display());
+        log::debug!("Download directory: {}", self.working_directory);
+        let download_dir = self.working_directory.directory().to_path_buf();
 
         // Begin download
         let (tx, rx) = oneshot::channel();

--- a/installer-downloader/src/log.rs
+++ b/installer-downloader/src/log.rs
@@ -1,4 +1,6 @@
-use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::{
+    Layer, filter::LevelFilter, fmt, layer::SubscriberExt, registry, util::SubscriberInitExt,
+};
 
 const LOG_FILENAME: &str = "mullvad-loader.log";
 const DATE_TIME_FORMAT_STR: &str = "[%Y-%m-%d %H:%M:%S%.3f]";
@@ -10,14 +12,31 @@ pub fn init() -> Option<tracing_appender::non_blocking::WorkerGuard> {
     let (non_blocking_file_appender, file_appender_guard) =
         tracing_appender::non_blocking(file_appender);
 
-    tracing_subscriber::fmt()
-        .with_max_level(LevelFilter::DEBUG)
-        .with_ansi(false)
-        .with_writer(non_blocking_file_appender)
-        .with_timer(tracing_subscriber::fmt::time::ChronoUtc::new(
-            DATE_TIME_FORMAT_STR.to_string(),
-        ))
-        .init();
+    // In debug mode, also log to stdout
+    if cfg!(debug_assertions) {
+        let stdout_layer = fmt::layer()
+            .with_ansi(true)
+            .with_writer(std::io::stdout)
+            .with_filter(LevelFilter::DEBUG);
+
+        let file_layer = fmt::layer()
+            .with_ansi(false)
+            .with_writer(non_blocking_file_appender)
+            .with_timer(fmt::time::ChronoUtc::new(DATE_TIME_FORMAT_STR.to_string()))
+            .with_filter(LevelFilter::DEBUG);
+        registry()
+            .with(stdout_layer)
+            .with(file_layer)
+            .try_init()
+            .ok()?;
+    } else {
+        let file_layer = fmt::layer()
+            .with_ansi(false)
+            .with_writer(non_blocking_file_appender)
+            .with_timer(fmt::time::ChronoUtc::new(DATE_TIME_FORMAT_STR.to_string()))
+            .with_filter(LevelFilter::DEBUG);
+        registry().with(file_layer).try_init().ok()?;
+    }
 
     Some(file_appender_guard)
 }

--- a/installer-downloader/src/main.rs
+++ b/installer-downloader/src/main.rs
@@ -17,6 +17,12 @@ mod inner {
         // Independently if log::init() succeed or fails, this value should be dropped last to
         // ensure that every log statement is flushed.
         let _log_flush_guard = log::init();
+        // Allow logging of sensitive values in debug builds.
+        let _safelog_guard = if cfg!(debug_assertions) {
+            safelog::disable_safe_logging().ok()
+        } else {
+            None
+        };
 
         ::log::debug!("Installer downloader version: {}", resource::VERSION);
 

--- a/mullvad-api/Cargo.toml
+++ b/mullvad-api/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["rlib", "staticlib"]
 
 [dependencies]
 anyhow = { workspace = true }
-async-trait = "0.1"
+async-trait = { workspace = true }
 chrono = { workspace = true }
 domain-fronting = "0.1"
 futures = { workspace = true }

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -120,7 +120,7 @@ tokio = { workspace = true, features = ["test-util"] }
 mullvad-update = { path = "../mullvad-update", features = ["client"] }
 
 [target.'cfg(target_os="android")'.dependencies]
-async-trait = "0.1"
+async-trait = { workspace = true }
 ctrlc = { workspace = true }
 hickory-resolver = { workspace = true }
 paranoid-android = "0.2.2"

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -40,7 +40,7 @@ talpid-cgroup = { path = "../talpid-cgroup" }
 talpid-dbus = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-async-trait = "0.1"
+async-trait = { workspace = true }
 either = { version = "1.15.0", features = ["serde"] }
 hickory-proto = { workspace = true }
 hickory-server = { workspace = true, features = ["resolver"] }

--- a/talpid-types/Cargo.toml
+++ b/talpid-types/Cargo.toml
@@ -11,7 +11,7 @@ base64 = "0.22.0"
 ipnetwork = { workspace = true, features = ["serde"] }
 itertools.workspace = true
 log = { workspace = true }
-safelog = { version = "0.8.2", features = ["serde"] }
+safelog = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 shadowsocks-crypto.workspace = true
 thiserror = { workspace = true }

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-async-trait = "0.1"
+async-trait = { workspace = true }
 byteorder = "1"
 futures = { workspace = true }
 gotatun = { workspace = true, features = ["daita", "device", "tun"] }

--- a/tunnel-obfuscation/Cargo.toml
+++ b/tunnel-obfuscation/Cargo.toml
@@ -15,7 +15,7 @@ harness = false
 name = "obfuscation_throughput"
 
 [dependencies]
-async-trait = "0.1"
+async-trait = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
 mullvad-masque-proxy = { path = "../mullvad-masque-proxy" }


### PR DESCRIPTION
Even though `installer-downloader`'s working directory is random, it is not important for us to know. Therefore we might as well mark it as sensitive using [safelog](https://crates.io/crates/safelog) to not leak anything.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10528)
<!-- Reviewable:end -->
