### PR TITLE
Prepare installer loader release 1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "installer-downloader"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/installer-downloader/CHANGELOG.md
+++ b/installer-downloader/CHANGELOG.md
@@ -20,6 +20,9 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+
+
+## [1.2.1] - 2026-06-09
 ### Changed
 - Write logs to `mullvad_paths::logs::frontend_log_dir` instead of a temporary directory.
 - Redact working directory from logs.

--- a/installer-downloader/Cargo.toml
+++ b/installer-downloader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "installer-downloader"
-version = "1.2.0"
+version = "1.2.1"
 edition.workspace = true
 rust-version.workspace = true
 description = "A secure minimal web installer for the Mullvad app"

--- a/mullvad-update/src/version/info.rs
+++ b/mullvad-update/src/version/info.rs
@@ -10,7 +10,7 @@ use crate::format::response::Response;
 use crate::version::parameters::VersionParameters;
 
 /// Lowest version to accept using 'verify'
-pub const MIN_VERIFY_METADATA_VERSION: usize = 0;
+pub const MIN_VERIFY_METADATA_VERSION: usize = 51;
 
 /// Version update information derived from querying a [`Response`] and filtering with [`VersionParameters`]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]


### PR DESCRIPTION
Changes:
* Move log directory.
* Other logging improvements.
* Bump minimum allowed metadata version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10568)
<!-- Reviewable:end -->
