### PR TITLE
Check that the release notes file does not contain too many characters

### DIFF
--- a/.github/workflows/android-pre-release-check.yml
+++ b/.github/workflows/android-pre-release-check.yml
@@ -1,0 +1,33 @@
+---
+name: Android - Pre-release check
+on:
+  pull_request:
+    paths:
+      - .github/workflows/android-pre-release-check.yml
+      - 'android/CHANGELOG.md'
+      - 'android/src/main/play/release-notes/en-US/default.txt'
+  push:
+    tags:
+      - 'android/**'
+
+permissions: {}
+
+env:
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+jobs:
+  check-changelog:
+    runs-on: android-build
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Calculate version
+        run: |
+          if [[ "$BRANCH_NAME" =~ ^android[-/](.+)$ ]]; then
+            version="${BASH_REMATCH[1]}"
+          else
+            version=$(./building/container-run.sh linux "cargo run -q --bin mullvad-version versionName")
+          fi
+          echo "Detected version: $version"
+          echo "version=$version" >> "$GITHUB_ENV"
+      - name: Check changelog
+        run: android/scripts/check-changelog.sh "$version"

--- a/android/scripts/check-changelog.sh
+++ b/android/scripts/check-changelog.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Check the changelog and release notes to make sure they are correct.
+
+set -eu
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR/../.."
+
+VERSION_NAME=$1
+
+if [[ -z ${VERSION_NAME+x} ]]; then
+    echo "Please give the release version as an argument to this script."
+    echo "For example: '2018.1-beta3' for a beta release, or '2018.6' for a stable one."
+    exit 1
+fi
+
+if [[ $VERSION_NAME != *"alpha"* && $VERSION_NAME != *"-dev-"* &&
+    $(grep "^## \\[android/$VERSION_NAME\\] - " android/CHANGELOG.md) == "" ]]; then
+
+    echo "It looks like you did not add $VERSION_NAME to the changelog?"
+    echo "Please make sure the changelog is up to date and correct before you proceed."
+    exit 1
+fi
+
+release_notes=$(<"android/src/main/play/release-notes/en-US/default.txt")
+if [[ $VERSION_NAME != *"alpha"* && $VERSION_NAME != *"-dev-"* && -z $release_notes ]]; then
+    echo "The release notes file is empty!"
+    echo "Beta and Stable require a release notes file."
+    exit 1
+fi
+
+if [[ "${#release_notes}" -gt 500 ]]; then
+    echo "The number of characters in the relase notes may not exceed 500"
+    echo "Current number of charachers ${#release_notes}"
+    exit 1
+fi

--- a/android/scripts/prepare-release.sh
+++ b/android/scripts/prepare-release.sh
@@ -6,7 +6,7 @@
 set -eu
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd "$SCRIPT_DIR/../.."
+cd "$SCRIPT_DIR"
 
 for argument in "$@"; do
     case "$argument" in
@@ -31,28 +31,22 @@ if [[ -n "$(git status --porcelain)" ]]; then
     exit 1
 fi
 
-if [[ $PRODUCT_VERSION != *"alpha"* &&
-    $(grep "^## \\[android/$PRODUCT_VERSION\\] - " android/CHANGELOG.md) == "" ]]; then
+./check-changelog.sh "$PRODUCT_VERSION"
 
-    echo "It looks like you did not add $PRODUCT_VERSION to the changelog?"
-    echo "Please make sure the changelog is up to date and correct before you proceed."
-    exit 1
-fi
-
-scripts/commit-relay-list "$PRODUCT_VERSION"
+../../scripts/commit-relay-list "$PRODUCT_VERSION"
 echo ""
 
 echo "### Generating version information ###"
-echo "$PRODUCT_VERSION" > dist-assets/android-version-name.txt
+echo "$PRODUCT_VERSION" > ../../dist-assets/android-version-name.txt
 ANDROID_VERSION="$PRODUCT_VERSION" cargo run -q --bin mullvad-version versionCode > \
-    dist-assets/android-version-code.txt
+    ../../dist-assets/android-version-code.txt
 if git diff --quiet dist-assets/android-version-*; then
     echo "Error: Version information unchanged."
     exit 1
 fi
 git commit -S -m "Update android app version to $PRODUCT_VERSION" \
-    dist-assets/android-version-name.txt \
-    dist-assets/android-version-code.txt
+    ../../dist-assets/android-version-name.txt \
+    ../../dist-assets/android-version-code.txt
 echo ""
 
 echo "### Tagging release as android/$PRODUCT_VERSION ###"

--- a/code-owners.json
+++ b/code-owners.json
@@ -36,7 +36,8 @@
     "building/sigstore/mullvad/mullvadvpn-app-build-android@**",
     "ci/android/**",
     "scripts/check-apostrophe-style",
-    "mullvad-jni/**"
+    "mullvad-jni/**",
+    ".github/workflows/android-*"
   ],
   "appteam-lead": [
     ".github/pinact.yml",


### PR DESCRIPTION
This PR aims to do the following

1. Add a github workflow that runs on any changes to the release notes file and check that the amount of characters are within the limit
2. Add two check to `prepare-release.sh`:<br>a. For non-alpha releases checks that the file is not empty.<br>b. For all releases checks that the file does not exceed the character limit (currently 500 characters).

---

This change is [![Reviewable](https://uploads.linear.app/f76f897f-1150-435f-bbf2-da1f324458b8/50859971-594c-4644-8c3c-bb9d6ad9e65d/27f2d8e2-b144-43dc-995e-909c237c5bca?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2Y3NmY4OTdmLTExNTAtNDM1Zi1iYmYyLWRhMWYzMjQ0NThiOC81MDg1OTk3MS01OTRjLTQ2NDQtOGMzYy1iYjlkNmFkOWU2NWQvMjdmMmQ4ZTItYjE0NC00M2RjLTk5NWUtOTA5YzIzN2M1YmNhIiwiaWF0IjoxNzgwOTkzNTE3LCJleHAiOjE4MTI1NjQwNzd9.wi1quE_NFgIVj_rYflEpuR8W-1Da31AaDN8V9sbvkMc)](<https://reviewable.io/reviews/mullvad/mullvadvpn-app/10562>)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10562)
<!-- Reviewable:end -->
