### PR TITLE
Tunnelmanager crashes during concurrent reconnect calls

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -27,6 +27,7 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Fixed
 - Stop logging access method credentials in logs.
+- UI crash when interacting with the tunnel.
 
 ## [2026.2 - 2026-04-21]
 ### Add

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -301,17 +301,21 @@ final class TunnelManager: @unchecked Sendable {
                 }
 
                 return tunnel.reconnectTunnel(to: selectNewRelay ? .random : .current) { result in
-                    if case let .success(observedState) = result {
-                        guard let connectionState = observedState.connectionState else { return }
-
-                        // This makes the app feel very responsive when the user wants to reconnect
-                        // If the tunnel is already connected, at worst the next tunnel status poll will correct the state
-                        self._tunnelStatus.state = .reconnecting(
-                            connectionState.selectedRelays,
-                            isPostQuantum: connectionState.isPostQuantum,
-                            isDaita: connectionState.isDaitaEnabled
-                        )
-                        self._tunnelStatus.observedState = observedState
+                    if case let .success(observedState) = result,
+                        let connectionState = observedState.connectionState
+                    {
+                        // This completion fires on Tunnel.dispatchQueue; hop to internalQueue
+                        // so _tunnelStatus is mutated under nslock like every other writer.
+                        self.internalQueue.async {
+                            _ = self.setTunnelStatus { tunnelStatus in
+                                tunnelStatus.state = .reconnecting(
+                                    connectionState.selectedRelays,
+                                    isPostQuantum: connectionState.isPostQuantum,
+                                    isDaita: connectionState.isDaitaEnabled
+                                )
+                                tunnelStatus.observedState = observedState
+                            }
+                        }
                     }
 
                     finish(result.error)
@@ -715,7 +719,7 @@ final class TunnelManager: @unchecked Sendable {
 
         DispatchQueue.main.async {
             self.observerList.notify { observer in
-                observer.tunnelManager(self, didUpdateTunnelStatus: self._tunnelStatus)
+                observer.tunnelManager(self, didUpdateTunnelStatus: newTunnelStatus)
             }
         }
 

--- a/ios/Operations/AsyncOperationQueue.swift
+++ b/ios/Operations/AsyncOperationQueue.swift
@@ -89,6 +89,14 @@ private final class ExclusivityManager: @unchecked Sendable {
             }
 
             if let index = operations.firstIndex(of: operation) {
+                // Break the successor's back-pointer so finished operations can be
+                // released immediately. Without this, addDependency chains every op
+                // to its predecessor — under load, releasing the tail triggers a
+                // recursive deinit cascade that overflows the stack.
+                let nextIndex = operations.index(after: index)
+                if nextIndex < operations.endIndex {
+                    operations[nextIndex].removeDependency(operation)
+                }
                 operations.remove(at: index)
             }
 


### PR DESCRIPTION
There's two bugs here. One in AsyncOperations that I'm fixing just because it isn't difficult. And another one that is a concurrency bug that users will actually run into. Both fixes are necessary to pass the snippet from the Linear task, but I struggle to imagine that real users will hit the stack overflow bug. I want to keep both fixes for completion sake. And we have scheduled the riddance of the abomination that is the `AsyncOperation` later this year.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10572)
<!-- Reviewable:end -->
