### PR TITLE
Reconstruction of e2e test reports

### DIFF
--- a/.github/actions/ios/run-ios-e2e-tests/action.yml
+++ b/.github/actions/ios/run-ios-e2e-tests/action.yml
@@ -69,6 +69,11 @@ runs:
     - name: Recover unfinalised screen recordings from xcresult
       if: always()
       run: |
+        # This prints a summary of the tests and generates the sqlite3 database used to
+        # recover the screen recordings
+        [[ -d "${{ env.TEST_REPORT_BUNDLE_PATH }}" ]] \
+          && xcrun xcresulttool get test-results summary --path "${{ env.TEST_REPORT_BUNDLE_PATH }}" \
+          || echo "Skipping summary, report is not a directory"
         "${{ inputs.outputs_path }}/mullvadvpn-app/ci/ios/recover-screen-recordings.sh" \
           "${{ env.TEST_REPORT_BUNDLE_PATH }}"
       shell: bash

--- a/.github/actions/ios/run-ios-e2e-tests/action.yml
+++ b/.github/actions/ios/run-ios-e2e-tests/action.yml
@@ -35,6 +35,7 @@ runs:
 
         echo "TEST_OUTPUT_DIRECTORY=$test_output_directory" >> $GITHUB_ENV
         echo "TEST_NAME_SANITIZED=$test_name_sanitized" >> $GITHUB_ENV
+        echo "TEST_REPORT_BUNDLE_PATH=${test_output_directory}/xcode-test-report.xcresult" >> $GITHUB_ENV
       shell: bash
       env:
         TEST_NAME: ${{ inputs.test_name }}
@@ -53,7 +54,7 @@ runs:
           -project MullvadVPN.xcodeproj \
           -scheme MullvadVPNUITests \
           -testPlan MullvadVPNUITestsAll $TEST_NAME_ARGUMENT \
-          -resultBundlePath ${{ env.TEST_OUTPUT_DIRECTORY }}/xcode-test-report \
+          -resultBundlePath ${{ env.TEST_REPORT_BUNDLE_PATH }} \
           -derivedDataPath derived-data \
           -allowProvisioningUpdates \
           -destination "platform=iOS,id=$TEST_DEVICE_UDID" \
@@ -69,7 +70,7 @@ runs:
       if: always()
       run: |
         "${{ inputs.outputs_path }}/mullvadvpn-app/ci/ios/recover-screen-recordings.sh" \
-          "${{ env.TEST_OUTPUT_DIRECTORY }}/xcode-test-report.xcresult"
+          "${{ env.TEST_REPORT_BUNDLE_PATH }}"
       shell: bash
 
     - name: Set artifact name with branch and timestamp
@@ -90,6 +91,6 @@ runs:
         name: ${{ env.ARTIFACT_NAME }}
         path: |
           ${{ env.TEST_OUTPUT_DIRECTORY }}/junit-test-report/junit.xml
-          ${{ env.TEST_OUTPUT_DIRECTORY }}/xcode-test-report.xcresult
+          ${{ env.TEST_REPORT_BUNDLE_PATH }}
       env:
         TEST_NAME: ${{ inputs.test_name }}


### PR DESCRIPTION
- Print a summary of the executed end to end tests

    This action initialises the lazily initialised database.sqlite3,
    which is used by the command to reconstruct the `.xcresult` file.

- Add extension to -resultBundlePath parameter

    Passing a path to `-resultBundlePath` that does not end with
    `.xcresult` results in Xcode creating a symbolic link from `<path>`
    to the actual result bundle at `<path>.xcresult`.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10561)
<!-- Reviewable:end -->
