### PR TITLE
Ignore pqcrypto advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -39,6 +39,11 @@ ignore = [
 
   # Paste unmaintained, but considered complete and trusted by the community.
   "RUSTSEC-2024-0436",
+
+  # pqcrypto-* crates are unmaintained, but there are no viable alternative for the HQC algorithm.
+  "RUSTSEC-2026-0162",  # pqcrypto-traits
+  "RUSTSEC-2026-0163",  # pqcrypto-internals
+  "RUSTSEC-2026-0168",  # pqcrypto-hqc
 ]
 
 # This section is considered when running `cargo deny check licenses`

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -87,3 +87,25 @@ reason = """
 Paste unmaintained, but considered complete and trusted by the community.
 netlink-packet-core depends on it.
 """
+
+# pqcrypto-* crates are unmaintained, but there are no viable alternative for the HQC algorithm.
+
+# pqcrypto-hqc
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0168"
+ignoreUntil = 2027-06-05
+reason = """
+pqcrypto-hqc has been archived, but there are no viable alternative for the HQC algorithm.
+"""
+
+# pqcrypto-internals
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0163"
+ignoreUntil = 2027-06-05
+reason = "pqcrypto-internals has been archived."
+
+# pqcrypto-traits
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0162"
+ignoreUntil = 2027-06-05
+reason = "pqcrypto-traits has been archived."


### PR DESCRIPTION
Silence [RUSTSEC-2026-0162](https://rustsec.org/advisories/RUSTSEC-2026-0162), [RUSTSEC-2026-0163](https://rustsec.org/advisories/RUSTSEC-2026-0163) and [RUSTSEC-2026-0168](https://rustsec.org/advisories/RUSTSEC-2026-0168). The pqcrypto-* crates are unmaintained, but there are no viable alternative for the HQC algorithm at the moment.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10532)
<!-- Reviewable:end -->
