### PR TITLE
Silence RUSTSEC-2025-0141 for one more year

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -73,7 +73,7 @@
 # code could trigger, it is just unmaintained.
 [[IgnoredVulns]]
 id = "RUSTSEC-2025-0141"
-ignoreUntil = 2026-06-07
+ignoreUntil = 2027-06-07
 reason = """
 Bincode is unmaintained. maybenot depend on it.
 Version 1.3.3 is considered "complete" and can still be used safely.

--- a/test/osv-scanner.toml
+++ b/test/osv-scanner.toml
@@ -22,7 +22,7 @@ tarpc transitively depends on unsound version of `rand`, and upgrade path for ta
 # code could trigger, it is just unmaintained.
 [[IgnoredVulns]]
 id = "RUSTSEC-2025-0141"
-ignoreUntil = 2026-06-07
+ignoreUntil = 2027-06-07
 reason = """
 Bincode is unmaintained. maybenot depend on it.
 Version 1.3.3 is considered "complete" and can still be used safely.


### PR DESCRIPTION
This PR bumps the "ignore until"-date for bincode by one year. The crate is considered stable, and we have no real reason to switch to any fork.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10549)
<!-- Reviewable:end -->
