### PR TITLE
Add post-quantum helper tests

### DIFF
--- a/talpid-tunnel-config-client/src/hqc.rs
+++ b/talpid-tunnel-config-client/src/hqc.rs
@@ -54,3 +54,41 @@ pub fn keypair() -> Keypair {
         secret_key,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decapsulate_roundtrips_shared_secret() {
+        let keypair = keypair();
+        let (shared_secret, ciphertext) = hqc256::encapsulate(&keypair.public_key);
+        let expected_shared_secret: [u8; 32] = Sha256::digest(shared_secret.as_bytes()).into();
+
+        let decapsulated_shared_secret = keypair.decapsulate(ciphertext.as_bytes()).unwrap();
+
+        assert_eq!(decapsulated_shared_secret, expected_shared_secret);
+    }
+
+    #[test]
+    fn decapsulate_rejects_invalid_ciphertext_length() {
+        let keypair = keypair();
+
+        for invalid_ciphertext in [&[][..], &[0u8][..]] {
+            let error = keypair.decapsulate(invalid_ciphertext).unwrap_err();
+
+            match error {
+                crate::Error::InvalidCiphertextLength {
+                    algorithm,
+                    actual,
+                    expected,
+                } => {
+                    assert_eq!(algorithm, ALGORITHM_NAME);
+                    assert_eq!(actual, invalid_ciphertext.len());
+                    assert_eq!(expected, hqc256::ciphertext_bytes());
+                }
+                error => panic!("unexpected error: {error:?}"),
+            }
+        }
+    }
+}

--- a/talpid-tunnel-config-client/src/lib.rs
+++ b/talpid-tunnel-config-client/src/lib.rs
@@ -455,4 +455,40 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn post_quantum_secrets_uses_expected_kems_in_order() {
+        let (request, (ml_kem_keypair, hqc_keypair)) = post_quantum_secrets();
+
+        let [ml_kem_pubkey, hqc_pubkey] =
+            <&[proto::KemPubkeyV1; 2]>::try_from(request.kem_pubkeys.as_slice()).unwrap();
+
+        assert_eq!(ml_kem_pubkey.algorithm_name, "ML-KEM-1024");
+        assert_eq!(ml_kem_pubkey.key_data, ml_kem_keypair.encapsulation_key());
+
+        assert_eq!(hqc_pubkey.algorithm_name, "HQC-256");
+        assert_eq!(hqc_pubkey.key_data, hqc_keypair.encapsulation_key());
+    }
+
+    #[test]
+    fn xor_assign_mixes_each_byte() {
+        let mut dst = [0u8; 32];
+        let src = [0xffu8; 32];
+
+        xor_assign(&mut dst, &src);
+        assert_eq!(dst, [0xffu8; 32]);
+
+        xor_assign(&mut dst, &src);
+        assert_eq!(dst, [0u8; 32]);
+    }
+
+    #[test]
+    fn xor_assign_matches_bytewise_xor() {
+        let mut dst = [0x55u8; 32];
+        let src = [0x33u8; 32];
+
+        xor_assign(&mut dst, &src);
+
+        assert_eq!(dst, [0x66u8; 32]);
+    }
 }

--- a/talpid-tunnel-config-client/src/ml_kem.rs
+++ b/talpid-tunnel-config-client/src/ml_kem.rs
@@ -66,3 +66,44 @@ pub fn keypair() -> Keypair {
         decapsulation_key,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ml_kem::kem::Encapsulate as _;
+
+    #[test]
+    fn decapsulate_roundtrips_shared_secret() {
+        let keypair = keypair();
+        let (ciphertext, shared_secret) = keypair
+            .encapsulation_key
+            .encapsulate(&mut rand_core::OsRng)
+            .unwrap();
+
+        let decapsulated_shared_secret = keypair.decapsulate(ciphertext.as_slice()).unwrap();
+
+        assert_eq!(decapsulated_shared_secret, shared_secret.0);
+    }
+
+    #[test]
+    fn decapsulate_rejects_invalid_ciphertext_length() {
+        let keypair = keypair();
+
+        for invalid_ciphertext in [&[][..], &[0u8][..]] {
+            let error = keypair.decapsulate(invalid_ciphertext).unwrap_err();
+
+            match error {
+                crate::Error::InvalidCiphertextLength {
+                    algorithm,
+                    actual,
+                    expected,
+                } => {
+                    assert_eq!(algorithm, ALGORITHM_NAME);
+                    assert_eq!(actual, invalid_ciphertext.len());
+                    assert_eq!(expected, CIPHERTEXT_LEN);
+                }
+                error => panic!("unexpected error: {error:?}"),
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds unit coverage for the existing post-quantum tunnel config helpers.

This checks that the ephemeral peer request publishes `ML-KEM-1024` and `HQC-256` in the expected order, that the published key bytes match the generated keypairs, and that the ML-KEM/HQC wrappers roundtrip with the underlying KEM crates.

It also covers invalid ciphertext length errors and the PSK XOR mixing helper.

Testing:
- `cargo fmt --package talpid-tunnel-config-client --check`
- `cargo fmt -- --check`
- `ci/cargo-ci.sh test -p talpid-tunnel-config-client`
- `ci/cargo-ci.sh clippy --package talpid-tunnel-config-client --all-targets --no-default-features`
- `ci/cargo-ci.sh clippy --package talpid-tunnel-config-client --all-targets --all-features`
- `ci/cargo-ci.sh test --workspace`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10544)
<!-- Reviewable:end -->
