### PR TITLE
Remove `wait_for_interfaces` from tun provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,7 +1779,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-util 0.7.18",
- "tun 0.8.10",
+ "tun 0.8.11",
  "typed-builder 0.21.2",
  "windows-sys 0.61.2",
  "x25519-dalek",
@@ -5734,7 +5734,7 @@ dependencies = [
  "talpid-windows",
  "thiserror 2.0.18",
  "tokio",
- "tun 0.8.10",
+ "tun 0.8.11",
  "windows-sys 0.61.2",
 ]
 
@@ -5827,7 +5827,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tun 0.8.10",
+ "tun 0.8.11",
  "tunnel-obfuscation",
  "widestring",
  "windows-sys 0.61.2",
@@ -6461,9 +6461,9 @@ dependencies = [
 
 [[package]]
 name = "tun"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e487da0cdd4a7ec9abe31c560fe53ec71275501fdc1e6aa6fccb781779686278"
+checksum = "dd9b35e3ba2b50284437061a8a30097f56473f287f48b3fe7660712cc03e9047"
 dependencies = [
  "bytes",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ tonic-prost-build = { version = "0.14.6", default-features = false }
 tower = { version = "0.5.1", features = ["util"] }
 tracing-appender = "0.2.4"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
-tun = { version = "0.8.10", default-features = false, features = ["async"] }
+tun = { version = "0.8.11", default-features = false, features = ["async"] }
 tun05 = { package = "tun", version = "0.5.5", features = ["async"] }
 vec1 = "1.12"
 webpki-roots = "1.0.4"

--- a/talpid-tunnel/src/tun_provider/windows.rs
+++ b/talpid-tunnel/src/tun_provider/windows.rs
@@ -59,16 +59,17 @@ impl WindowsTunProvider {
 
     /// Open a tunnel using the current tunnel config.
     pub fn open_tun(&mut self) -> Result<WindowsTun, Error> {
+        let has_ipv4 = self.config.addresses.iter().any(|addr| addr.is_ipv4());
+        let has_ipv6 = self.config.addresses.iter().any(|addr| addr.is_ipv6());
+
         let mut tunnel_device = {
             let mut builder = TunnelDeviceBuilder::default();
 
-            // TODO: see comment on `wait_for_interfaces_sync` for why MTU and metric are not set
-            // here. Revert when fixed.
             // When routing, the metric of a route is equal to the sum of the interface metric and
             // metric value set for the route itself. Setting the interface metric to 1 gives tunnel
             // routes the highest possible priority.
-            //builder.config.metric(1);
-            //builder.config.mtu(self.config.mtu);
+            builder.config.metric(1);
+            builder.config.mtu(self.config.mtu);
 
             /// Tunnel adapter name
             const ADAPTER_NAME: &str = "Mullvad";
@@ -84,43 +85,17 @@ impl WindowsTunProvider {
                 .platform_config(|cfg: &mut tun::PlatformConfig| {
                     cfg.device_guid(ADAPTER_GUID);
 
+                    // TODO: This isn't cancellable by the user or TSM, which means tunnel state machine can
+                    // become unresponsive if it takes a long time for the interfaces to appear. Seems to happen
+                    // for some users.
+                    cfg.wait_for_interfaces(has_ipv4, has_ipv6, Duration::from_secs(30));
+
                     let wintun_path = self.config.resource_dir.join("wintun.dll");
                     cfg.wintun_file(wintun_path);
                 });
 
             builder.create()?
         };
-
-        let luid = NET_LUID_LH {
-            Value: tunnel_device.dev.tun_luid(),
-        };
-        let has_ipv4 = self.config.addresses.iter().any(|addr| addr.is_ipv4());
-        let has_ipv6 = self.config.addresses.iter().any(|addr| addr.is_ipv6());
-
-        // TODO: `tun` does not wait for IP interfaces to become configurable after creating the tun
-        // interface. This can cause `SetIpInterfaceEntry` to fail when setting metric, MTU, IP
-        // addresses, etc. Upstream a fix.
-        // TODO: This isn't cancellable by the user or TSM, which means tunnel state machine can
-        // become unresponsive if it takes a long time for the interfaces to appear. Seems to happen
-        // for some users.
-        log::debug!("Waiting for IP interfaces");
-        talpid_windows::net::wait_for_interfaces_sync(
-            luid,
-            has_ipv4,
-            has_ipv6,
-            Duration::from_secs(30),
-        )
-        .map_err(Error::WaitForInterfaces)?;
-        log::debug!("Waiting for IP interfaces: done");
-
-        let mtu = self.config.mtu.into();
-        // TODO: see comment on `wait_for_interfaces_sync` for why we don't use tun here.
-        crate::network_interface::initialize_interfaces(
-            luid,
-            has_ipv4.then_some(mtu),
-            has_ipv6.then_some(mtu),
-        )
-        .map_err(Error::InitializeInterfaces)?;
 
         // TODO: `tun` currently cannot handle IPv6 without using netsh,
         // so we add IPs ourselves.

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -4303,9 +4303,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tun"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e487da0cdd4a7ec9abe31c560fe53ec71275501fdc1e6aa6fccb781779686278"
+checksum = "dd9b35e3ba2b50284437061a8a30097f56473f287f48b3fe7660712cc03e9047"
 dependencies = [
  "bytes",
  "cfg-if",

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -48,7 +48,7 @@ tokio = { version = "1.44", default-features = false }
 tokio-serial = "5.4.1"
 tonic = "0.14.6"
 tower = "0.5.1"
-tun = "0.8.10"
+tun = "0.8.11"
 windows-registry = "0.6.1"
 windows-sys = "0.52.0"
 


### PR DESCRIPTION
Use upstreamed race condition fix (see #10458 and https://github.com/meh/rust-tun/pull/162).

Fix DES-3037

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10558)
<!-- Reviewable:end -->
