### PR TITLE
Always scroll to the absolute top of the select location list when recents are enabled

### DIFF
--- a/ios/MullvadVPN/View controllers/SelectLocation/Views/ExitLocationView.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/Views/ExitLocationView.swift
@@ -81,25 +81,16 @@ struct ExitLocationView<ViewModel: SelectLocationViewModel>: View {
             .listStyle(.plain)
             .coordinateSpace(.exitLocationScroll)
             .onAppear {
-                if viewModel.isRecentsEnabled {
-                    scrollProxy.scrollTo(topAnchor, anchor: .center)
-                } else {
-                    scrollToCurrentSelection(scrollProxy)
-                }
+                scrollToCurrentSelection(scrollProxy)
             }
             .onChange(of: viewModel.isRecentsEnabled) {
-                if viewModel.isRecentsEnabled {
-                    scrollProxy.scrollTo(topAnchor, anchor: .center)
-                } else {
-                    scrollToCurrentSelection(scrollProxy)
-                }
+                scrollToCurrentSelection(scrollProxy)
+            }
+            .onChange(of: viewModel.multihopContext) {
+                scrollToCurrentSelection(scrollProxy)
             }
             .onChange(of: viewModel.searchText) { oldValue, newValue in
-                if !newValue.isEmpty {
-                    scrollProxy.scrollTo(topAnchor, anchor: .center)
-                } else if newValue.isEmpty {
-                    scrollToCurrentSelection(scrollProxy)
-                }
+                scrollToCurrentSelection(scrollProxy)
             }
         }
         .mullvadInputAlert(item: $newCustomListAlert)
@@ -249,10 +240,13 @@ struct ExitLocationView<ViewModel: SelectLocationViewModel>: View {
     }
 
     private func scrollToCurrentSelection(_ scrollProxy: ScrollViewProxy) {
-        guard viewModel.searchText.isEmpty,
+        if viewModel.isRecentsEnabled {
+            scrollProxy.scrollTo(topAnchor, anchor: .center)
+        } else if viewModel.searchText.isEmpty,
             let selectedLocation = context.selectedLocation
-        else { return }
-        scrollProxy.scrollTo(selectedLocation.id, anchor: .center)
+        {
+            scrollProxy.scrollTo(selectedLocation.id, anchor: .center)
+        }
     }
 }
 


### PR DESCRIPTION
This PR fixes the incorrect scroll position in the Select Location view when Recents are enabled. The view now always scrolls to the top when it appears.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10545)
<!-- Reviewable:end -->
