### PR TITLE
Add `ct state established` to custom dns nft rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ Line wrap the file at 100 chars.                                              Th
 - Align ciphers for custom shadowsocks API access methods between clients and `mullvad-daemon`. Any
   existing, invalid access method is removed with a settings migration.
 
+#### Linux
+- Plug hole in Custom DNS firewall rules for LAN resolvers.
+
 
 ## [2026.3-beta2] - 2026-06-01
 ### Fixed

--- a/talpid-core/src/firewall/linux.rs
+++ b/talpid-core/src/firewall/linux.rs
@@ -748,13 +748,7 @@ impl<'a> PolicyBatch<'a> {
         check_endpoint(&mut in_rule, End::Src, &endpoint.endpoint);
 
         // Allow all incoming traffic from established connections to the endpoint
-        let allowed_states = nftnl::expr::ct::States::ESTABLISHED.bits();
-        // bitwise mask will bitwise-and the allowed_states and the ct state. It will then xor it
-        // will 0 (which changes nothing). This means it works as a bitwise-and which checks that
-        // the ESTABLISHED bit is set in the connection state.
-        in_rule.add_expr(&nft_expr!(ct state));
-        in_rule.add_expr(&nft_expr!(bitwise mask allowed_states, xor 0u32));
-        in_rule.add_expr(&nft_expr!(cmp != 0u32));
+        check_ct_established(&mut in_rule);
         add_verdict(&mut in_rule, &Verdict::Accept);
 
         self.batch.add(&in_rule, nftnl::MsgType::Add);
@@ -787,10 +781,7 @@ impl<'a> PolicyBatch<'a> {
         let mut in_rule = Rule::new(&self.in_chain);
         // Allow incoming traffic from established connections to the endpoint
         check_endpoint(&mut in_rule, End::Src, &endpoint.endpoint);
-        let allowed_states = nftnl::expr::ct::States::ESTABLISHED.bits();
-        in_rule.add_expr(&nft_expr!(ct state));
-        in_rule.add_expr(&nft_expr!(bitwise mask allowed_states, xor 0u32));
-        in_rule.add_expr(&nft_expr!(cmp != 0u32));
+        check_ct_established(&mut in_rule);
         if !endpoint.clients.allow_all() {
             in_rule.add_expr(&nft_expr!(meta skuid));
             in_rule.add_expr(&nft_expr!(cmp == super::ROOT_UID));
@@ -857,6 +848,11 @@ impl<'a> PolicyBatch<'a> {
 
             allow_rule.add_expr(&addr);
             allow_rule.add_expr(&nft_expr!(cmp == host));
+
+            if let Direction::In = direction {
+                check_ct_established(&mut allow_rule);
+            }
+
             add_verdict(&mut allow_rule, &Verdict::Accept);
 
             self.batch.add(&allow_rule, nftnl::MsgType::Add);
@@ -920,10 +916,7 @@ impl<'a> PolicyBatch<'a> {
         // connections.
         let mut interface_rule = Rule::new(&self.forward_chain);
         check_iface(&mut interface_rule, Direction::In, tunnel_interface)?;
-        interface_rule.add_expr(&nft_expr!(ct state));
-        let allowed_states = nftnl::expr::ct::States::ESTABLISHED.bits();
-        interface_rule.add_expr(&nft_expr!(bitwise mask allowed_states, xor 0u32));
-        interface_rule.add_expr(&nft_expr!(cmp != 0u32));
+        check_ct_established(&mut interface_rule);
         add_verdict(&mut interface_rule, &Verdict::Accept);
         self.batch.add(&interface_rule, nftnl::MsgType::Add);
 
@@ -1149,6 +1142,19 @@ fn l4proto(protocol: TransportProtocol) -> u8 {
         TransportProtocol::Udp => libc::IPPROTO_UDP as u8,
         TransportProtocol::Tcp => libc::IPPROTO_TCP as u8,
     }
+}
+
+/// Add `ct state established` requirement to `rule`.
+///
+/// This matches packets which are a part of an already established connection.
+fn check_ct_established(rule: &mut Rule<'_>) {
+    // bitwise mask will bitwise-and the allowed_states and the ct state. It will then xor it
+    // with 0 (which changes nothing). This means it works as a bitwise-and which checks that
+    // the ESTABLISHED bit is set in the connection state.
+    let established = nftnl::expr::ct::States::ESTABLISHED.bits();
+    rule.add_expr(&nft_expr!(ct state));
+    rule.add_expr(&nft_expr!(bitwise mask established, xor 0u32));
+    rule.add_expr(&nft_expr!(cmp != 0u32));
 }
 
 fn add_verdict(rule: &mut Rule<'_>, verdict: &expr::Verdict) {


### PR DESCRIPTION
The previous DNS rules for custom LAN DNS were a bit too relaxed, and
allowed all incoming packets from `<dns_resolver>:53`. This change
requires that an outgoing connection is established first (e.g. a DNS
request is sent), before we accept reply packets to the source port.

Essentially, given a custom dns resolver at `fe80::1`,
this would change the following nftables rules:

    iif != "wg0-mullvad" udp sport 53 ip6 saddr fe80::1 accept
    iif != "wg0-mullvad" tcp sport 53 ip6 saddr fe80::1 accept

...to this:

    iif != "wg0-mullvad" udp sport 53 ip6 saddr fe80::1 ct state established accept
    iif != "wg0-mullvad" tcp sport 53 ip6 saddr fe80::1 ct state established accept

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10537)
<!-- Reviewable:end -->
