### PR TITLE
Instantiate file cache only once in the app

### DIFF
--- a/ios/MullvadMockData/MullvadREST/MockRelayCacheProvider.swift
+++ b/ios/MullvadMockData/MullvadREST/MockRelayCacheProvider.swift
@@ -1,0 +1,20 @@
+//
+//  MockRelayCacheProvider.swift
+//  MullvadVPN
+//
+//  Created by Jon Petersson on 2026-06-08.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+@testable import MullvadREST
+
+public struct MockRelayCacheTracker: RelayCacheTrackerProviding {
+    public init() {}
+
+    public func getCachedRelays() throws -> MullvadREST.CachedRelays {
+        CachedRelays(
+            relays: ServerRelaysResponseStubs.sampleRelays,
+            updatedAt: Date()
+        )
+    }
+}

--- a/ios/MullvadREST/Relay/RelayCacheProviding.swift
+++ b/ios/MullvadREST/Relay/RelayCacheProviding.swift
@@ -1,0 +1,11 @@
+//
+//  RelayCacheProviding.swift
+//  MullvadVPN
+//
+//  Created by Jon Petersson on 2026-06-08.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+public protocol RelayCacheTrackerProviding: Sendable {
+    func getCachedRelays() throws -> CachedRelays
+}

--- a/ios/MullvadTypes/FileCache.swift
+++ b/ios/MullvadTypes/FileCache.swift
@@ -46,18 +46,15 @@ public final class FileCache<Content: Codable>: FileCacheProtocol, @unchecked Se
     }
 
     public func read() throws -> Content {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+
         // Fast path: if the file modification time hasn't changed, return the cached content.
         let currentModificationTime = fileModificationTime()
-        let cached: Content? = cacheLock.withLock {
-            if let cachedContent, let contentModified, contentModified == currentModificationTime,
-                currentModificationTime != nil
-            {
-                return cachedContent
-            }
-            return nil
-        }
-        if let cached {
-            return cached
+        if let cachedContent, let contentModified, contentModified == currentModificationTime,
+            currentModificationTime != nil
+        {
+            return cachedContent
         }
 
         // Slow path: acquire a shared lock and read from disk.
@@ -71,17 +68,17 @@ public final class FileCache<Content: Codable>: FileCacheProtocol, @unchecked Se
 
         let data = try Data(contentsOf: fileURL)
         let content = try JSONDecoder().decode(Content.self, from: data)
-        let mtime = fileModificationTime()
 
-        cacheLock.withLock {
-            cachedContent = content
-            contentModified = mtime
-        }
+        cachedContent = content
+        contentModified = fileModificationTime()
 
         return content
     }
 
     public func write(_ content: Content) throws {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+
         // Encode before acquiring the lock to minimize exclusive lock hold time.
         let data = try JSONEncoder().encode(content)
 
@@ -102,14 +99,14 @@ public final class FileCache<Content: Codable>: FileCacheProtocol, @unchecked Se
             throw FileCacheError.renameFailed(errno)
         }
 
-        let mtime = fileModificationTime()
-        cacheLock.withLock {
-            cachedContent = content
-            contentModified = mtime
-        }
+        cachedContent = content
+        contentModified = fileModificationTime()
     }
 
     public func clear() throws {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+
         let lockFd = try openLockFile()
         defer { close(lockFd) }
 
@@ -120,10 +117,8 @@ public final class FileCache<Content: Codable>: FileCacheProtocol, @unchecked Se
 
         try FileManager.default.removeItem(at: fileURL)
 
-        cacheLock.withLock {
-            cachedContent = nil
-            contentModified = nil
-        }
+        cachedContent = nil
+        contentModified = nil
     }
 
     // MARK: - Private

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -672,6 +672,8 @@
 		7AA1309B2D0048D800640DF9 /* MainButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA1309A2D0048D800640DF9 /* MainButton.swift */; };
 		7AA1309F2D007B2500640DF9 /* VisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA1309E2D007B2500640DF9 /* VisualEffectView.swift */; };
 		7AA130A12D01B1E200640DF9 /* SplitMainButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA130A02D01B1E200640DF9 /* SplitMainButton.swift */; };
+		7AA3C8FD2FD6F95200D0C26A /* MockRelayCacheProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA3C8FC2FD6F94A00D0C26A /* MockRelayCacheProvider.swift */; };
+		7AA3C8FF2FD6F9F100D0C26A /* RelayCacheProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA3C8FE2FD6F9ED00D0C26A /* RelayCacheProviding.swift */; };
 		7AA513862BC91C6B00D081A4 /* LogRotationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA513852BC91C6B00D081A4 /* LogRotationTests.swift */; };
 		7AA564462F29014D001D1FB9 /* IncludeAllNetworksPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA564452F290144001D1FB9 /* IncludeAllNetworksPage.swift */; };
 		7AA564482F2B6813001D1FB9 /* String+Assets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA564472F2B680D001D1FB9 /* String+Assets.swift */; };
@@ -2346,6 +2348,8 @@
 		7AA1309A2D0048D800640DF9 /* MainButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainButton.swift; sourceTree = "<group>"; };
 		7AA1309E2D007B2500640DF9 /* VisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEffectView.swift; sourceTree = "<group>"; };
 		7AA130A02D01B1E200640DF9 /* SplitMainButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitMainButton.swift; sourceTree = "<group>"; };
+		7AA3C8FC2FD6F94A00D0C26A /* MockRelayCacheProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRelayCacheProvider.swift; sourceTree = "<group>"; };
+		7AA3C8FE2FD6F9ED00D0C26A /* RelayCacheProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayCacheProviding.swift; sourceTree = "<group>"; };
 		7AA513852BC91C6B00D081A4 /* LogRotationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogRotationTests.swift; sourceTree = "<group>"; };
 		7AA564452F290144001D1FB9 /* IncludeAllNetworksPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncludeAllNetworksPage.swift; sourceTree = "<group>"; };
 		7AA564472F2B680D001D1FB9 /* String+Assets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Assets.swift"; sourceTree = "<group>"; };
@@ -4983,6 +4987,7 @@
 				A900E9BB2ACC609200C95F67 /* DevicesProxy+Stubs.swift */,
 				F0ACE32E2BE4EA8B006D5333 /* MockProxyFactory.swift */,
 				F0FA160D2D7F2C3D007E2546 /* MockRelayCache.swift */,
+				7AA3C8FC2FD6F94A00D0C26A /* MockRelayCacheProvider.swift */,
 				58FE25EF2AA77664003D1918 /* RelaySelectorStub.swift */,
 				A900E9B92ACC5D0600C95F67 /* RESTRequestExecutor+Stubs.swift */,
 				F0FA160B2D7F2BF2007E2546 /* ServerRelaysResponse+Stubs.swift */,
@@ -5028,6 +5033,7 @@
 				F0F3161A2BF358590078DBCF /* NoRelaysSatisfyingConstraintsError.swift */,
 				7AD63A3A2CD5278900445268 /* ObfuscationMethodSelector.swift */,
 				5820675A26E6576800655B05 /* RelayCache.swift */,
+				7AA3C8FE2FD6F9ED00D0C26A /* RelayCacheProviding.swift */,
 				F0791F1A2D76377400449F6D /* RelayCandidates.swift */,
 				F0DDE4282B220A15006B57A7 /* RelaySelector.swift */,
 				F0B894F42BF7528700817A42 /* RelaySelector+Shadowsocks.swift */,
@@ -6166,6 +6172,7 @@
 				7AFBE38D2D09AB2E002335FC /* MultihopPicker.swift in Sources */,
 				7A3AD5012C1068A800E9AD90 /* RelayPicking.swift in Sources */,
 				F06045EC2B2322A500B2D37A /* Jittered.swift in Sources */,
+				7AA3C8FF2FD6F9F100D0C26A /* RelayCacheProviding.swift in Sources */,
 				7AA5C3702E9D21DB00B35530 /* DefaultLocationService.swift in Sources */,
 				F0DDE4152B220458006B57A7 /* ShadowsocksConfigurationCache.swift in Sources */,
 				06799AEA28F98E4800ACD94E /* RESTProxy.swift in Sources */,
@@ -7337,6 +7344,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F0ACE31D2BE4E4F2006D5333 /* DevicesProxy+Stubs.swift in Sources */,
+				7AA3C8FD2FD6F95200D0C26A /* MockRelayCacheProvider.swift in Sources */,
 				F07F63CE2C63E5790027A351 /* AccessMethodRepository+Stub.swift in Sources */,
 				F0ACE31E2BE4E4F2006D5333 /* AccountsProxy+Stubs.swift in Sources */,
 				7AA5C3792E9FD8BA00B35530 /* URLSessionStub.swift in Sources */,

--- a/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
@@ -592,7 +592,8 @@ final class ApplicationCoordinator: Coordinator, Presenting, @preconcurrency Roo
         let tunnelCoordinator = TunnelCoordinator(
             tunnelManager: tunnelManager,
             outgoingConnectionService: outgoingConnectionService,
-            settingsStore: settingsManager.store
+            settingsStore: settingsManager.store,
+            relayCacheTracker: relayCacheTracker
         )
 
         tunnelCoordinator.showSelectLocationPicker = { [weak self] in

--- a/ios/MullvadVPN/Coordinators/TunnelCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/TunnelCoordinator.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2026 Mullvad VPN AB. All rights reserved.
 //
 
+import MullvadREST
 import MullvadSettings
 import Routing
 import UIKit
@@ -29,7 +30,8 @@ class TunnelCoordinator: Coordinator, Presenting {
     init(
         tunnelManager: TunnelManager,
         outgoingConnectionService: OutgoingConnectionServiceHandling,
-        settingsStore: SettingsStore
+        settingsStore: SettingsStore,
+        relayCacheTracker: RelayCacheTrackerProtocol
     ) {
         self.tunnelManager = tunnelManager
 
@@ -38,7 +40,11 @@ class TunnelCoordinator: Coordinator, Presenting {
             outgoingConnectionService: outgoingConnectionService
         )
 
-        controller = TunnelViewController(interactor: interactor, settingsStore: settingsStore)
+        controller = TunnelViewController(
+            interactor: interactor,
+            settingsStore: settingsStore,
+            relayCacheTracker: relayCacheTracker
+        )
 
         super.init()
 

--- a/ios/MullvadVPN/RelayCacheTracker/RelayCacheTracker.swift
+++ b/ios/MullvadVPN/RelayCacheTracker/RelayCacheTracker.swift
@@ -13,12 +13,11 @@ import MullvadTypes
 import Operations
 import UIKit
 
-protocol RelayCacheTrackerProtocol: Sendable {
+protocol RelayCacheTrackerProtocol: RelayCacheTrackerProviding {
     func startPeriodicUpdates()
     func stopPeriodicUpdates()
     func updateRelays(completionHandler: ((sending Result<RelaysFetchResult, Error>) -> Void)?) -> Cancellable
     func fetchRelays(completionHandler: ((sending Result<RelaysFetchResult, Error>) -> Void)?) -> Cancellable
-    func getCachedRelays() throws -> CachedRelays
     func getNextUpdateDate() -> Date
     func addObserver(_ observer: RelayCacheTrackerObserver)
     func removeObserver(_ observer: RelayCacheTrackerObserver)

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ConnectionViewComponentPreview.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ConnectionViewComponentPreview.swift
@@ -66,7 +66,7 @@ struct ConnectionViewComponentPreview<Content: View>: View {
         viewModel = ConnectionViewViewModel(
             tunnelStatus: connectedTunnelStatus,
             relayConstraints: RelayConstraints(),
-            relayCache: RelayCache(cacheDirectory: ApplicationConfiguration.containerURL),
+            relayCacheTracker: MockRelayCacheTracker(),
             customListRepository: CustomListRepository(settingsStore: settingsManager.store)
         )
         viewModel.outgoingConnectionInfo = OutgoingConnectionInfo(

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ConnectionViewViewModel.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ConnectionViewViewModel.swift
@@ -52,13 +52,13 @@ class ConnectionViewViewModel: ObservableObject {
     init(
         tunnelStatus: TunnelStatus,
         relayConstraints: RelayConstraints,
-        relayCache: RelayCacheProtocol,
+        relayCacheTracker: RelayCacheTrackerProviding,
         customListRepository: CustomListRepositoryProtocol
     ) {
         self.tunnelStatus = tunnelStatus
         self.relayConstraints = relayConstraints
         self.destinationDescriber = DestinationDescriber(
-            relayCache: relayCache,
+            relayCacheTracker: relayCacheTracker,
             customListRepository: customListRepository
         )
     }

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/DestinationDescriber.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/DestinationDescriber.swift
@@ -16,14 +16,14 @@ protocol DestinationDescribing {
 }
 
 struct DestinationDescriber: DestinationDescribing {
-    let relayCache: RelayCacheProtocol
+    let relayCacheTracker: RelayCacheTrackerProviding
     let customListRepository: CustomListRepositoryProtocol
 
     public init(
-        relayCache: RelayCacheProtocol,
+        relayCacheTracker: RelayCacheTrackerProviding,
         customListRepository: CustomListRepositoryProtocol
     ) {
-        self.relayCache = relayCache
+        self.relayCacheTracker = relayCacheTracker
         self.customListRepository = customListRepository
     }
 
@@ -54,11 +54,12 @@ struct DestinationDescriber: DestinationDescribing {
     private func relayDescription(_ destination: UserSelectedRelays) -> String? {
         guard
             let location = destination.locations.first,
-            let cachedRelays = try? relayCache.read().relays
+            let relays = try? relayCacheTracker.getCachedRelays().relays
         else { return nil }
+
         let locatedRelays = RelayWithLocation.locateRelays(
-            relays: cachedRelays.wireguard.relays,
-            locations: cachedRelays.locations
+            relays: relays.wireguard.relays,
+            locations: relays.locations
         )
 
         guard

--- a/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
@@ -62,14 +62,18 @@ class TunnelViewController: UIViewController, RootContainment {
         false
     }
 
-    init(interactor: TunnelViewControllerInteractor, settingsStore: SettingsStore) {
+    init(
+        interactor: TunnelViewControllerInteractor,
+        settingsStore: SettingsStore,
+        relayCacheTracker: RelayCacheTrackerProviding
+    ) {
         self.interactor = interactor
 
         tunnelState = interactor.tunnelStatus.state
         connectionViewViewModel = ConnectionViewViewModel(
             tunnelStatus: interactor.tunnelStatus,
             relayConstraints: interactor.tunnelSettings.relayConstraints,
-            relayCache: RelayCache(cacheDirectory: ApplicationConfiguration.containerURL),
+            relayCacheTracker: relayCacheTracker,
             customListRepository: CustomListRepository(settingsStore: settingsStore)
         )
         indicatorsViewViewModel = FeatureIndicatorsViewModel(

--- a/ios/MullvadVPNTests/MullvadVPN/View controllers/Tunnel/DestinationDescriberTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/View controllers/Tunnel/DestinationDescriberTests.swift
@@ -22,10 +22,10 @@ final class DestinationDescriberTests: XCTestCase {
     }
 
     func testDescribeList() throws {
-        let relayCache = MockRelayCache()
+        let relayCacheTracker = MockRelayCacheTracker()
         let customListRepository = CustomListRepository(settingsStore: store)
         let describer = DestinationDescriber(
-            relayCache: relayCache,
+            relayCacheTracker: relayCacheTracker,
             customListRepository: customListRepository
         )
         let listid = UUID()
@@ -46,10 +46,10 @@ final class DestinationDescriberTests: XCTestCase {
     }
 
     func testDescribeSubsetOfList() throws {
-        let relayCache = MockRelayCache()
+        let relayCacheTracker = MockRelayCacheTracker()
         let customListRepository = CustomListRepository(settingsStore: store)
         let describer = DestinationDescriber(
-            relayCache: relayCache,
+            relayCacheTracker: relayCacheTracker,
             customListRepository: customListRepository
         )
         let listid = UUID()
@@ -70,30 +70,30 @@ final class DestinationDescriberTests: XCTestCase {
     }
 
     func testDescribeCountryDestination() {
-        let relayCache = MockRelayCache()
+        let relayCacheTracker = MockRelayCacheTracker()
         let customListRepository = CustomListRepository(settingsStore: store)
         let describer = DestinationDescriber(
-            relayCache: relayCache,
+            relayCacheTracker: relayCacheTracker,
             customListRepository: customListRepository
         )
         XCTAssertEqual(describer.describe(.init(locations: [.country("se")])), "Sweden")
     }
 
     func testDescribeCityDestination() {
-        let relayCache = MockRelayCache()
+        let relayCacheTracker = MockRelayCacheTracker()
         let customListRepository = CustomListRepository(settingsStore: store)
         let describer = DestinationDescriber(
-            relayCache: relayCache,
+            relayCacheTracker: relayCacheTracker,
             customListRepository: customListRepository
         )
         XCTAssertEqual(describer.describe(.init(locations: [.city("se", "sto")])), "Stockholm")
     }
 
     func testDescribeRelayDestination() {
-        let relayCache = MockRelayCache()
+        let relayCacheTracker = MockRelayCacheTracker()
         let customListRepository = CustomListRepository(settingsStore: store)
         let describer = DestinationDescriber(
-            relayCache: relayCache,
+            relayCacheTracker: relayCacheTracker,
             customListRepository: customListRepository
         )
         XCTAssertEqual(


### PR DESCRIPTION
We're currently instatiating the FileCache from multiple places in the code while we should only do it once and inject it wherever needed. This PR does that and hopefully fixes the many (silent?) crashes we've seen related to the relay cache silently.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10554)
<!-- Reviewable:end -->
