### PR TITLE
Remove unused entries from `test/deny.toml`

### DIFF
--- a/test/deny.toml
+++ b/test/deny.toml
@@ -19,12 +19,6 @@ yanked = "deny"
 ignore = [
   # Ignored audit issues. This list should be kept short, and effort should be
   # put into removing items from the list.
-
-  # test-rpc does not deal with random user input
-  "RUSTSEC-2025-0055",
-
-  # Bincode is unmaintained. Version 1.3.3 is considered "complete" and can still be used
-  "RUSTSEC-2025-0141",
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
These ignored advisories have seemingly resolved themselves with time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10533)
<!-- Reviewable:end -->
