### PR TITLE
Pin all github actions with pinact

### DIFF
--- a/.github/actions/mullvad-build-env/action.yml
+++ b/.github/actions/mullvad-build-env/action.yml
@@ -47,7 +47,7 @@ runs:
         fi
 
     - name: Setup Rust cache
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       with:
         add-job-id-key: "false"  # Preserve cache across jobs
         cache-directories: >-
@@ -58,7 +58,7 @@ runs:
         cache-bin: false
 
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
+      uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b  # v3.0.0
       env:
         # Workaround for arduino/setup-protoc#112
         # TODO: Remove this once setup/protoc upstream ships node24.
@@ -103,7 +103,7 @@ runs:
 
     - name: Install msbuild
       if: runner.os == 'Windows'
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce  # v2.0.0
       with:
         vs-version: latest
 

--- a/.github/pinact.yml
+++ b/.github/pinact.yml
@@ -11,3 +11,12 @@ min_age:
   value: 7
   always: true
 separator: "  # "
+# Actions that intentionally aren't pinned to a verifiable version tag.
+ignore_actions:
+  # Ships per-tool branches (e.g. cargo-shear), not semver release tags.
+  - name: taiki-e/install-action
+    ref: cargo-shear
+  # Pinned to a master-branch commit SHA; there's no release tag to verify
+  # the version comment against. ref: .* so bumping the SHA needs no edit here.
+  - name: mristin/opinionated-commit-message
+    ref: .*

--- a/.github/pinact.yml
+++ b/.github/pinact.yml
@@ -10,6 +10,4 @@ version: 3
 min_age:
   value: 7
   always: true
-files:
-  - pattern: .github/workflows/android-*.yml
 separator: "  # "

--- a/.github/workflows/code-owner-approval.yml
+++ b/.github/workflows/code-owner-approval.yml
@@ -22,10 +22,10 @@ jobs:
       # Required to write a custom commit status with createCommitStatus
       statuses: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
 
       - name: Check code owner approvals
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
         with:
           # Requires a token with read access to the "Members" scope under organization,
           # and read access to the "Pull request" scope under the repository.

--- a/.github/workflows/code-owner-ownerless.yml
+++ b/.github/workflows/code-owner-ownerless.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
         with:
           ref: ${{ github.event.pull_request.base.sha }}
 
@@ -20,7 +20,7 @@ jobs:
         run: git fetch origin ${{ github.event.pull_request.head.sha }}
 
       - name: Check for new ownerless files
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/daemon-nix.yml
+++ b/.github/workflows/daemon-nix.yml
@@ -26,7 +26,7 @@ jobs:
         run: git submodule update --init --depth=1 dist-assets/binaries
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25  # v22
 
       - name: Build desktop app
         run: nix develop -c build

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -91,7 +91,7 @@ jobs:
         run: rustup override set ${{ matrix.rust }}
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           add-job-id-key: "false"  # Preserve cache across jobs
           cache-targets: "false"  # Only cache cargo registry

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -197,7 +197,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
       - name: Build test-manager
         run: ./test/scripts/container-run.sh cargo build --package test-manager --release
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -275,13 +275,13 @@ jobs:
           mkdir "${{ github.workspace }}/bin"
           echo "${{ github.workspace }}/bin/" >> "$GITHUB_PATH"
       - name: Download Test Manager
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         if: ${{ needs.build-test-manager-linux.result == 'success' }}
         with:
           name: linux-test-manager-build
           path: ${{ github.workspace }}/bin
       - name: Download Test Runner binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         if: ${{ needs.build-test-runner-binaries-linux.result == 'success' }}
         with:
           name: linux-test-runner-binaries
@@ -291,7 +291,7 @@ jobs:
           chmod +x ${{ github.workspace }}/bin/*
         shell: bash
       - name: Download App
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         if: ${{ needs.build-linux-app.result == 'success' }}
         with:
           name: linux-build
@@ -388,7 +388,7 @@ jobs:
           mkdir "${{ github.workspace }}/bin"
           echo "${{ github.workspace }}/bin/" >> "$GITHUB_PATH"
       - name: Download Test Manager
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         if: ${{ needs.build-test-manager-linux.result == 'success' }}
         with:
           name: linux-test-manager-build
@@ -397,7 +397,7 @@ jobs:
         run: |
           chmod +x ${{ github.workspace }}/bin/*
       - name: Download App
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         if: ${{ needs.build-windows.result == 'success' }}
         with:
           name: windows-build
@@ -463,7 +463,7 @@ jobs:
         os: ${{ fromJSON(needs.prepare-matrices.outputs.macos_matrix) }}
     steps:
       - name: Download App
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         if: ${{ needs.build-macos.result == 'success' }}
         with:
           name: macos-build
@@ -497,7 +497,7 @@ jobs:
       image: ${{ needs.prepare-linux.outputs.container_image }}
     steps:
       - name: Download test report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           pattern: '*_report'
           merge-multiple: true
@@ -510,7 +510,7 @@ jobs:
         run: |
           mkdir "${{ github.workspace }}/bin"
       - name: Download report compiler
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: linux-test-manager-build
           path: ${{ github.workspace }}/bin

--- a/.github/workflows/git-commit-message-style.yml
+++ b/.github/workflows/git-commit-message-style.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       # Make sure there are no whitespaces other than space, tab and newline in a commit message.
       - name: Check for unicode whitespaces
-        uses: gsactions/commit-message-checker@v2
+        uses: gsactions/commit-message-checker@16fa2d5de096ae0d35626443bcd24f1e756cafee  # v2.0.0
         with:
           # Pattern matches strings not containing weird unicode whitespace/separator characters
           # \P{Z} = All non-whitespace characters (the u-flag is needed to enable \P{Z})

--- a/.github/workflows/ios-end-to-end-tests-nightly-notification.yml
+++ b/.github/workflows/ios-end-to-end-tests-nightly-notification.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Send custom event details to a Slack workflow
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a  # v2.1.1
         with:
           webhook: ${{ secrets.IOS_SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger

--- a/.github/workflows/ios-rust-ffi.yml
+++ b/.github/workflows/ios-rust-ffi.yml
@@ -30,7 +30,7 @@ jobs:
           git submodule update --init --recursive ios/wireguard-apple
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b  # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b  # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/lint-toml.yml
+++ b/.github/workflows/lint-toml.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: tombi-toml/setup-tombi@v1
+      - uses: tombi-toml/setup-tombi@cc9f0ae573fc213f40bb4844eaa64bceeaf16348  # v1.1.0
         with:
           version: '0.11.6'
 

--- a/.github/workflows/nix-check.yml
+++ b/.github/workflows/nix-check.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v27
+        uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b  # v27
 
       - name: Check formatting
         run: nix shell nixpkgs#nixfmt-tree --command treefmt --ci

--- a/.github/workflows/proto-format-check.yml
+++ b/.github/workflows/proto-format-check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Run clang-format for proto files
-        uses: jidicula/clang-format-action@v4.11.0
+        uses: jidicula/clang-format-action@f62da5e3d3a2d88ff364771d9d938773a618ab5e  # v4.11.0
         with:
           clang-format-version: 15
           include-regex: ^.*\.proto$

--- a/.github/workflows/raas-build.yml
+++ b/.github/workflows/raas-build.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25  # v22
 
       - name: Build raas
         run: nix build ./ci/ios/test-router#raas --print-build-logs

--- a/.github/workflows/rust-supply-chain.yml
+++ b/.github/workflows/rust-supply-chain.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: ./.github/actions/mullvad-build-env
 
       - name: Run cargo deny
-        uses: EmbarkStudios/cargo-deny-action@v2
+        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe  # v2.0.20
         with:
           log-level: warn
           rust-version: stable
@@ -30,7 +30,7 @@ jobs:
 
       # Run an additional license check for the iOS crate to catch GPL3 issues
       - name: Run cargo deny for iOS (GPL3 check)
-        uses: EmbarkStudios/cargo-deny-action@v2
+        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe  # v2.0.20
         with:
           manifest-path: mullvad-ios/Cargo.toml
           log-level: error

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -60,7 +60,7 @@ jobs:
           git submodule update --init --depth=1 dist-assets/binaries
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           add-job-id-key: "false"  # Preserve cache across jobs
           cache-targets: "false"  # Only cache cargo registry

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # 2.0.0
         with:
           ignore_paths: >-
             ./android/gradlew

--- a/.github/workflows/testframework-rust-supply-chain.yml
+++ b/.github/workflows/testframework-rust-supply-chain.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Run cargo deny (test workspace)
-        uses: EmbarkStudios/cargo-deny-action@v2
+        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe  # v2.0.20
         with:
           manifest-path: ./test/Cargo.toml
           log-level: warn

--- a/.github/workflows/workflow-check.yml
+++ b/.github/workflows/workflow-check.yml
@@ -3,9 +3,9 @@ name: Workflow check
 on:
   pull_request:
     paths:
-      - .github/workflows/workflow-check.yml
+      - .github/workflows/**
+      - .github/actions/**
       - .github/pinact.yml
-      - .github/workflows/android-*.yml
   workflow_dispatch:
 
 permissions: {}
@@ -42,5 +42,6 @@ jobs:
         run: pinact run --check --verify-comment
 
       # Reject "<sha> #vX.Y" (no space); pinact silently ignores that form.
+      # Scope matches pinact's: all workflows plus composite actions.
       - name: Check version comment format
-        run: '! grep -rnE "@[0-9a-f]{40} #[^ ]" .github/workflows/android-*.yml'
+        run: '! grep -rnE "@[0-9a-f]{40} #[^ ]" --include="*.yml" --include="*.yaml" .github/workflows .github/actions'

--- a/code-owners.json
+++ b/code-owners.json
@@ -35,12 +35,12 @@
     "building/android-container-image.txt",
     "building/sigstore/mullvad/mullvadvpn-app-build-android@**",
     "ci/android/**",
-    ".github/pinact.yml",
-    ".github/workflows/workflow-check.yml",
     "scripts/check-apostrophe-style",
     "mullvad-jni/**"
   ],
   "appteam-lead": [
+    ".github/pinact.yml",
+    ".github/workflows/workflow-check.yml",
     "audits/**",
     "ci/keys/**",
     "ci/verify-locked-down-signatures.sh",


### PR DESCRIPTION
By pinning all actions to a specific git hash we both get more reliable behavior and better supply chain security (if a malicious or hacked actions maintainer moves the tag we will no longer pull in the malicious action due to pinning).

This moves the ownership of the pinact stuff to the @mullvad/appteam-lead team, due to it being supply chain security related and affecting all teams.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10530)
<!-- Reviewable:end -->
