### PR TITLE
Log reason why WireGuard tunnel is torn down

### DIFF
--- a/talpid-dns/src/android.rs
+++ b/talpid-dns/src/android.rs
@@ -19,6 +19,7 @@ impl super::DnsMonitorT for DnsMonitor {
     }
 
     fn reset(&mut self) -> Result<(), Self::Error> {
+        log::debug!("DnsMonitor::reset is a no-op");
         Ok(())
     }
 }

--- a/talpid-routing/src/unix/mod.rs
+++ b/talpid-routing/src/unix/mod.rs
@@ -247,6 +247,7 @@ impl RouteManagerHandle {
     /// (Android) This is a noop since we don't directly control the routes on Android.
     #[cfg(target_os = "android")]
     pub fn clear_routes(&self) -> Result<(), Error> {
+        log::debug!("RouteManagerHandle::clear_routes is a no-op");
         Ok(())
     }
 

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -723,14 +723,18 @@ impl WireguardMonitor {
 
     /// Blocks the current thread until tunnel disconnects
     pub fn wait(mut self) -> Result<()> {
-        let wait_result = match self.close_msg_receiver.recv() {
-            Ok(CloseMsg::EphemeralPeerNegotiationTimeout) | Ok(CloseMsg::PingErr) => {
-                Err(Error::TimeoutError)
+        let wait_result = {
+            let result = self.close_msg_receiver.recv();
+            log::debug!("Tunnel was closed: {:#?}", result);
+            match result {
+                Ok(CloseMsg::EphemeralPeerNegotiationTimeout) | Ok(CloseMsg::PingErr) => {
+                    Err(Error::TimeoutError)
+                }
+                Ok(CloseMsg::Stop) | Ok(CloseMsg::ObfuscatorExpired) => Ok(()),
+                Ok(CloseMsg::SetupError(error)) => Err(error),
+                Ok(CloseMsg::ObfuscatorFailed(error)) => Err(error),
+                Err(_) => Ok(()),
             }
-            Ok(CloseMsg::Stop) | Ok(CloseMsg::ObfuscatorExpired) => Ok(()),
-            Ok(CloseMsg::SetupError(error)) => Err(error),
-            Ok(CloseMsg::ObfuscatorFailed(error)) => Err(error),
-            Err(_) => Ok(()),
         };
 
         self.pinger_stop_sender.close();


### PR DESCRIPTION
Manual E2E run:
https://github.com/mullvad/mullvadvpn-app/actions/runs/27006545273 (success)

Second run:
https://github.com/mullvad/mullvadvpn-app/actions/runs/27013645288
attempt 1 failed due restart of testing devices
attempt 2 failed due to login taking too long time. 
attempt 3 successful

Third run (Improved speed, removed other tests and duplicated test 12 times):
https://github.com/mullvad/mullvadvpn-app/actions/runs/27016419994
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10535)
<!-- Reviewable:end -->
