### PR TITLE
Enable E2E tests for PRs with label

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -2,6 +2,7 @@
 name: Android - Build and test
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - '**'
       - '!.github/**'
@@ -96,6 +97,8 @@ jobs:
   prepare:
     name: Prepare
     runs-on: ["${{ inputs.android_build_runner || 'android-build' }}"]
+    # Limit label triggers to the "E2E" test label.
+    if: github.event.action != 'labeled' || github.event.label.name == 'E2E'
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -118,6 +121,7 @@ jobs:
           >> $GITHUB_ENV
           echo "INNER_E2E_TEST_REPEAT=${{ github.event.inputs.e2e_test_repeat ||
           (github.event_name == 'schedule' && env.SCHEDULE_E2E_REPEAT) ||
+          (contains(github.event.pull_request.labels.*.name, 'E2E') && '1') ||
           env.DEFAULT_E2E_REPEAT }}" \
           >> $GITHUB_ENV
     outputs:


### PR DESCRIPTION
This PR adds support for conditionally enabling our full E2E test suite for PRs by adding the "E2E" label.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10552)
<!-- Reviewable:end -->
