### PR TITLE
Implement userspace obfuscation for QUIC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6090,6 +6090,7 @@ dependencies = [
  "async-trait",
  "bitflags 1.3.2",
  "byteorder",
+ "bytes",
  "chrono",
  "futures",
  "gotatun",

--- a/mullvad-ios/src/tunnel_adapter/mod.rs
+++ b/mullvad-ios/src/tunnel_adapter/mod.rs
@@ -32,7 +32,7 @@ use talpid_types::net::wireguard::{PrivateKey, PublicKey};
 use tokio::sync::Notify;
 use tonic::transport::channel::Endpoint;
 use tower::util::service_fn;
-use tunnel_obfuscation::create_obfuscator;
+use tunnel_obfuscation::create_local_socket_obfuscator;
 
 use self::pinger::SmoltcpPinger;
 use self::tun_device::IosTunDevice;
@@ -670,7 +670,7 @@ impl IosTunnelAdapter {
             }),
         };
 
-        let obfuscator = create_obfuscator(&settings)
+        let obfuscator = create_local_socket_obfuscator(&settings)
             .await
             .map_err(|e| format!("Obfuscation proxy: {e}"))?;
         let endpoint = obfuscator.endpoint();

--- a/mullvad-ios/src/tunnel_obfuscator_proxy/mod.rs
+++ b/mullvad-ios/src/tunnel_obfuscator_proxy/mod.rs
@@ -5,7 +5,8 @@ use std::{
 use talpid_types::net::wireguard::PublicKey;
 use tokio::task::JoinHandle;
 use tunnel_obfuscation::{
-    Settings as ObfuscationSettings, create_obfuscator, lwo, quic, shadowsocks, udp2tcp,
+    Settings as ObfuscationSettings, create_local_socket_obfuscator, lwo, quic, shadowsocks,
+    udp2tcp,
 };
 
 mod ffi;
@@ -64,7 +65,7 @@ impl TunnelObfuscatorRuntime {
         let runtime = mullvad_ios_runtime().map_err(io::Error::other)?;
 
         let obfuscator = runtime.block_on(async move {
-            create_obfuscator(&self.settings)
+            create_local_socket_obfuscator(&self.settings)
                 .await
                 .map_err(io::Error::other)
         })?;

--- a/mullvad-masque-proxy/benches/fragmentation.rs
+++ b/mullvad-masque-proxy/benches/fragmentation.rs
@@ -16,12 +16,12 @@ fn assemble_fragment_ordered(c: &mut Criterion) {
         let mut fragment_buf = Vec::with_capacity(FRAGMENT_BUFFER_CAP);
         for i in 0..n_packets {
             let packet_id = i;
-            let mut payload = Bytes::from(vec![i as u8; payload_len as usize]);
+            let payload = Bytes::from(vec![i as u8; payload_len as usize]);
 
             fragment_buf.extend(
                 &mut fragment_packet(
                     MAX_PAYLOAD_SIZE + FRAGMENT_HEADER_SIZE_FRAGMENTED,
-                    &mut payload,
+                    &payload,
                     packet_id,
                 )
                 .unwrap(),
@@ -65,12 +65,12 @@ fn assemble_fragment_random(c: &mut Criterion) {
         let mut fragment_buf = Vec::with_capacity(FRAGMENT_BUFFER_CAP);
         for i in 0..n_packets {
             let packet_id = i;
-            let mut payload = Bytes::from(vec![i as u8; payload_len as usize]);
+            let payload = Bytes::from(vec![i as u8; payload_len as usize]);
 
             fragment_buf.extend(
                 &mut fragment_packet(
                     MAX_PAYLOAD_SIZE + FRAGMENT_HEADER_SIZE_FRAGMENTED,
-                    &mut payload,
+                    &payload,
                     packet_id,
                 )
                 .unwrap(),

--- a/mullvad-masque-proxy/examples/masque-client.rs
+++ b/mullvad-masque-proxy/examples/masque-client.rs
@@ -89,7 +89,6 @@ async fn main() {
     let endpoint_socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).await.unwrap();
 
     let config = ClientConfig::builder()
-        .client_socket(local_socket)
         .quinn_socket(endpoint_socket)
         .server_addr(server_addr)
         .server_host(server_hostname)
@@ -107,7 +106,9 @@ async fn main() {
         }
     }
 
-    let client = client.expect("Failed to connect client").run();
+    let client = client
+        .expect("Failed to connect client")
+        .proxy_socket(local_socket);
     let result = client.until_closed().await;
 
     if let Err(e) = result {

--- a/mullvad-masque-proxy/src/client/mod.rs
+++ b/mullvad-masque-proxy/src/client/mod.rs
@@ -505,7 +505,7 @@ async fn server_socket_task(
             // drop the added context ID, since packet will have to be fragmented.
             let _ = VarInt::decode(&mut packet);
 
-            for fragment in fragment::fragment_packet(maximum_packet_size, &mut packet, fragment_id)
+            for fragment in fragment::fragment_packet(maximum_packet_size, &packet, fragment_id)
                 .map_err(Error::PacketTooLarge)?
             {
                 debug_assert!(fragment.len() <= maximum_packet_size as usize);

--- a/mullvad-masque-proxy/src/client/mod.rs
+++ b/mullvad-masque-proxy/src/client/mod.rs
@@ -456,6 +456,57 @@ impl Client {
             _stats: self.stats,
         }
     }
+
+    /// Start the proxy using the given channels, returning a [`RunningClient`].
+    ///
+    /// Packets received from `outgoing_rx` are proxied to the remote server,
+    /// and incoming packets are sent back to `incoming_tx`.
+    #[must_use]
+    pub fn proxy_channels<B: AsRef<[u8]> + Send + 'static>(
+        self,
+        outgoing_packet_rx: mpsc::Receiver<B>,
+        incoming_packet_tx: mpsc::Sender<BytesMut>,
+    ) -> RunningClient {
+        log::trace!("proxy_channels");
+        let stream_id: StreamId = self.request_stream.id();
+
+        let mut tasks = Tasks::default();
+
+        let (outgoing_datagram_tx, outgoing_datagram_rx) = mpsc::channel(MAX_INFLIGHT_PACKETS);
+        let (incoming_datagram_tx, incoming_datagram_rx) = mpsc::channel(MAX_INFLIGHT_PACKETS);
+
+        tasks.spawn_task(inline_rx_task(
+            outgoing_packet_rx,
+            DatagramFragmentor::new(
+                self.quinn_conn,
+                stream_id,
+                self.max_udp_payload_size,
+                Arc::clone(&self.stats),
+            ),
+            outgoing_datagram_tx,
+        ));
+
+        tasks.spawn_task(fragment_reassembly_task(
+            stream_id,
+            incoming_datagram_rx,
+            incoming_packet_tx,
+            Arc::clone(&self.stats),
+        ));
+
+        tasks.spawn_task(server_socket_task(
+            stream_id,
+            self.connection,
+            incoming_datagram_tx,
+            outgoing_datagram_rx,
+        ));
+
+        RunningClient {
+            tasks,
+            _send_stream: self.send_stream,
+            _request_stream: self.request_stream,
+            _stats: self.stats,
+        }
+    }
 }
 
 /// Task stopped gracefully because the client was shutting down.
@@ -464,7 +515,7 @@ struct Stopped;
 impl RunningClient {
     /// Wait until the connection is remotely closed, or an error occurs.
     pub async fn until_closed(self) -> Result<()> {
-        self.tasks.join_all().await
+        self.tasks.join_and_abort().await
     }
 }
 
@@ -758,7 +809,26 @@ async fn client_socket_non_gso_tx_task(
     Ok(Stopped)
 }
 
-/// Reassemble incoming QUIC datagrams and forward complete packets to `packet_tx`.
+/// Read packets from a `outgoing_packet_rx`, fragment them, and forward to the `outgoing_datagram_tx`.
+async fn inline_rx_task<B: AsRef<[u8]>>(
+    mut outgoing_packet_rx: mpsc::Receiver<B>,
+    mut fragmentor: DatagramFragmentor,
+    outgoing_datagram_tx: mpsc::Sender<Bytes>,
+) -> Result<Stopped> {
+    'outer: while let Some(packet) = outgoing_packet_rx.recv().await {
+        let read_buf = fragmentor.get_read_buf();
+        read_buf.extend_from_slice(packet.as_ref());
+
+        for datagram in fragmentor.fragment()? {
+            if outgoing_datagram_tx.send(datagram).await.is_err() {
+                break 'outer;
+            }
+        }
+    }
+    Ok(Stopped)
+}
+
+/// Reassemble incoming QUIC datagrams and forward complete packets to `incoming_packet_tx`.
 async fn fragment_reassembly_task(
     stream_id: StreamId,
     mut incoming_datagram_rx: mpsc::Receiver<Datagram>,

--- a/mullvad-masque-proxy/src/client/mod.rs
+++ b/mullvad-masque-proxy/src/client/mod.rs
@@ -11,12 +11,7 @@ use std::{
     sync::{Arc, LazyLock},
     time::Duration,
 };
-use tokio::{
-    net::UdpSocket,
-    select,
-    sync::{mpsc, oneshot, watch},
-    task::JoinSet,
-};
+use tokio::{net::UdpSocket, select, sync::mpsc, task::JoinSet};
 use typed_builder::TypedBuilder;
 
 use h3::{client, ext::Protocol, proto::varint::VarInt, quic::StreamId};
@@ -42,8 +37,6 @@ const LE_ROOT_CERT: &[u8] = include_bytes!("../../../mullvad-api/le_root_cert.pe
 
 /// Handle to a ready client that's connected, but is not yet proxying traffic.
 pub struct Client {
-    client_socket: Arc<UdpSocket>,
-
     /// QUIC endpoint
     quinn_conn: quinn::Connection,
 
@@ -68,7 +61,7 @@ pub struct Client {
 ///
 /// Dropping this will stop the proxy.
 pub struct RunningClient {
-    tasks: JoinSet<Result<Stopped>>,
+    tasks: Tasks,
 
     /// Send stream over a QUIC connection - this needs to be kept alive to not close the HTTP
     /// QUIC stream.
@@ -137,9 +130,6 @@ pub enum Error {
 
 #[derive(TypedBuilder, Debug)]
 pub struct ClientConfig {
-    /// Socket that accepts proxy clients
-    pub client_socket: UdpSocket,
-
     /// Socket to bind the QUIC endpoint socket to
     pub quinn_socket: UdpSocket,
 
@@ -167,6 +157,56 @@ pub struct ClientConfig {
     /// Set the authorization header to use in the CONNECT-UDP request.
     #[builder(default)]
     pub auth_header: Option<String>,
+}
+
+#[derive(Default)]
+struct Tasks(JoinSet<Result<Stopped>>);
+
+impl Tasks {
+    /// Spawn a task on a `JoinSet`, logging when it starts and when it returns an error.
+    #[track_caller]
+    fn spawn_task(&mut self, future: impl Future<Output = Result<Stopped>> + Send + 'static) {
+        let location = std::panic::Location::caller();
+        self.0.spawn(async move {
+            log::trace!("Task spawned at {location}");
+            let result = future.await;
+            if let Err(err) = &result {
+                log::debug!("Task at {location} exited with error: {err:?}");
+            } else {
+                log::trace!("Task at {location} completed successfully");
+            }
+            result
+        });
+    }
+
+    /// Wait for all tasks to finish, returning the first error, if any.
+    ///
+    /// After the first task completes, the rest are aborted, so this returns
+    /// once all tasks have stopped.
+    async fn join_and_abort(mut self) -> Result<()> {
+        let result = self.0.join_next().await.expect("JoinSet is not empty");
+        let mut results = vec![result];
+
+        self.0.abort_all();
+
+        // at this point all tasks are being aborted, so we won't have to wait long.
+        while let Some(result) = self.0.join_next().await {
+            results.push(result);
+        }
+
+        // check for errors and return the first one, if any.
+        // we do this because tasks might (in theory) race when returning,
+        // and one task crashing will cause others to exit with Ok(Stopped).
+        results.into_iter().try_for_each(|result| match result {
+            Err(join_err) if join_err.is_panic() => {
+                let err = anyhow!("{:?}", join_err.into_panic());
+                Err(Error::TaskPanicked(err))
+            }
+            Ok(Err(e)) => Err(e),
+            Ok(Ok(Stopped)) => Ok(()),
+            Err(_cancelled) => Ok(()),
+        })
+    }
 }
 
 impl Client {
@@ -213,10 +253,11 @@ impl Client {
         )
         .await?;
 
+        log::debug!("QUIC proxy client connected");
+
         Ok(Self {
             quinn_conn: connection,
             connection: h3_connection,
-            client_socket: Arc::new(config.client_socket),
             request_stream,
             send_stream,
             max_udp_payload_size,
@@ -366,57 +407,48 @@ impl Client {
         }
     }
 
+    /// Start proxying traffic from the given socket, returning a [`RunningClient`].
+    ///
+    /// The sockets will be connected to the address of the first arriving packet, and will only proxy from that
+    /// address.
     #[must_use]
-    pub fn run(self) -> RunningClient {
+    pub fn proxy_socket(self, client_socket: UdpSocket) -> RunningClient {
+        let client_socket = Arc::new(client_socket);
         let stream_id: StreamId = self.request_stream.id();
 
-        let mut tasks = JoinSet::new();
+        let mut tasks = Tasks::default();
 
-        /// Spawn a task on the `tasks` JoinSet, and log when it returns.
-        macro_rules! spawn {
-            ($fn_name:ident $args:tt) => {{
-                let future = $fn_name $args;
-                tasks.spawn(async move {
-                    let result = future.await;
-                    if let Err(err) = &result {
-                        log::debug!("{} exited with error {:?}", stringify!($fn_name), err);
-                    }
-                    result
-                })
-            }};
-        }
+        let (outgoing_datagram_tx, outgoing_datagram_rx) = mpsc::channel(MAX_INFLIGHT_PACKETS);
+        let (incoming_datagram_tx, incoming_datagram_rx) = mpsc::channel(MAX_INFLIGHT_PACKETS);
+        let (incoming_packet_tx, incoming_packet_rx) =
+            mpsc::channel::<BytesMut>(MAX_INFLIGHT_PACKETS);
 
-        let (return_addr_tx, return_addr_rx) = oneshot::channel();
-        let (client_tx, client_rx) = mpsc::channel(MAX_INFLIGHT_PACKETS);
-        let (server_tx, server_rx) = mpsc::channel(MAX_INFLIGHT_PACKETS);
-        let (send_tx, send_rx) = mpsc::channel::<(SocketAddr, Bytes)>(MAX_INFLIGHT_PACKETS);
-
-        spawn!(client_socket_rx_task(
-            self.client_socket.clone(),
-            client_tx,
-            return_addr_tx,
+        tasks.spawn_task(client_socket_rx_task(
+            Arc::clone(&client_socket),
+            DatagramFragmentor::new(
+                self.quinn_conn,
+                stream_id,
+                self.max_udp_payload_size,
+                Arc::clone(&self.stats),
+            ),
+            outgoing_datagram_tx,
         ));
 
-        spawn!(client_socket_tx_task(self.client_socket.clone(), send_rx));
+        tasks.spawn_task(client_socket_tx_task(client_socket, incoming_packet_rx));
 
-        spawn!(fragment_reassembly_task(
+        tasks.spawn_task(fragment_reassembly_task(
             stream_id,
-            server_rx,
-            return_addr_rx,
-            send_tx,
+            incoming_datagram_rx,
+            incoming_packet_tx,
             Arc::clone(&self.stats),
         ));
 
-        spawn!(server_socket_task(
+        tasks.spawn_task(server_socket_task(
             stream_id,
-            self.max_udp_payload_size,
-            self.quinn_conn,
             self.connection,
-            server_tx,
-            client_rx,
-            Arc::clone(&self.stats),
+            incoming_datagram_tx,
+            outgoing_datagram_rx,
         ));
-
         RunningClient {
             tasks,
             _send_stream: self.send_stream,
@@ -431,50 +463,26 @@ struct Stopped;
 
 impl RunningClient {
     /// Wait until the connection is remotely closed, or an error occurs.
-    pub async fn until_closed(mut self) -> Result<()> {
-        let result = self.tasks.join_next().await.expect("JoinSet is not empty");
-        let mut results = vec![result];
-
-        self.tasks.abort_all();
-
-        // at this point all tasks are being aborted, so we won't have to wait long.
-        while let Some(result) = self.tasks.join_next().await {
-            results.push(result);
-        }
-
-        // check for errors and return the first one, if any.
-        // we do this because tasks might (in theory) race when returning,
-        // and one task crashing will cause others to exit with Ok(Stopped).
-        results.into_iter().try_for_each(|result| match result {
-            Err(join_err) if join_err.is_panic() => {
-                let err = anyhow!("{:?}", join_err.into_panic());
-                Err(Error::TaskPanicked(err))
-            }
-            Ok(Err(e)) => Err(e),
-            Ok(Ok(Stopped)) => Ok(()),
-            Err(_cancelled) => Ok(()),
-        })
+    pub async fn until_closed(self) -> Result<()> {
+        self.tasks.join_all().await
     }
 }
 
+/// Forward datagrams between the QUIC connection and the task pipeline.
 async fn server_socket_task(
     stream_id: StreamId,
-    max_udp_payload_size: u16,
-    quinn_conn: quinn::Connection,
     mut connection: h3::client::Connection<h3_quinn::Connection, bytes::Bytes>,
-    server_tx: mpsc::Sender<Datagram>,
-    mut client_rx: mpsc::Receiver<Bytes>,
-    stats: Arc<Stats>,
+    // Channel to which we send packets from the server
+    incoming_datagram_tx: mpsc::Sender<Datagram>,
+    // Incoming packets from the client, to be send to the server
+    mut outgoing_datagram_rx: mpsc::Receiver<Bytes>,
 ) -> Result<Stopped> {
-    let mut fragment_id = 0u16;
-    let stream_id_size = VarInt::from(stream_id).size() as u16;
-
     loop {
-        let packet = select! {
+        select! {
             datagram = connection.read_datagram() => {
                 match datagram {
                     Ok(Some(response)) => {
-                        if server_tx.send(response).await.is_err() {
+                        if incoming_datagram_tx.send(response).await.is_err() {
                             break; // channel closed, exit gracefully
                         }
                     }
@@ -484,118 +492,165 @@ async fn server_socket_task(
 
                 continue;
             }
-            packet = client_rx.recv() => packet,
+            datagram = outgoing_datagram_rx.recv() => {
+                if let Some(datagram) = datagram {
+                    connection
+                        .send_datagram(stream_id, datagram)
+                        .map_err(Error::SendDatagram)?;
+                } else {
+                    break;
+                }
+            },
         };
-
-        let Some(mut packet) = packet else { break };
-
-        // Maximum QUIC payload (including fragmentation headers)
-        let maximum_packet_size = if let Some(max_datagram_size) = quinn_conn.max_datagram_size() {
-            max_datagram_size as u16 - stream_id_size
-        } else {
-            max_udp_payload_size - QUIC_HEADER_SIZE - stream_id_size
-        };
-
-        if packet.len() <= usize::from(maximum_packet_size) {
-            stats.tx(packet.len(), false);
-            connection
-                .send_datagram(stream_id, packet)
-                .map_err(Error::SendDatagram)?;
-        } else {
-            // drop the added context ID, since packet will have to be fragmented.
-            let _ = VarInt::decode(&mut packet);
-
-            for fragment in fragment::fragment_packet(maximum_packet_size, &packet, fragment_id)
-                .map_err(Error::PacketTooLarge)?
-            {
-                debug_assert!(fragment.len() <= maximum_packet_size as usize);
-
-                stats.tx(fragment.len(), true);
-                connection
-                    .send_datagram(stream_id, fragment)
-                    .map_err(Error::SendDatagram)?;
-            }
-            fragment_id = fragment_id.wrapping_add(1);
-        }
     }
 
     Ok(Stopped)
 }
 
+/// Buffers outgoing packets and fragments them to fit the QUIC datagram size limit.
+///
+/// Call [`Self::get_read_buf`] to get a buffer with the MASQUE context ID already
+/// encoded, write the packet payload into it, then call [`Self::fragment`] to get
+/// an iterator over the resulting datagrams (one if it fits, multiple if fragmented).
+struct DatagramFragmentor {
+    quinn_conn: quinn::Connection,
+    stream_id_size: u16,
+    max_udp_payload_size: u16,
+    stats: Arc<Stats>,
+    fragment_id: u16,
+    read_buf: BytesMut,
+    fragments_buf: Vec<Bytes>,
+}
+
+impl DatagramFragmentor {
+    const TOTAL_BUFFER_CAPACITY: usize = 100 * crate::MAX_UDP_SIZE;
+    fn new(
+        quinn_conn: quinn::Connection,
+        stream_id: StreamId,
+        max_udp_payload_size: u16,
+        stats: Arc<Stats>,
+    ) -> Self {
+        Self {
+            quinn_conn,
+            stream_id_size: VarInt::from(stream_id).size() as u16,
+            max_udp_payload_size,
+            stats,
+            fragment_id: 0,
+            read_buf: BytesMut::with_capacity(Self::TOTAL_BUFFER_CAPACITY),
+            fragments_buf: Vec::new(),
+        }
+    }
+
+    /// Get a writable buffer, with [`crate::HTTP_MASQUE_DATAGRAM_CONTEXT_ID`]
+    /// encoded at the start. Write the packet payload into it, then call
+    /// [`Self::fragment`] to return an iterator over resulting datagrams.
+    fn get_read_buf(&mut self) -> &mut BytesMut {
+        if !self.read_buf.try_reclaim(crate::MAX_UDP_SIZE) {
+            self.read_buf.reserve(Self::TOTAL_BUFFER_CAPACITY);
+        }
+        crate::HTTP_MASQUE_DATAGRAM_CONTEXT_ID.encode(&mut self.read_buf);
+        &mut self.read_buf
+    }
+
+    /// Split [`Self::read_buf`] into datagrams, fragmenting if necessary.
+    ///
+    /// Returns an iterator over the resulting datagrams.
+    fn fragment(&mut self) -> Result<impl Iterator<Item = Bytes> + '_> {
+        let packet = self.read_buf.split().freeze();
+
+        let maximum_packet_size =
+            if let Some(max_datagram_size) = self.quinn_conn.max_datagram_size() {
+                max_datagram_size as u16 - self.stream_id_size
+            } else {
+                self.max_udp_payload_size - QUIC_HEADER_SIZE - self.stream_id_size
+            };
+
+        self.fragments_buf.clear();
+        if packet.len() <= usize::from(maximum_packet_size) {
+            self.stats.tx(packet.len(), false);
+            self.fragments_buf.push(packet);
+        } else {
+            let mut stripped = packet;
+            let _ = VarInt::decode(&mut stripped);
+
+            for fragment in
+                fragment::fragment_packet(maximum_packet_size, &stripped, self.fragment_id)
+                    .map_err(Error::PacketTooLarge)?
+            {
+                debug_assert!(fragment.len() <= maximum_packet_size as usize);
+                self.stats.tx(fragment.len(), true);
+                self.fragments_buf.push(fragment);
+            }
+            self.fragment_id = self.fragment_id.wrapping_add(1);
+        }
+        Ok(self.fragments_buf.drain(..))
+    }
+}
+
+/// Read packets from the socket, fragment them, and forward them to `outgoing_datagram_tx`.
+///
+/// The socket is connected to the first sender's address.
 async fn client_socket_rx_task(
     client_socket: Arc<UdpSocket>,
-    client_tx: mpsc::Sender<Bytes>,
-    return_addr_oneshot: oneshot::Sender<watch::Receiver<SocketAddr>>,
+    mut fragmentor: DatagramFragmentor,
+    outgoing_datagram_tx: mpsc::Sender<Bytes>,
 ) -> Result<Stopped> {
-    const TOTAL_BUFFER_CAPACITY: usize = 100 * crate::MAX_UDP_SIZE;
+    // Read the first packet with recv_buf_from to discover the sender's address, then
+    // connect the socket so all subsequent I/O is filtered to that peer.
+    let read_buf = fragmentor.get_read_buf();
+    let (_bytes_received, peer_addr) = client_socket
+        .recv_buf_from(read_buf)
+        .await
+        .map_err(Error::ClientRead)?;
 
-    let mut client_read_buf = BytesMut::with_capacity(TOTAL_BUFFER_CAPACITY);
+    client_socket
+        .connect(peer_addr)
+        .await
+        .map_err(Error::ClientRead)?;
 
-    let mut recv = async || {
-        if !client_read_buf.try_reclaim(crate::MAX_UDP_SIZE) {
-            // Allocate space for new packets
-            client_read_buf.reserve(TOTAL_BUFFER_CAPACITY);
+    for packet in fragmentor.fragment()? {
+        if outgoing_datagram_tx.send(packet).await.is_err() {
+            return Ok(Stopped);
         }
+    }
 
-        // this is the variable ID used to signify UDP payloads in HTTP datagrams.
-        crate::HTTP_MASQUE_DATAGRAM_CONTEXT_ID.encode(&mut client_read_buf);
-
-        let (_bytes_received, recv_addr) = client_socket
-            .recv_buf_from(&mut client_read_buf)
+    'outer: loop {
+        let read_buf = fragmentor.get_read_buf();
+        let _bytes_received = client_socket
+            .recv_buf(read_buf)
             .await
             .map_err(Error::ClientRead)?;
 
-        let packet = client_read_buf.split().freeze();
-        Result::Ok((packet, recv_addr))
-    };
-
-    // call recv once outside the loop to get the initial return address
-    let (packet, mut return_addr) = recv().await?;
-    let (return_addr_tx, return_addr_rx) = watch::channel(return_addr);
-    let _ = return_addr_oneshot.send(return_addr_rx);
-
-    if client_tx.send(packet).await.is_err() {
-        return Ok(Stopped);
-    };
-
-    loop {
-        let (packet, recv_addr) = recv().await?;
-
-        // notify other tasks if the return address changes
-        if recv_addr != return_addr {
-            return_addr = recv_addr;
-            if return_addr_tx.send(return_addr).is_err() {
-                break; // channel closed, exit gracefully
+        for packet in fragmentor.fragment()? {
+            if outgoing_datagram_tx.send(packet).await.is_err() {
+                break 'outer;
             }
         }
-
-        if client_tx.send(packet).await.is_err() {
-            break; // channel closed, exit gracefully
-        };
     }
 
     Ok(Stopped)
 }
 
+/// Forward packets from `incoming_packet_rx` to the connected client socket.
 async fn client_socket_tx_task(
     client_socket: Arc<UdpSocket>,
-    send_rx: mpsc::Receiver<(SocketAddr, Bytes)>,
+    incoming_packet_rx: mpsc::Receiver<BytesMut>,
 ) -> Result<Stopped> {
     #[cfg(target_os = "windows")]
     if *windows::MAX_GSO_SEGMENTS > 1 {
         log::debug!("UDP GSO enabled");
-        return client_socket_gso_tx_task(client_socket, send_rx).await;
+        return client_socket_gso_tx_task(client_socket, incoming_packet_rx).await;
     }
 
     log::debug!("UDP GSO disabled");
 
-    client_socket_non_gso_tx_task(client_socket, send_rx).await
+    client_socket_non_gso_tx_task(client_socket, incoming_packet_rx).await
 }
 
 #[cfg(target_os = "windows")]
 async fn client_socket_gso_tx_task(
     client_socket: Arc<UdpSocket>,
-    mut send_rx: mpsc::Receiver<(SocketAddr, Bytes)>,
+    mut incoming_packet_rx: mpsc::Receiver<BytesMut>,
 ) -> Result<Stopped> {
     use bytes::Buf;
     use std::{collections::VecDeque, mem};
@@ -618,21 +673,21 @@ async fn client_socket_gso_tx_task(
     loop {
         // Fill up queue
         if queued_packets.is_empty() {
-            let Some((dest, packet)) = send_rx.recv().await else {
+            let Some(packet) = incoming_packet_rx.recv().await else {
                 break; // channel closed, exit gracefully
             };
-            queued_packets.push_back((dest, packet));
+            queued_packets.push_back(packet);
         }
-        while let Ok((dest, packet)) = send_rx.try_recv() {
-            queued_packets.push_back((dest, packet));
+        while let Ok(packet) = incoming_packet_rx.try_recv() {
+            queued_packets.push_back(packet);
         }
 
-        let (dest, packet) = queued_packets.pop_front().expect("never empty");
+        let packet = queued_packets.pop_front().expect("never empty");
 
-        // If the queue is empty now, send a single packet using send_to
+        // If the queue is empty now, send a single packet using send
         if queued_packets.is_empty() {
             client_socket
-                .send_to(packet.chunk(), dest)
+                .send(packet.chunk())
                 .await
                 .map_err(Error::ClientWrite)?;
             continue;
@@ -643,27 +698,19 @@ async fn client_socket_gso_tx_task(
         buffer.extend_from_slice(packet.chunk());
 
         loop {
-            let Some((next_dest, next_packet)) = queued_packets.pop_front() else {
+            let Some(next_packet) = queued_packets.pop_front() else {
                 break;
             };
 
-            // If the destination differs, stop coalescing packets
-            if next_dest != dest {
-                // Flush the buffer now and queue this packet
-                // This should occur rarely, as we're expecting a single UDP client
-                queued_packets.push_front((next_dest, next_packet));
-                break;
-            }
-
             // On overflow, also stop coalescing
             if buffer.len() + next_packet.len() > buffer.capacity() {
-                queued_packets.push_front((next_dest, next_packet));
+                queued_packets.push_front(next_packet);
                 break;
             }
 
             // If this packet is larger, we are done
             if next_packet.len() > segment_size {
-                queued_packets.push_front((next_dest, next_packet));
+                queued_packets.push_front(next_packet);
                 break;
             }
 
@@ -688,9 +735,7 @@ async fn client_socket_gso_tx_task(
                 unsafe { *(cmsg_buf.data_mut_ptr() as *mut u32) = segment_size as u32 };
 
                 let io_slices = [IoSlice::new(&buffer); 1];
-                let daddr = socket2::SockAddr::from(dest);
                 let msg_hdr = socket2::MsgHdr::new()
-                    .with_addr(&daddr)
                     .with_buffers(&io_slices)
                     .with_control(cmsg_buf.as_slice());
 
@@ -705,34 +750,24 @@ async fn client_socket_gso_tx_task(
 
 async fn client_socket_non_gso_tx_task(
     client_socket: Arc<UdpSocket>,
-    mut send_rx: mpsc::Receiver<(SocketAddr, Bytes)>,
+    mut incoming_packet_rx: mpsc::Receiver<BytesMut>,
 ) -> Result<Stopped> {
-    while let Some((dest, buf)) = send_rx.recv().await {
-        client_socket
-            .send_to(&buf, dest)
-            .await
-            .map_err(Error::ClientWrite)?;
+    while let Some(buf) = incoming_packet_rx.recv().await {
+        client_socket.send(&buf).await.map_err(Error::ClientWrite)?;
     }
     Ok(Stopped)
 }
 
+/// Reassemble incoming QUIC datagrams and forward complete packets to `packet_tx`.
 async fn fragment_reassembly_task(
     stream_id: StreamId,
-    mut server_rx: mpsc::Receiver<Datagram>,
-    return_addr_rx: oneshot::Receiver<watch::Receiver<SocketAddr>>,
-    send_tx: mpsc::Sender<(SocketAddr, Bytes)>,
+    mut incoming_datagram_rx: mpsc::Receiver<Datagram>,
+    incoming_packet_tx: mpsc::Sender<BytesMut>,
     stats: Arc<Stats>,
 ) -> Result<Stopped> {
     let mut fragments = Fragments::default();
 
-    // wait for the return address to be known
-    let Ok(return_addr) = return_addr_rx.await else {
-        return Ok(Stopped); // channel closed, exit gracefully
-    };
-
-    while let Some(response) = server_rx.recv().await {
-        let return_addr = *return_addr.borrow();
-
+    while let Some(response) = incoming_datagram_rx.recv().await {
         if response.stream_id() != stream_id {
             log::debug!("Received datagram with an unexpected stream ID");
             continue;
@@ -742,18 +777,18 @@ async fn fragment_reassembly_task(
 
         match fragments.handle_incoming_packet(payload) {
             Ok(DefragReceived::Nonfragmented(payload)) => {
-                stats.rx(payload.len(), false);
-                if send_tx.send((return_addr, payload)).await.is_err() {
+                stats.rx(original_payload_len, false);
+                // Usually, the `Bytes` buffer is unique (refcount = 1), so the conversion below
+                // doesn't require a clone. This seems to be the case except for very large
+                // datagrams.
+                let payload = BytesMut::from(payload);
+                if incoming_packet_tx.send(payload).await.is_err() {
                     break; // channel closed, exit gracefully
                 }
             }
             Ok(DefragReceived::Reassembled(reassembled_payload)) => {
                 stats.rx(original_payload_len, true);
-                if send_tx
-                    .send((return_addr, reassembled_payload))
-                    .await
-                    .is_err()
-                {
+                if incoming_packet_tx.send(reassembled_payload).await.is_err() {
                     break; // channel closed, exit gracefully
                 }
             }

--- a/mullvad-masque-proxy/src/fragment.rs
+++ b/mullvad-masque-proxy/src/fragment.rs
@@ -161,11 +161,11 @@ struct Fragment {
 ///
 /// `payload` must not contain any fragmentation headers.
 /// `maximum_packet_size` is the maximum fragment size including headers.
-pub fn fragment_packet(
+pub fn fragment_packet<'a>(
     maximum_packet_size: u16,
-    payload: &'_ mut Bytes,
+    payload: &'a [u8],
     packet_id: u16,
-) -> Result<impl Iterator<Item = Bytes> + '_, PacketTooLarge> {
+) -> Result<impl Iterator<Item = Bytes> + 'a, PacketTooLarge> {
     let fragment_payload_size = maximum_packet_size - FRAGMENT_HEADER_SIZE_FRAGMENTED;
 
     let num_fragments: usize = payload.chunks(fragment_payload_size.into()).count();
@@ -212,8 +212,8 @@ mod test {
         'outer: for packet_id in max_payload_size..255u16 {
             let payload = (0..packet_id as u8).collect::<Vec<u8>>();
 
-            let mut payload_clone = Bytes::from(payload.clone());
-            let mut fragment_buf = fragment_packet(max_payload_size, &mut payload_clone, packet_id)
+            let payload_clone = Bytes::from(payload.clone());
+            let mut fragment_buf = fragment_packet(max_payload_size, &payload_clone, packet_id)
                 .unwrap()
                 .collect::<Vec<_>>();
 
@@ -244,11 +244,11 @@ mod test {
         let mut payloads = HashSet::new();
         for i in 0..n_packets {
             let packet_id = i as u16;
-            let mut payload = Bytes::from(vec![i as u8; payload_len]);
+            let payload = Bytes::from(vec![i as u8; payload_len]);
             payloads.insert(payload.clone());
 
             fragment_buf
-                .extend(&mut fragment_packet(max_payload_size, &mut payload, packet_id).unwrap());
+                .extend(&mut fragment_packet(max_payload_size, &payload, packet_id).unwrap());
         }
         fragment_buf.shuffle(&mut rng());
 
@@ -279,8 +279,8 @@ mod test {
             let payload = (0..255).collect::<Vec<u8>>();
             let max_payload_size = 50;
 
-            let mut payload_clone = Bytes::from(payload.clone());
-            let mut fragment_buf = fragment_packet(max_payload_size, &mut payload_clone, packet_id)
+            let payload_clone = Bytes::from(payload.clone());
+            let mut fragment_buf = fragment_packet(max_payload_size, &payload_clone, packet_id)
                 .unwrap()
                 .collect::<Vec<_>>();
 
@@ -296,11 +296,11 @@ mod test {
             );
 
             // then send a bunch of fragments to fill the queue
-            let mut bad_payload = Bytes::from([0u8; 2].to_vec());
+            let bad_payload = Bytes::from([0u8; 2].to_vec());
             for _ in fragment_buf.len()..number_of_bad_fragments {
                 let incomplete_fragment = fragment_packet(
                     1 + FRAGMENT_HEADER_SIZE_FRAGMENTED,
-                    &mut bad_payload,
+                    &bad_payload,
                     bad_packet_ids.next().unwrap(),
                 )
                 .unwrap()

--- a/mullvad-masque-proxy/src/fragment.rs
+++ b/mullvad-masque-proxy/src/fragment.rs
@@ -64,7 +64,7 @@ pub enum DefragReceived {
     /// Received a fragment but was unable to reassemble the packet
     Fragment,
     /// Received reassembled packet
-    Reassembled(Bytes),
+    Reassembled(BytesMut),
 }
 
 impl Fragments {
@@ -148,7 +148,7 @@ impl Fragments {
             payload.extend_from_slice(&fragment.payload);
         }
 
-        Ok(DefragReceived::Reassembled(payload.freeze()))
+        Ok(DefragReceived::Reassembled(payload))
     }
 }
 
@@ -244,7 +244,7 @@ mod test {
         let mut payloads = HashSet::new();
         for i in 0..n_packets {
             let packet_id = i as u16;
-            let payload = Bytes::from(vec![i as u8; payload_len]);
+            let payload = BytesMut::from(Bytes::from(vec![i as u8; payload_len]));
             payloads.insert(payload.clone());
 
             fragment_buf

--- a/mullvad-masque-proxy/src/lib.rs
+++ b/mullvad-masque-proxy/src/lib.rs
@@ -16,7 +16,7 @@ pub const HTTP_MASQUE_FRAGMENTED_DATAGRAM_CONTEXT_ID: VarInt = VarInt::from_u32(
 const MAX_UDP_SIZE: usize = (u16::MAX - UDP_HEADER_SIZE + 1) as usize;
 
 /// Maximum number of inflight packets, in both directions.
-const MAX_INFLIGHT_PACKETS: usize = 100;
+pub const MAX_INFLIGHT_PACKETS: usize = 100;
 
 /// Fragment headers size for fragmented packets
 pub const FRAGMENT_HEADER_SIZE_FRAGMENTED: u16 = 5;

--- a/mullvad-masque-proxy/src/server/mod.rs
+++ b/mullvad-masque-proxy/src/server/mod.rs
@@ -383,7 +383,7 @@ async fn proxy_rx_task(
 
             let _ = VarInt::decode(&mut received_packet);
             let Ok(fragments) =
-                fragment::fragment_packet(maximum_packet_size, &mut received_packet, fragment_id)
+                fragment::fragment_packet(maximum_packet_size, &received_packet, fragment_id)
             else {
                 continue;
             };

--- a/mullvad-masque-proxy/src/server/mod.rs
+++ b/mullvad-masque-proxy/src/server/mod.rs
@@ -310,10 +310,9 @@ async fn proxy_tx_task(udp_socket: impl AsRef<UdpSocket>, mut client_rx: mpsc::R
 
         let quic_payload = quic_datagram.into_payload();
 
-        let packet = match fragments.handle_incoming_packet(quic_payload) {
-            Ok(DefragReceived::Reassembled(packet) | DefragReceived::Nonfragmented(packet)) => {
-                packet
-            }
+        let res = match fragments.handle_incoming_packet(quic_payload) {
+            Ok(DefragReceived::Nonfragmented(packet)) => udp_socket.send(&packet).await,
+            Ok(DefragReceived::Reassembled(packet)) => udp_socket.send(&packet).await,
             Ok(DefragReceived::Fragment) => continue,
             Err(err) => {
                 log::trace!("Failed to reassemble incoming packet: {err}");
@@ -321,7 +320,7 @@ async fn proxy_tx_task(udp_socket: impl AsRef<UdpSocket>, mut client_rx: mpsc::R
             }
         };
 
-        if let Err(err) = udp_socket.send(&packet).await {
+        if let Err(err) = res {
             log::trace!("Failed to forward packet to UDP socket {err}");
         }
     }

--- a/mullvad-masque-proxy/tests/proxy.rs
+++ b/mullvad-masque-proxy/tests/proxy.rs
@@ -175,7 +175,6 @@ async fn setup_masque(mtu: u16) -> anyhow::Result<(UdpSocket, UdpSocket)> {
     let quinn_socket = UdpSocket::bind(any_localhost_addr).await?;
 
     let client_config = client::ClientConfig::builder()
-        .client_socket(local_socket)
         .quinn_socket(quinn_socket)
         .server_addr(masque_server_addr)
         .server_host(HOST.to_owned())
@@ -191,7 +190,7 @@ async fn setup_masque(mtu: u16) -> anyhow::Result<(UdpSocket, UdpSocket)> {
 
     tokio::spawn(async move {
         client
-            .run()
+            .proxy_socket(local_socket)
             .until_closed()
             .await
             .expect("QUIC client errored");

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 [dependencies]
 async-trait = { workspace = true }
 byteorder = "1"
+bytes = { workspace = true }
 futures = { workspace = true }
 gotatun = { workspace = true, features = ["daita", "device", "tun"] }
 internet-checksum = "0.2"

--- a/talpid-wireguard/src/config.rs
+++ b/talpid-wireguard/src/config.rs
@@ -29,6 +29,8 @@ pub struct Config {
     pub enable_ipv6: bool,
     /// Obfuscator config to be used for reaching the relay.
     pub obfuscator_config: Option<Obfuscators>,
+    /// MTU including obfuscation overhead.
+    pub obfuscation_mtu: u16,
     /// Enable quantum-resistant PSK exchange
     pub quantum_resistant: bool,
     /// Enable DAITA
@@ -52,6 +54,7 @@ impl Config {
     pub fn from_parameters(
         params: &wireguard::TunnelParameters,
         default_mtu: u16,
+        obfuscation_mtu: u16,
     ) -> Result<Config, Error> {
         Self::new(
             &params.connection,
@@ -59,6 +62,7 @@ impl Config {
             &params.generic_options,
             &params.obfuscation,
             default_mtu,
+            obfuscation_mtu,
         )
     }
 
@@ -69,6 +73,7 @@ impl Config {
         generic_options: &GenericTunnelOptions,
         obfuscator_config: &Option<Obfuscators>,
         default_mtu: u16,
+        obfuscation_mtu: u16,
     ) -> Result<Config, Error> {
         let mut tunnel = connection.tunnel.clone();
 
@@ -97,6 +102,7 @@ impl Config {
             #[cfg(target_os = "linux")]
             enable_ipv6: generic_options.enable_ipv6,
             obfuscator_config: obfuscator_config.to_owned(),
+            obfuscation_mtu,
             quantum_resistant: wg_options.quantum_resistant,
             daita: wg_options.daita,
         };
@@ -110,6 +116,21 @@ impl Config {
         }
 
         Ok(config)
+    }
+
+    /// Derive [tunnel_obfuscation::Settings] from the current config state.
+    ///
+    /// This is computed on demand so that it always reflects the current
+    /// private key (which may change during ephemeral peer negotiation).
+    pub fn obfuscation_settings(&self) -> Option<tunnel_obfuscation::Settings> {
+        self.obfuscator_config.as_ref().map(|obfuscator_config| {
+            crate::obfuscation::settings_from_config(
+                self.tunnel.private_key.public_key(),
+                self.entry_peer.public_key.clone(),
+                obfuscator_config,
+                self.obfuscation_mtu,
+            )
+        })
     }
 
     /// Return whether the config connects to an exit peer from another remote peer.

--- a/talpid-wireguard/src/ephemeral.rs
+++ b/talpid-wireguard/src/ephemeral.rs
@@ -27,10 +27,8 @@ pub async fn config_ephemeral_peers(
     tunnel: &Arc<AsyncMutex<Option<TunnelType>>>,
     config: &mut Config,
     retry_attempt: u32,
-    obfuscation_mtu: u16,
     obfuscator: Arc<AsyncMutex<Option<ObfuscatorHandle>>>,
     close_obfs_sender: sync_mpsc::Sender<CloseMsg>,
-    is_gotatun: bool,
 ) -> std::result::Result<(), CloseMsg> {
     let iface_name = {
         let tunnel = tunnel.lock().await;
@@ -44,16 +42,8 @@ pub async fn config_ephemeral_peers(
     log::trace!("Temporarily lowering tunnel MTU before ephemeral peer config");
     try_set_ipv4_mtu(&iface_name, talpid_tunnel::MIN_IPV4_MTU);
 
-    config_ephemeral_peers_inner(
-        tunnel,
-        config,
-        retry_attempt,
-        obfuscation_mtu,
-        obfuscator,
-        close_obfs_sender,
-        is_gotatun,
-    )
-    .await?;
+    config_ephemeral_peers_inner(tunnel, config, retry_attempt, obfuscator, close_obfs_sender)
+        .await?;
 
     log::trace!("Resetting tunnel MTU");
     try_set_ipv4_mtu(&iface_name, config.mtu);
@@ -80,21 +70,16 @@ pub async fn config_ephemeral_peers(
     tunnel: &Arc<AsyncMutex<Option<TunnelType>>>,
     config: &mut Config,
     retry_attempt: u32,
-    obfuscation_mtu: u16,
     obfuscator: Arc<AsyncMutex<Option<ObfuscatorHandle>>>,
     close_obfs_sender: sync_mpsc::Sender<CloseMsg>,
-    #[cfg(not(target_os = "android"))] is_gotatun: bool,
     #[cfg(target_os = "android")] tun_provider: Arc<Mutex<TunProvider>>,
 ) -> Result<(), CloseMsg> {
     config_ephemeral_peers_inner(
         tunnel,
         config,
         retry_attempt,
-        obfuscation_mtu,
         obfuscator,
         close_obfs_sender,
-        #[cfg(not(target_os = "android"))]
-        is_gotatun,
         #[cfg(target_os = "android")]
         tun_provider,
     )
@@ -105,10 +90,8 @@ async fn config_ephemeral_peers_inner(
     tunnel: &Arc<AsyncMutex<Option<TunnelType>>>,
     config: &mut Config,
     retry_attempt: u32,
-    obfuscation_mtu: u16,
     obfuscator: Arc<AsyncMutex<Option<ObfuscatorHandle>>>,
     close_obfs_sender: sync_mpsc::Sender<CloseMsg>,
-    #[cfg(not(target_os = "android"))] is_gotatun: bool,
     #[cfg(target_os = "android")] tun_provider: Arc<Mutex<TunProvider>>,
 ) -> Result<(), CloseMsg> {
     let ephemeral_private_key = PrivateKey::new_from_random();
@@ -142,11 +125,8 @@ async fn config_ephemeral_peers_inner(
             tunnel,
             entry_tun_config,
             None,
-            obfuscation_mtu,
             obfuscator.clone(),
             close_obfs_sender,
-            #[cfg(not(target_os = "android"))]
-            is_gotatun,
             #[cfg(target_os = "android")]
             &tun_provider,
         )
@@ -179,11 +159,8 @@ async fn config_ephemeral_peers_inner(
         tunnel,
         config.clone(),
         daita,
-        obfuscation_mtu,
         obfuscator,
         close_obfs_sender,
-        #[cfg(not(target_os = "android"))]
-        is_gotatun,
         #[cfg(target_os = "android")]
         &tun_provider,
     )
@@ -199,7 +176,6 @@ async fn reconfigure_tunnel(
     tunnel: &Arc<AsyncMutex<Option<TunnelType>>>,
     mut config: Config,
     daita: Option<DaitaSettings>,
-    obfuscation_mtu: u16,
     obfuscator: Arc<AsyncMutex<Option<ObfuscatorHandle>>>,
     close_obfs_sender: sync_mpsc::Sender<CloseMsg>,
     tun_provider: &Arc<Mutex<TunProvider>>,
@@ -207,15 +183,17 @@ async fn reconfigure_tunnel(
     let mut obfs_guard = obfuscator.lock().await;
     if let Some(obfuscator_handle) = obfs_guard.take() {
         obfuscator_handle.abort();
-        *obfs_guard = super::obfuscation::apply_obfuscation_config(
-            &mut config,
-            obfuscation_mtu,
-            close_obfs_sender,
-            true, // is_gotatun: always true on Android
-            tun_provider.clone(),
-        )
-        .await
-        .map_err(CloseMsg::ObfuscatorFailed)?;
+        if let Some(obfuscation_settings) = config.obfuscation_settings() {
+            let new_obfuscator_handle = super::obfuscation::spawn_local_socket_obfuscator(
+                &mut config.entry_peer,
+                obfuscation_settings,
+                close_obfs_sender,
+                tun_provider.clone(),
+            )
+            .await
+            .map_err(CloseMsg::ObfuscatorFailed)?;
+            *obfs_guard = Some(new_obfuscator_handle);
+        }
     }
     {
         let mut shared_tunnel = tunnel.lock().await;
@@ -239,22 +217,24 @@ async fn reconfigure_tunnel(
     tunnel: &Arc<AsyncMutex<Option<TunnelType>>>,
     mut config: Config,
     daita: Option<DaitaSettings>,
-    obfuscation_mtu: u16,
     obfuscator: Arc<AsyncMutex<Option<ObfuscatorHandle>>>,
     close_obfs_sender: sync_mpsc::Sender<CloseMsg>,
-    is_gotatun: bool,
 ) -> Result<Config, CloseMsg> {
     let mut obfs_guard = obfuscator.lock().await;
-    if let Some(obfuscator_handle) = obfs_guard.take() {
-        obfuscator_handle.abort();
-        *obfs_guard = super::obfuscation::apply_obfuscation_config(
-            &mut config,
-            obfuscation_mtu,
-            close_obfs_sender,
-            is_gotatun,
-        )
-        .await
-        .map_err(CloseMsg::ObfuscatorFailed)?;
+    if let Some(old_obfuscator_handle) = obfs_guard.take() {
+        old_obfuscator_handle.abort();
+        if let Some(obfuscation_settings) = config.obfuscation_settings() {
+            let new_obfuscator_handle = super::obfuscation::spawn_local_socket_obfuscator(
+                &mut config.entry_peer,
+                obfuscation_settings,
+                close_obfs_sender,
+                #[cfg(target_os = "linux")]
+                config.fwmark,
+            )
+            .await
+            .map_err(CloseMsg::ObfuscatorFailed)?;
+            *obfs_guard = Some(new_obfuscator_handle);
+        }
     }
 
     {

--- a/talpid-wireguard/src/gotatun/mod.rs
+++ b/talpid-wireguard/src/gotatun/mod.rs
@@ -35,6 +35,7 @@ use talpid_tunnel::tun_provider::{self, Tun, TunProvider};
 use talpid_tunnel_config_client::DaitaSettings;
 use talpid_types::net::wireguard::PeerConfig;
 use tun::{AbstractDevice, AsyncDevice};
+use tunnel_obfuscation::Settings as ObfuscationSettings;
 
 #[cfg(all(feature = "multihop-pcap", target_os = "linux"))]
 use gotatun::tun::{
@@ -520,7 +521,7 @@ async fn create_devices(
         optimize_buffer_size: bool,
     ) -> Result<Devices, gotatun::device::Error> {
         let factory = udp_obfuscator_factory(
-            config,
+            config.obfuscation_settings().as_ref(),
             optimize_buffer_size,
             #[cfg(target_os = "android")]
             android_tun,
@@ -788,7 +789,7 @@ where
 /// - `optimize_buffer_size`: if UDP socket buffer sizes should be tweaked. Empirically this might
 ///   now always succeed due to suspected hardware related issues / limitations.
 fn udp_obfuscator_factory(
-    config: &Config,
+    settings: Option<&ObfuscationSettings>,
     optimize_buffer_size: bool,
     #[cfg(target_os = "android")] android_tun: Arc<Tun>,
 ) -> MaybeObfuscatingTransportFactory<UdpFactory> {
@@ -798,10 +799,10 @@ fn udp_obfuscator_factory(
                 tun: android_tun,
                 udp: udp_socket_factory(optimize_buffer_size),
             }
-        },
+        }
         _ => { udp_socket_factory(optimize_buffer_size) }
     };
-    MaybeObfuscatingTransportFactory::from_config(factory, config)
+    MaybeObfuscatingTransportFactory::from_settings(factory, settings)
 }
 
 /// Provide a [`UdpSocketFactory`] for the entry-device.

--- a/talpid-wireguard/src/gotatun/mod.rs
+++ b/talpid-wireguard/src/gotatun/mod.rs
@@ -3,6 +3,7 @@ use crate::config::patch_allowed_ips;
 use crate::{
     Tunnel, TunnelError,
     config::Config,
+    obfuscation::ObfuscatorSocketBypass,
     stats::{Stats, StatsMap},
 };
 #[cfg(target_os = "android")]
@@ -31,6 +32,7 @@ use std::{
     ops::Deref,
     sync::{Arc, Mutex},
 };
+use talpid_net::bypass::SocketBypass;
 use talpid_tunnel::tun_provider::{self, Tun, TunProvider};
 use talpid_tunnel_config_client::DaitaSettings;
 use talpid_types::net::wireguard::PeerConfig;
@@ -82,6 +84,9 @@ pub struct GotaTun {
     #[cfg(target_os = "android")]
     android_tun: Arc<Tun>,
 
+    #[cfg(target_os = "android")]
+    tun_provider: Arc<Mutex<TunProvider>>,
+
     /// Tunnel config
     config: Config,
 
@@ -93,6 +98,7 @@ impl GotaTun {
     async fn new(
         tun_dev: AsyncDevice,
         #[cfg(target_os = "android")] android_tun: Arc<Tun>,
+        #[cfg(target_os = "android")] tun_provider: Arc<Mutex<TunProvider>>,
         config: Config,
         interface_name: String,
     ) -> Result<Self, TunnelError> {
@@ -105,6 +111,8 @@ impl GotaTun {
             tun_dev.clone(),
             #[cfg(target_os = "android")]
             android_tun.clone(),
+            #[cfg(target_os = "android")]
+            tun_provider.clone(),
         )
         .await
         .map_err(TunnelError::GotaTunDevice)?;
@@ -115,6 +123,8 @@ impl GotaTun {
             tun_dev,
             #[cfg(target_os = "android")]
             android_tun,
+            #[cfg(target_os = "android")]
+            tun_provider,
             devices: Some(devices),
         })
     }
@@ -237,7 +247,7 @@ pub async fn open_gotatun_tunnel(
     log::trace!("calling get_tunnel_for_userspace");
     #[cfg(not(target_os = "android"))]
     let async_tun = {
-        let tun = get_tunnel_for_userspace(tun_provider, config, routes)?;
+        let tun = get_tunnel_for_userspace(tun_provider.clone(), config, routes)?;
 
         #[cfg(unix)]
         {
@@ -299,6 +309,8 @@ pub async fn open_gotatun_tunnel(
         async_tun,
         #[cfg(target_os = "android")]
         tun.clone(),
+        #[cfg(target_os = "android")]
+        tun_provider,
         config,
         interface_name,
     )
@@ -432,6 +444,8 @@ impl Tunnel for GotaTun {
                         self.tun_dev.clone(),
                         #[cfg(target_os = "android")]
                         self.android_tun.clone(),
+                        #[cfg(target_os = "android")]
+                        self.tun_provider.clone(),
                     )
                     .await
                     .map_err(TunnelError::GotaTunDevice)?
@@ -450,6 +464,8 @@ impl Tunnel for GotaTun {
                         self.tun_dev.clone(),
                         #[cfg(target_os = "android")]
                         self.android_tun.clone(),
+                        #[cfg(target_os = "android")]
+                        self.tun_provider.clone(),
                     )
                     .await
                     .map_err(TunnelError::GotaTunDevice)?
@@ -482,6 +498,8 @@ impl Tunnel for GotaTun {
                         self.tun_dev.clone(),
                         #[cfg(target_os = "android")]
                         self.android_tun.clone(),
+                        #[cfg(target_os = "android")]
+                        self.tun_provider.clone(),
                     )
                     .await
                     .map_err(TunnelError::GotaTunDevice)?
@@ -492,6 +510,8 @@ impl Tunnel for GotaTun {
                     self.tun_dev.clone(),
                     #[cfg(target_os = "android")]
                     self.android_tun.clone(),
+                    #[cfg(target_os = "android")]
+                    self.tun_provider.clone(),
                 )
                 .await
                 .map_err(TunnelError::GotaTunDevice)?,
@@ -512,12 +532,25 @@ async fn create_devices(
     daita: Option<&DaitaSettings>,
     tun_dev: GotaTunDevice,
     #[cfg(target_os = "android")] android_tun: Arc<Tun>,
+    #[cfg(target_os = "android")] tun_provider: Arc<Mutex<TunProvider>>,
 ) -> Result<Devices, gotatun::device::Error> {
+    let bypass = Arc::new(ObfuscatorSocketBypass {
+        #[cfg(target_os = "linux")]
+        fwmark: config.fwmark.unwrap_or_else(|| {
+            log::error!("'fwmark' not set");
+            0
+        }),
+
+        #[cfg(target_os = "android")]
+        tun_provider,
+    });
+
     async fn create_devices_inner(
         config: &Config, // TODO: do not include config to reduce confusion
         daita: Option<&DaitaSettings>,
         tun_dev: GotaTunDevice,
         #[cfg(target_os = "android")] android_tun: Arc<Tun>,
+        bypass: Arc<dyn SocketBypass>,
         optimize_buffer_size: bool,
     ) -> Result<Devices, gotatun::device::Error> {
         let factory = udp_obfuscator_factory(
@@ -525,6 +558,7 @@ async fn create_devices(
             optimize_buffer_size,
             #[cfg(target_os = "android")]
             android_tun,
+            bypass,
         );
         let devices = if let Some(exit_peer) = &config.exit_peer {
             // Multihop setup
@@ -605,6 +639,7 @@ async fn create_devices(
         tun_dev.clone(),
         #[cfg(target_os = "android")]
         android_tun.clone(),
+        bypass.clone(),
         true,
     )
     .await
@@ -628,6 +663,7 @@ async fn create_devices(
                 tun_dev,
                 #[cfg(target_os = "android")]
                 android_tun.clone(),
+                bypass,
                 false,
             )
             .await
@@ -792,17 +828,18 @@ fn udp_obfuscator_factory(
     settings: Option<&ObfuscationSettings>,
     optimize_buffer_size: bool,
     #[cfg(target_os = "android")] android_tun: Arc<Tun>,
+    bypass: Arc<dyn SocketBypass>,
 ) -> MaybeObfuscatingTransportFactory<UdpFactory> {
     let factory = cfg_select! {
         target_os = "android" => {
             AndroidUdpSocketFactory {
-                tun: android_tun,
+                tun: Arc::clone(&android_tun),
                 udp: udp_socket_factory(optimize_buffer_size),
             }
         }
         _ => { udp_socket_factory(optimize_buffer_size) }
     };
-    MaybeObfuscatingTransportFactory::from_settings(factory, settings)
+    MaybeObfuscatingTransportFactory::from_settings(factory, settings, bypass)
 }
 
 /// Provide a [`UdpSocketFactory`] for the entry-device.

--- a/talpid-wireguard/src/gotatun/obfuscation/lwo.rs
+++ b/talpid-wireguard/src/gotatun/obfuscation/lwo.rs
@@ -6,10 +6,7 @@ use gotatun::{
     packet::{Packet, PacketBufPool},
     udp::{UdpRecv, UdpSend, UdpTransportFactory, UdpTransportFactoryParams},
 };
-use talpid_types::net::obfuscation::{ObfuscatorConfig, Obfuscators};
 use tunnel_obfuscation::lwo;
-
-use crate::config::Config;
 
 /// A [`UdpSend`] wrapper that LWO-obfuscates every outgoing packet before forwarding it to the
 /// inner sender.
@@ -101,18 +98,6 @@ fn obfuscate_all(packets: &mut [(Packet, SocketAddr)], tx_key: &[u8; 32]) {
 fn deobfuscate_all(packets: &mut [(Packet, SocketAddr)], rx_key: &[u8; 32]) {
     for (packet, _) in packets.iter_mut() {
         lwo::deobfuscate(packet, rx_key);
-    }
-}
-
-/// Extract LWO obfuscation settings from the tunnel config.
-pub fn lwo_config(config: &Config) -> Option<([u8; 32], [u8; 32], SocketAddr)> {
-    match &config.obfuscator_config {
-        Some(Obfuscators::Single(ObfuscatorConfig::Lwo { endpoint })) => {
-            let tx_key = *config.entry_peer.public_key.as_bytes();
-            let rx_key = *config.tunnel.private_key.public_key().as_bytes();
-            Some((tx_key, rx_key, *endpoint))
-        }
-        _ => None,
     }
 }
 

--- a/talpid-wireguard/src/gotatun/obfuscation/mod.rs
+++ b/talpid-wireguard/src/gotatun/obfuscation/mod.rs
@@ -9,10 +9,9 @@ use gotatun::{
     packet::{Packet, PacketBufPool},
     udp::{UdpRecv, UdpSend, UdpTransportFactory, UdpTransportFactoryParams},
 };
+use tunnel_obfuscation::Settings as ObfuscationSettings;
 
-use crate::config::Config;
-
-use lwo::{LwoRecv, LwoSend, LwoUdpTransportFactory, lwo_config};
+use lwo::{LwoRecv, LwoSend, LwoUdpTransportFactory};
 
 /// A [`UdpSend`] wrapper that optionally obfuscates outgoing packets.
 #[derive(Clone)]
@@ -109,17 +108,16 @@ pub enum MaybeObfuscatingTransportFactory<F: UdpTransportFactory> {
 }
 
 impl<F: UdpTransportFactory> MaybeObfuscatingTransportFactory<F> {
-    /// Create a transport factory from the tunnel config.
-    pub fn from_config(inner: F, config: &Config) -> Self {
-        match lwo_config(config) {
-            Some((tx_key, rx_key, endpoint)) => Self::Lwo(LwoUdpTransportFactory {
+    /// Create a transport factory from the obfuscation settings.
+    pub fn from_settings(inner: F, settings: Option<&ObfuscationSettings>) -> Self {
+        match settings {
+            Some(ObfuscationSettings::Lwo(settings)) => Self::Lwo(LwoUdpTransportFactory {
                 inner,
-                tx_key,
-                rx_key,
-                endpoint,
+                rx_key: *settings.client_public_key.as_bytes(),
+                tx_key: *settings.server_public_key.as_bytes(),
+                endpoint: settings.server_addr,
             }),
-            // Use `Self::Plain` for proxy socket obfuscation or no obfuscation
-            None => Self::Plain(inner),
+            _ => Self::Plain(inner),
         }
     }
 }

--- a/talpid-wireguard/src/gotatun/obfuscation/mod.rs
+++ b/talpid-wireguard/src/gotatun/obfuscation/mod.rs
@@ -2,22 +2,29 @@
 //! or applies obfuscation.
 
 mod lwo;
+mod quic;
 
-use std::{io, net::SocketAddr};
+use std::{io, net::SocketAddr, sync::Arc};
 
 use gotatun::{
     packet::{Packet, PacketBufPool},
     udp::{UdpRecv, UdpSend, UdpTransportFactory, UdpTransportFactoryParams},
 };
+use talpid_net::bypass::SocketBypass;
 use tunnel_obfuscation::Settings as ObfuscationSettings;
 
+use crate::gotatun::obfuscation::quic::{NoopRecv, NoopSend, QuicTransportFactory};
+
 use lwo::{LwoRecv, LwoSend, LwoUdpTransportFactory};
+use quic::{QuicRecv, QuicSend};
 
 /// A [`UdpSend`] wrapper that optionally obfuscates outgoing packets.
 #[derive(Clone)]
 pub enum MaybeObfuscatingSend<S: UdpSend> {
     Plain(S),
     Lwo(LwoSend<S>),
+    QuicV4(QuicSend),
+    QuicV6(NoopSend),
 }
 
 impl<S: UdpSend> UdpSend for MaybeObfuscatingSend<S> {
@@ -27,6 +34,8 @@ impl<S: UdpSend> UdpSend for MaybeObfuscatingSend<S> {
         match self {
             Self::Plain(inner) => inner.send_to(packet, destination).await,
             Self::Lwo(inner) => inner.send_to(packet, destination).await,
+            Self::QuicV4(inner) => inner.send_to(packet, destination).await,
+            Self::QuicV6(inner) => inner.send_to(packet, destination).await,
         }
     }
 
@@ -34,6 +43,8 @@ impl<S: UdpSend> UdpSend for MaybeObfuscatingSend<S> {
         match self {
             Self::Plain(inner) => inner.max_number_of_packets_to_send(),
             Self::Lwo(inner) => inner.max_number_of_packets_to_send(),
+            Self::QuicV4(inner) => inner.max_number_of_packets_to_send(),
+            Self::QuicV6(inner) => inner.max_number_of_packets_to_send(),
         }
     }
 
@@ -45,6 +56,8 @@ impl<S: UdpSend> UdpSend for MaybeObfuscatingSend<S> {
         match self {
             Self::Plain(inner) => inner.send_many_to(send_buf, packets).await,
             Self::Lwo(inner) => inner.send_many_to(send_buf, packets).await,
+            Self::QuicV4(inner) => inner.send_many_to(&mut (), packets).await,
+            Self::QuicV6(inner) => inner.send_many_to(&mut (), packets).await,
         }
     }
 
@@ -52,6 +65,8 @@ impl<S: UdpSend> UdpSend for MaybeObfuscatingSend<S> {
         match self {
             Self::Plain(inner) => inner.local_addr(),
             Self::Lwo(inner) => inner.local_addr(),
+            Self::QuicV4(inner) => inner.local_addr(),
+            Self::QuicV6(inner) => inner.local_addr(),
         }
     }
 
@@ -60,6 +75,8 @@ impl<S: UdpSend> UdpSend for MaybeObfuscatingSend<S> {
         match self {
             Self::Plain(inner) => inner.set_fwmark(mark),
             Self::Lwo(inner) => inner.set_fwmark(mark),
+            Self::QuicV4(inner) => inner.set_fwmark(mark),
+            Self::QuicV6(inner) => inner.set_fwmark(mark),
         }
     }
 }
@@ -68,6 +85,8 @@ impl<S: UdpSend> UdpSend for MaybeObfuscatingSend<S> {
 pub enum MaybeObfuscatingRecv<R: UdpRecv> {
     Plain(R),
     Lwo(LwoRecv<R>),
+    QuicV4(QuicRecv),
+    QuicV6(NoopRecv),
 }
 
 impl<R: UdpRecv> UdpRecv for MaybeObfuscatingRecv<R> {
@@ -77,6 +96,8 @@ impl<R: UdpRecv> UdpRecv for MaybeObfuscatingRecv<R> {
         match self {
             Self::Plain(inner) => inner.recv_from(pool).await,
             Self::Lwo(inner) => inner.recv_from(pool).await,
+            Self::QuicV4(inner) => inner.recv_from(pool).await,
+            Self::QuicV6(inner) => inner.recv_from(pool).await,
         }
     }
 
@@ -89,6 +110,8 @@ impl<R: UdpRecv> UdpRecv for MaybeObfuscatingRecv<R> {
         match self {
             Self::Plain(inner) => inner.recv_many_from(recv_buf, pool, packets).await,
             Self::Lwo(inner) => inner.recv_many_from(recv_buf, pool, packets).await,
+            Self::QuicV4(inner) => inner.recv_many_from(&mut (), pool, packets).await,
+            Self::QuicV6(inner) => inner.recv_many_from(&mut (), pool, packets).await,
         }
     }
 
@@ -96,6 +119,8 @@ impl<R: UdpRecv> UdpRecv for MaybeObfuscatingRecv<R> {
         match self {
             Self::Plain(inner) => inner.enable_udp_gro(),
             Self::Lwo(inner) => inner.enable_udp_gro(),
+            Self::QuicV4(inner) => inner.enable_udp_gro(),
+            Self::QuicV6(inner) => inner.enable_udp_gro(),
         }
     }
 }
@@ -105,11 +130,16 @@ impl<R: UdpRecv> UdpRecv for MaybeObfuscatingRecv<R> {
 pub enum MaybeObfuscatingTransportFactory<F: UdpTransportFactory> {
     Plain(F),
     Lwo(LwoUdpTransportFactory<F>),
+    Quic(QuicTransportFactory),
 }
 
 impl<F: UdpTransportFactory> MaybeObfuscatingTransportFactory<F> {
-    /// Create a transport factory from the obfuscation settings.
-    pub fn from_settings(inner: F, settings: Option<&ObfuscationSettings>) -> Self {
+    /// Create a transport factory from the tunnel config.
+    pub fn from_settings(
+        inner: F,
+        settings: Option<&ObfuscationSettings>,
+        bypass: Arc<dyn SocketBypass>,
+    ) -> Self {
         match settings {
             Some(ObfuscationSettings::Lwo(settings)) => Self::Lwo(LwoUdpTransportFactory {
                 inner,
@@ -117,6 +147,13 @@ impl<F: UdpTransportFactory> MaybeObfuscatingTransportFactory<F> {
                 tx_key: *settings.server_public_key.as_bytes(),
                 endpoint: settings.server_addr,
             }),
+            Some(ObfuscationSettings::Quic(settings)) => Self::Quic(QuicTransportFactory {
+                settings: settings.clone(),
+                running_client: None,
+                bypass,
+            }),
+
+            // Use `Self::Plain` for proxy socket obfuscation or no obfuscation
             _ => Self::Plain(inner),
         }
     }
@@ -156,6 +193,19 @@ impl<F: UdpTransportFactory> UdpTransportFactory for MaybeObfuscatingTransportFa
                     (
                         MaybeObfuscatingSend::Lwo(sv6),
                         MaybeObfuscatingRecv::Lwo(rv6),
+                    ),
+                ))
+            }
+            Self::Quic(factory) => {
+                let ((sv4, rv4), (sv6, rv6)) = factory.bind(params).await?;
+                Ok((
+                    (
+                        MaybeObfuscatingSend::QuicV4(sv4),
+                        MaybeObfuscatingRecv::QuicV4(rv4),
+                    ),
+                    (
+                        MaybeObfuscatingSend::QuicV6(sv6),
+                        MaybeObfuscatingRecv::QuicV6(rv6),
                     ),
                 ))
             }

--- a/talpid-wireguard/src/gotatun/obfuscation/quic.rs
+++ b/talpid-wireguard/src/gotatun/obfuscation/quic.rs
@@ -1,0 +1,124 @@
+use std::{io, net::SocketAddr, sync::Arc};
+
+use bytes::BytesMut;
+use gotatun::{
+    packet::{Packet, PacketBufPool},
+    udp::{UdpRecv, UdpSend, UdpTransportFactory, UdpTransportFactoryParams},
+};
+use talpid_net::bypass::{BypassSocket, SocketBypass};
+use tokio::sync::mpsc;
+
+#[derive(Clone)]
+pub struct QuicSend {
+    packet_tx: mpsc::Sender<Packet>,
+}
+
+pub struct QuicRecv {
+    /// packets incoming from the network
+    packet_rx: mpsc::Receiver<BytesMut>,
+    target_addr: SocketAddr,
+}
+
+impl UdpRecv for QuicRecv {
+    type RecvManyBuf = ();
+
+    async fn recv_from(&mut self, _pool: &mut PacketBufPool) -> io::Result<(Packet, SocketAddr)> {
+        let bytes = self
+            .packet_rx
+            .recv()
+            .await
+            .ok_or(io::Error::new(io::ErrorKind::BrokenPipe, "Channel closed"))?;
+
+        Ok((Packet::from_bytes(bytes), self.target_addr))
+    }
+}
+
+impl UdpSend for QuicSend {
+    // Sending multiple packets at a time is pointless for an in process transport
+    type SendManyBuf = ();
+
+    async fn send_to(&self, packet: Packet, _destination: SocketAddr) -> io::Result<()> {
+        self.packet_tx
+            .send(packet)
+            .await
+            .map_err(|e| io::Error::new(io::ErrorKind::BrokenPipe, e))
+    }
+}
+pub struct QuicTransportFactory {
+    pub(super) settings: tunnel_obfuscation::quic::Settings,
+    pub running_client: Option<tunnel_obfuscation::quic::RunningClient>,
+    pub bypass: Arc<dyn SocketBypass>,
+}
+
+impl UdpTransportFactory for QuicTransportFactory {
+    type SendV4 = QuicSend;
+    type SendV6 = NoopSend;
+    type RecvV4 = QuicRecv;
+    type RecvV6 = NoopRecv;
+
+    async fn bind(
+        &mut self,
+        _params: &UdpTransportFactoryParams,
+    ) -> io::Result<((Self::SendV4, Self::RecvV4), (Self::SendV6, Self::RecvV6))> {
+        log::debug!("Starting QUIC proxy using userspace transport");
+        if self.running_client.is_some() {
+            log::debug!("Reconnecting to QUIC proxy");
+        }
+        self.running_client = None;
+
+        let BypassSocket {
+            socket: quinn_socket,
+            guard: _bypass,
+        } = tunnel_obfuscation::socket::create_remote_socket(
+            &self.bypass,
+            self.settings.quic_endpoint().is_ipv4(),
+        )
+        .await
+        .map_err(io::Error::other)?;
+
+        let config = self.settings.build_client_config(quinn_socket);
+
+        let client = tunnel_obfuscation::quic::Client::connect(config)
+            .await
+            .map_err(io::Error::other)?;
+
+        let (outgoing_tx, outgoing_rx) =
+            mpsc::channel(tunnel_obfuscation::quic::MAX_INFLIGHT_PACKETS);
+        let (incoming_tx, incoming_rx) =
+            mpsc::channel(tunnel_obfuscation::quic::MAX_INFLIGHT_PACKETS);
+        let send = QuicSend {
+            packet_tx: outgoing_tx,
+        };
+        let recv = QuicRecv {
+            packet_rx: incoming_rx,
+            target_addr: self.settings.wireguard_endpoint(),
+        };
+        let running_client = client.proxy_channels(outgoing_rx, incoming_tx);
+        self.running_client = Some(running_client);
+        Ok(((send, recv), (NoopSend, NoopRecv)))
+    }
+}
+
+// The internal WireGuard endpoint for QUIC is always IPv4 (Ipv4Addr::LOCALHOST, 51820), but we must
+// implement an internal transport for IPv6. These will never actually be called,
+#[derive(Clone)]
+pub struct NoopSend;
+pub struct NoopRecv;
+impl UdpRecv for NoopRecv {
+    type RecvManyBuf = ();
+    async fn recv_from(&mut self, _: &mut PacketBufPool) -> io::Result<(Packet, SocketAddr)> {
+        std::future::pending().await
+    }
+}
+
+impl UdpSend for NoopSend {
+    type SendManyBuf = ();
+
+    async fn send_to(&self, _: Packet, destination: SocketAddr) -> io::Result<()> {
+        log::error!("Got unexpected packet to {destination:?}");
+        Err(io::Error::new(
+            io::ErrorKind::AddrNotAvailable,
+            "Proxying IPv6 WireGuard packets inside QUIC is not supported",
+        ))
+    }
+}

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -7,8 +7,10 @@ use self::config::Config;
 use futures::channel::mpsc;
 use futures::future::Future;
 use obfuscation::ObfuscatorHandle;
+use std::env;
 #[cfg(windows)]
 use std::io;
+use std::sync::LazyLock;
 use std::{
     convert::Infallible,
     net::IpAddr,
@@ -145,6 +147,24 @@ static FORCE_USERSPACE_WIREGUARD: LazyLock<bool> = LazyLock::new(|| {
         .unwrap_or(false)
 });
 
+#[cfg(not(target_os = "android"))]
+/// Force the use of the kernel module for WireGuard, even when userspace
+/// obfuscation is available. Causes a panic if features that require userspace
+/// wireguard (i.e. GotaTun) are enabled, such as DAITA.
+static FORCE_KERNEL_WIREGUARD: LazyLock<bool> = LazyLock::new(|| {
+    env::var("TALPID_FORCE_KERNEL_WIREGUARD")
+        .map(|v| v != "0")
+        .unwrap_or(false)
+});
+
+/// Forces packets to be delivered to the obfuscator via a local socket, even when
+/// a userspace obfuscation transport is available.
+static FORCE_LOCAL_SOCKET_OBFUSCATION: LazyLock<bool> = LazyLock::new(|| {
+    env::var("TALPID_FORCE_LOCAL_SOCKET_OBFUSCATION")
+        .map(|v| v != "0")
+        .unwrap_or(false)
+});
+
 impl WireguardMonitor {
     /// Starts a WireGuard tunnel with the given config
     #[cfg(not(target_os = "android"))]
@@ -153,19 +173,27 @@ impl WireguardMonitor {
         args: TunnelArgs<'_>,
         _log_path: Option<&Path>,
     ) -> Result<WireguardMonitor> {
-        let is_single_lwo = params
-            .obfuscation
-            .as_ref()
-            .is_some_and(obfuscation::is_single_lwo);
-        let userspace_wireguard =
-            *FORCE_USERSPACE_WIREGUARD || params.use_userspace_wg() || is_single_lwo;
+        let require_userspace_wireguard = params.use_userspace_wg() || *FORCE_USERSPACE_WIREGUARD;
+        let userspace_obfuscation = obfuscation::userspace_transport_available(params)
+            && !*FORCE_LOCAL_SOCKET_OBFUSCATION
+            && !*FORCE_KERNEL_WIREGUARD;
+        assert!(
+            !(*FORCE_KERNEL_WIREGUARD && require_userspace_wireguard),
+            "Cannot force kernel WireGuard when userspace is required (DAITA, etc.)"
+        );
+        let userspace_wireguard = require_userspace_wireguard || userspace_obfuscation;
+
         let route_mtu = args
             .runtime
             .block_on(get_route_mtu(params, &args.route_manager));
         let tunnel_mtu = calculate_tunnel_mtu(route_mtu, params, userspace_wireguard);
 
-        let mut config = crate::config::Config::from_parameters(params, tunnel_mtu)
-            .map_err(Error::WireguardConfigError)?;
+        // Build obfuscation settings and optionally start a local socket obfuscator.
+        // For GotaTun + LWO/QUIC, obfuscation is applied inline and no local socket is needed.
+        let obfuscation_mtu = route_mtu;
+        let mut config =
+            crate::config::Config::from_parameters(params, tunnel_mtu, obfuscation_mtu)
+                .map_err(Error::WireguardConfigError)?;
 
         let endpoint_addrs: Vec<IpAddr> = params
             .get_next_hop_endpoints()
@@ -174,26 +202,16 @@ impl WireguardMonitor {
             .collect();
 
         let (close_obfs_sender, close_obfs_listener) = sync_mpsc::channel();
+
         // Start obfuscation server and patch the WireGuard config to point the endpoint to it.
-        // For GotaTun + LWO, apply_obfuscation_config returns None and obfuscation is inline.
-        let obfuscation_mtu = route_mtu;
-        let obfuscator = args
-            .runtime
-            .block_on(obfuscation::apply_obfuscation_config(
-                &mut config,
-                obfuscation_mtu,
-                close_obfs_sender.clone(),
-                userspace_wireguard,
-            ))?;
-        // Adjust tunnel MTU again for obfuscation packet overhead
-        if params.options.mtu.is_none()
-            && let Some(obfuscator) = obfuscator.as_ref()
-        {
-            config.mtu = clamp_tunnel_mtu(
-                params,
-                config.mtu.saturating_sub(obfuscator.packet_overhead()),
-            );
-        }
+        // For userspace_obfuscation, apply_obfuscation_config returns None and obfuscation is inline.
+        let obfuscator = get_obfuscator(
+            params,
+            &args,
+            userspace_obfuscation,
+            &mut config,
+            &close_obfs_sender,
+        )?;
 
         #[cfg(target_os = "windows")]
         let (setup_done_tx, setup_done_rx) = mpsc::channel(0);
@@ -277,10 +295,8 @@ impl WireguardMonitor {
                     &tunnel,
                     &mut config,
                     args.retry_attempt,
-                    obfuscation_mtu,
                     obfuscator.clone(),
                     ephemeral_obfs_sender,
-                    userspace_wireguard,
                 )
                 .await
                 {
@@ -418,29 +434,26 @@ impl WireguardMonitor {
         let userspace_multihop = true;
 
         let tunnel_mtu = calculate_tunnel_mtu(route_mtu, params, userspace_multihop);
-        let mut config = crate::config::Config::from_parameters(params, tunnel_mtu)
-            .map_err(Error::WireguardConfigError)?;
+        let obfuscation_mtu = route_mtu;
+        let mut config =
+            crate::config::Config::from_parameters(params, tunnel_mtu, obfuscation_mtu)
+                .map_err(Error::WireguardConfigError)?;
 
         let (close_obfs_sender, close_obfs_listener) = sync_mpsc::channel();
-        let obfuscation_mtu = route_mtu;
-        let obfuscator = args
-            .runtime
-            .block_on(obfuscation::apply_obfuscation_config(
-                &mut config,
-                obfuscation_mtu,
-                close_obfs_sender.clone(),
-                true, // is_gotatun
-                args.tun_provider.clone(),
-            ))?;
-        // Adjust MTU again for obfuscation packet overhead
-        if params.options.mtu.is_none()
-            && let Some(obfuscator) = obfuscator.as_ref()
-        {
-            config.mtu = clamp_tunnel_mtu(
-                params,
-                config.mtu.saturating_sub(obfuscator.packet_overhead()),
-            );
-        }
+
+        // Android always uses GotaTun (userspace WireGuard). When the obfuscation can be
+        // applied inline (LWO or QUIC), skip the local socket obfuscator and let
+        // MaybeObfuscatingTransportFactory handle it directly.
+        let userspace_obfuscation =
+            obfuscation::userspace_transport_available(params) && !*FORCE_LOCAL_SOCKET_OBFUSCATION;
+
+        let obfuscator = get_obfuscator(
+            params,
+            &args,
+            userspace_obfuscation,
+            &mut config,
+            &close_obfs_sender,
+        )?;
 
         let should_negotiate_ephemeral_peer = config.quantum_resistant || config.daita;
 
@@ -515,7 +528,6 @@ impl WireguardMonitor {
                     &tunnel,
                     &mut config,
                     args.retry_attempt,
-                    obfuscation_mtu,
                     obfuscator.clone(),
                     ephemeral_obfs_sender,
                     args.tun_provider,
@@ -929,6 +941,43 @@ impl WireguardMonitor {
             ipv6_gateway: config.ipv6_gateway,
         }
     }
+}
+
+fn get_obfuscator(
+    params: &TunnelParameters,
+    args: &TunnelArgs<'_>,
+    userspace_obfuscation: bool,
+    config: &mut Config,
+    close_obfs_sender: &sync_mpsc::Sender<CloseMsg>,
+) -> Result<Option<ObfuscatorHandle>> {
+    let Some(obfuscation_settings) = config.obfuscation_settings() else {
+        return Ok(None);
+    };
+    if userspace_obfuscation {
+        log::debug!("Using inline obfuscation");
+        return Ok(None);
+    };
+    log::debug!("Using proxy socket obfuscation");
+
+    let obfuscator = args
+        .runtime
+        .block_on(obfuscation::spawn_local_socket_obfuscator(
+            &mut config.entry_peer,
+            obfuscation_settings,
+            close_obfs_sender.clone(),
+            #[cfg(target_os = "android")]
+            args.tun_provider.clone(),
+            #[cfg(target_os = "linux")]
+            config.fwmark,
+        ))?;
+
+    if params.options.mtu.is_none() {
+        config.mtu = clamp_tunnel_mtu(
+            params,
+            config.mtu.saturating_sub(obfuscator.packet_overhead()),
+        );
+    }
+    Ok(Some(obfuscator))
 }
 
 /// Log the tunnel stats from the current tunnel.

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -19,8 +19,6 @@ use std::{
     sync::{Arc, mpsc as sync_mpsc},
 };
 #[cfg(not(target_os = "android"))]
-use std::{env, sync::LazyLock};
-#[cfg(not(target_os = "android"))]
 use talpid_routing::{self, RequiredRoute};
 use talpid_tunnel::{EventHook, TunnelArgs, TunnelEvent, TunnelMetadata, tun_provider};
 use talpid_tunnel::{IPV4_HEADER_SIZE, IPV6_HEADER_SIZE, WIREGUARD_HEADER_SIZE};
@@ -204,7 +202,8 @@ impl WireguardMonitor {
         let (close_obfs_sender, close_obfs_listener) = sync_mpsc::channel();
 
         // Start obfuscation server and patch the WireGuard config to point the endpoint to it.
-        // For userspace_obfuscation, apply_obfuscation_config returns None and obfuscation is inline.
+        // For userspace_obfuscation, apply_obfuscation_config returns None obfuscation is set
+        // up in `open_gotatun_tunnel`.
         let obfuscator = get_obfuscator(
             params,
             &args,

--- a/talpid-wireguard/src/obfuscation.rs
+++ b/talpid-wireguard/src/obfuscation.rs
@@ -1,7 +1,7 @@
 //! Glue between tunnel-obfuscation and WireGuard configurations
 
 use super::{Error, Result};
-use crate::{CloseMsg, config::Config};
+use crate::CloseMsg;
 #[cfg(target_os = "android")]
 use std::sync::Mutex;
 use std::{
@@ -14,12 +14,14 @@ use talpid_net::bypass::{BypassToken, SocketBypass};
 use talpid_tunnel::tun_provider::TunProvider;
 use talpid_types::{
     ErrorExt,
-    net::obfuscation::{ObfuscatorConfig, Obfuscators},
+    net::{
+        obfuscation::{ObfuscatorConfig, Obfuscators},
+        wireguard::{PeerConfig, PublicKey},
+    },
 };
-
 use tunnel_obfuscation::{
-    Settings as ObfuscationSettings, create_obfuscator_with_bypass, lwo, multiplexer, quic,
-    shadowsocks, udp2tcp,
+    Settings as ObfuscationSettings, create_local_socket_obfuscator_with_bypass, lwo, multiplexer,
+    quic, shadowsocks, udp2tcp,
 };
 
 /// Begin running obfuscation machine, if configured. This function will patch `config`'s endpoint
@@ -27,33 +29,21 @@ use tunnel_obfuscation::{
 ///
 /// # Arguments
 ///
-/// * obfuscation_mtu - "MTU" including obfuscation overhead
-/// * is_gotatun - `true` when the userspace GotaTun implementation is in use
-pub async fn apply_obfuscation_config(
-    config: &mut Config,
-    obfuscation_mtu: u16,
+/// * close_msg_sender - channel to send close messages on failure
+/// * tun_provider - (Android only) used to bypass the VPN for the remote socket
+/// * fwmark - (Linux only) firewall mark to apply to the obfuscator's remote socket
+pub async fn spawn_local_socket_obfuscator(
+    entry_peer: &mut PeerConfig,
+    obfuscation_settings: tunnel_obfuscation::Settings,
     close_msg_sender: sync_mpsc::Sender<CloseMsg>,
-    is_gotatun: bool,
     #[cfg(target_os = "android")] tun_provider: Arc<Mutex<TunProvider>>,
-) -> Result<Option<ObfuscatorHandle>> {
-    let Some(ref obfuscator_config) = config.obfuscator_config else {
-        return Ok(None);
-    };
-
-    // When GotaTun is in use and LWO is configured, obfuscation is applied inline by
-    // MaybeObfuscatingTransportFactory.
-    if is_gotatun && is_single_lwo(obfuscator_config) {
-        log::debug!("GotaTun + LWO: skipping proxy, obfuscation will be applied inline");
-        return Ok(None);
-    }
-
-    let settings = settings_from_config(config, obfuscator_config, obfuscation_mtu);
-
-    log::trace!("Obfuscation settings: {settings:?}");
+    #[cfg(target_os = "linux")] fwmark: Option<u32>,
+) -> Result<ObfuscatorHandle> {
+    log::trace!("Obfuscation settings: {obfuscation_settings:?}");
 
     let bypass = Arc::new(ObfuscatorSocketBypass {
         #[cfg(target_os = "linux")]
-        fwmark: config.fwmark.unwrap_or_else(|| {
+        fwmark: fwmark.unwrap_or_else(|| {
             log::error!("'fwmark' not set");
             0
         }),
@@ -62,13 +52,13 @@ pub async fn apply_obfuscation_config(
         tun_provider,
     });
 
-    let obfuscator = create_obfuscator_with_bypass(bypass, &settings)
+    let obfuscator = create_local_socket_obfuscator_with_bypass(bypass, &obfuscation_settings)
         .await
         .map_err(Error::ObfuscationError)?;
 
     let packet_overhead = obfuscator.packet_overhead();
 
-    patch_endpoint(config, obfuscator.endpoint());
+    patch_endpoint(entry_peer, obfuscator.endpoint());
 
     let obfuscation_task = tokio::spawn(async move {
         match obfuscator.run().await {
@@ -86,35 +76,42 @@ pub async fn apply_obfuscation_config(
         }
     });
 
-    Ok(Some(ObfuscatorHandle {
+    Ok(ObfuscatorHandle {
         obfuscation_task,
         packet_overhead,
-    }))
+    })
 }
 
-/// Returns `true` when the obfuscation config is a single LWO method.
-pub fn is_single_lwo(obfuscators: &Obfuscators) -> bool {
+/// Returns `true` when the obfuscation config can be applied inline in userspace WireGuard
+/// (GotaTun), avoiding the need for a local socket obfuscator.
+pub fn userspace_transport_available(
+    params: &talpid_types::net::wireguard::TunnelParameters,
+) -> bool {
     matches!(
-        obfuscators,
-        Obfuscators::Single(ObfuscatorConfig::Lwo { .. })
+        params.obfuscation.as_ref(),
+        Some(Obfuscators::Single(ObfuscatorConfig::Lwo { .. }))
     )
 }
 
 /// Patch the first peer in the WireGuard configuration to use the local proxy endpoint
-fn patch_endpoint(config: &mut Config, endpoint: SocketAddr) {
+fn patch_endpoint(entry_peer: &mut PeerConfig, endpoint: SocketAddr) {
     log::trace!("Patching first WireGuard peer to become {endpoint}");
-    config.entry_peer.endpoint = endpoint;
+    entry_peer.endpoint = endpoint;
 }
 
-fn settings_from_config(
-    config: &Config,
+pub fn settings_from_config(
+    client_public_key: PublicKey,
+    server_public_key: PublicKey,
     obfuscation_config: &Obfuscators,
     mtu: u16,
 ) -> ObfuscationSettings {
     match obfuscation_config {
-        Obfuscators::Single(obfuscation_config) => {
-            settings_from_single_config(config, obfuscation_config, mtu)
-        }
+        Obfuscators::Single(obfuscation_config) => settings_from_single_config(
+            client_public_key,
+            server_public_key,
+            obfuscation_config,
+            mtu,
+        ),
         Obfuscators::Multiplexer {
             direct,
             configs: (first_obfs, remaining_obfs),
@@ -124,7 +121,12 @@ fn settings_from_config(
                 transports.push(multiplexer::Transport::Direct(*direct));
             }
             for obfs_config in iter::once(first_obfs).chain(remaining_obfs) {
-                let settings = settings_from_single_config(config, obfs_config, mtu);
+                let settings = settings_from_single_config(
+                    client_public_key.clone(),
+                    server_public_key.clone(),
+                    obfs_config,
+                    mtu,
+                );
                 transports.push(multiplexer::Transport::Obfuscated(settings));
             }
             ObfuscationSettings::Multiplexer(multiplexer::Settings { transports })
@@ -133,7 +135,8 @@ fn settings_from_config(
 }
 
 fn settings_from_single_config(
-    config: &Config,
+    client_public_key: PublicKey,
+    server_public_key: PublicKey,
     obfuscation_config: &ObfuscatorConfig,
     mtu: u16,
 ) -> ObfuscationSettings {
@@ -168,8 +171,8 @@ fn settings_from_single_config(
         }
         ObfuscatorConfig::Lwo { endpoint } => ObfuscationSettings::Lwo(lwo::Settings {
             server_addr: *endpoint,
-            client_public_key: config.tunnel.private_key.public_key(),
-            server_public_key: config.entry_peer.public_key.clone(),
+            client_public_key,
+            server_public_key,
         }),
     }
 }

--- a/talpid-wireguard/src/obfuscation.rs
+++ b/talpid-wireguard/src/obfuscation.rs
@@ -90,6 +90,7 @@ pub fn userspace_transport_available(
     matches!(
         params.obfuscation.as_ref(),
         Some(Obfuscators::Single(ObfuscatorConfig::Lwo { .. }))
+            | Some(Obfuscators::Single(ObfuscatorConfig::Quic { .. }))
     )
 }
 
@@ -199,12 +200,12 @@ impl Drop for ObfuscatorHandle {
     }
 }
 
-struct ObfuscatorSocketBypass {
+pub struct ObfuscatorSocketBypass {
     #[cfg(target_os = "linux")]
-    fwmark: u32,
+    pub fwmark: u32,
 
     #[cfg(target_os = "android")]
-    tun_provider: Arc<Mutex<TunProvider>>,
+    pub tun_provider: Arc<Mutex<TunProvider>>,
 }
 
 impl SocketBypass for ObfuscatorSocketBypass {

--- a/talpid-wireguard/src/wireguard_nt/mod.rs
+++ b/talpid-wireguard/src/wireguard_nt/mod.rs
@@ -1040,6 +1040,7 @@ mod tests {
         ipv6_gateway: None,
         mtu: 0,
         obfuscator_config: None,
+        obfuscation_mtu: 0,
         quantum_resistant: false,
         daita: false,
     });

--- a/tunnel-obfuscation/benches/obfuscation_throughput.rs
+++ b/tunnel-obfuscation/benches/obfuscation_throughput.rs
@@ -16,7 +16,7 @@ use talpid_net::bypass::NoopBypass;
 use talpid_types::net::wireguard::PublicKey;
 use tokio::net::UdpSocket;
 use tunnel_obfuscation::{
-    Obfuscator,
+    LocalSocketObfuscator,
     lwo::{self, Lwo, Settings, obfuscate_thread_local},
 };
 
@@ -101,7 +101,7 @@ fn bench_proxy_lwo(c: &mut Criterion) {
         };
         let lwo = Lwo::new(Arc::new(NoopBypass), &settings).await.unwrap();
         let proxy_addr = lwo.endpoint();
-        tokio::spawn((Box::new(lwo) as Box<dyn Obfuscator>).run());
+        tokio::spawn((Box::new(lwo) as Box<dyn LocalSocketObfuscator>).run());
 
         // Warm up: send one packet so the proxy connects its client socket
         let wg = UdpSocket::bind("127.0.0.1:0").await.unwrap();

--- a/tunnel-obfuscation/src/lib.rs
+++ b/tunnel-obfuscation/src/lib.rs
@@ -7,7 +7,7 @@ pub mod lwo;
 pub mod multiplexer;
 pub mod quic;
 pub mod shadowsocks;
-pub(crate) mod socket;
+pub mod socket;
 pub mod udp2tcp;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/tunnel-obfuscation/src/lib.rs
+++ b/tunnel-obfuscation/src/lib.rs
@@ -52,7 +52,7 @@ pub enum Error {
 }
 
 #[async_trait]
-pub trait Obfuscator: Send {
+pub trait LocalSocketObfuscator: Send {
     async fn run(self: Box<Self>) -> Result<()>;
 
     /// Returns the address of the local socket.
@@ -73,20 +73,24 @@ pub enum Settings {
     Multiplexer(multiplexer::Settings),
 }
 
-pub async fn create_obfuscator(settings: &Settings) -> Result<Box<dyn Obfuscator>> {
-    create_obfuscator_with_bypass(Arc::new(NoopBypass), settings).await
+pub async fn create_local_socket_obfuscator(
+    settings: &Settings,
+) -> Result<Box<dyn LocalSocketObfuscator>> {
+    create_local_socket_obfuscator_with_bypass(Arc::new(NoopBypass), settings).await
 }
 
-pub async fn create_obfuscator_with_bypass(
+pub async fn create_local_socket_obfuscator_with_bypass(
     bypass: Arc<dyn SocketBypass>,
     settings: &Settings,
-) -> Result<Box<dyn Obfuscator>> {
+) -> Result<Box<dyn LocalSocketObfuscator>> {
     match settings {
         Settings::Udp2Tcp(s) => udp2tcp::Udp2Tcp::new(bypass, s).await.map(box_obfuscator),
         Settings::Shadowsocks(s) => shadowsocks::Shadowsocks::new(bypass, s)
             .await
             .map(box_obfuscator),
-        Settings::Quic(s) => quic::Quic::new(bypass, s).await.map(box_obfuscator),
+        Settings::Quic(s) => quic::QuicLocalSocket::new(bypass, s)
+            .await
+            .map(box_obfuscator),
         Settings::Lwo(s) => lwo::Lwo::new(bypass, s).await.map(box_obfuscator),
         Settings::Multiplexer(s) => multiplexer::Multiplexer::new(bypass, s)
             .await
@@ -94,6 +98,6 @@ pub async fn create_obfuscator_with_bypass(
     }
 }
 
-fn box_obfuscator(obfs: impl Obfuscator + 'static) -> Box<dyn Obfuscator> {
-    Box::new(obfs) as Box<dyn Obfuscator>
+fn box_obfuscator(obfs: impl LocalSocketObfuscator + 'static) -> Box<dyn LocalSocketObfuscator> {
+    Box::new(obfs) as Box<dyn LocalSocketObfuscator>
 }

--- a/tunnel-obfuscation/src/lwo.rs
+++ b/tunnel-obfuscation/src/lwo.rs
@@ -12,7 +12,7 @@ use talpid_types::net::wireguard::PublicKey;
 use tokio::{io, net::UdpSocket, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 
-use crate::{Obfuscator, socket::create_remote_socket};
+use crate::{LocalSocketObfuscator, socket::create_remote_socket};
 
 const MAX_UDP_SIZE: usize = u16::MAX as usize;
 
@@ -279,7 +279,7 @@ fn xor_bytes(data: &mut [u8], key: &[u8; 32]) {
 }
 
 #[async_trait]
-impl Obfuscator for Lwo {
+impl LocalSocketObfuscator for Lwo {
     fn endpoint(&self) -> SocketAddr {
         self.local_endpoint
     }

--- a/tunnel-obfuscation/src/main.rs
+++ b/tunnel-obfuscation/src/main.rs
@@ -1,5 +1,7 @@
 use std::{env::args, net::SocketAddr};
-use tunnel_obfuscation::{Obfuscator, Settings, create_obfuscator, udp2tcp};
+use tunnel_obfuscation::{
+    LocalSocketObfuscator, Settings, create_local_socket_obfuscator, udp2tcp,
+};
 
 #[tokio::main]
 async fn main() {
@@ -16,14 +18,14 @@ async fn main() {
     }
 }
 
-async fn instantiate_requested(obfuscator_type: &str) -> Box<dyn Obfuscator> {
+async fn instantiate_requested(obfuscator_type: &str) -> Box<dyn LocalSocketObfuscator> {
     match obfuscator_type {
         "udp2tcp" => {
             let settings = udp2tcp::Settings {
                 peer: SocketAddr::new("127.0.0.1".parse().unwrap(), 3030),
             };
 
-            create_obfuscator(&Settings::Udp2Tcp(settings))
+            create_local_socket_obfuscator(&Settings::Udp2Tcp(settings))
                 .await
                 .expect("Creating obfuscator failed")
         }

--- a/tunnel-obfuscation/src/multiplexer.rs
+++ b/tunnel-obfuscation/src/multiplexer.rs
@@ -314,7 +314,7 @@ impl Multiplexer {
                 Ok(addr)
             }
             Transport::Obfuscated(obfuscator_settings) => {
-                let obfuscator = crate::create_obfuscator_with_bypass(
+                let obfuscator = crate::create_local_socket_obfuscator_with_bypass(
                     Arc::clone(&self.bypass),
                     &obfuscator_settings,
                 )
@@ -365,7 +365,7 @@ pub enum Transport {
 }
 
 #[async_trait]
-impl crate::Obfuscator for Multiplexer {
+impl crate::LocalSocketObfuscator for Multiplexer {
     fn endpoint(&self) -> SocketAddr {
         self.client_socket_addr
     }
@@ -386,7 +386,7 @@ impl crate::Obfuscator for Multiplexer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Obfuscator;
+    use crate::LocalSocketObfuscator;
     use talpid_net::bypass::NoopBypass;
 
     /// Test whether the multiplexer works with a direct transports

--- a/tunnel-obfuscation/src/quic.rs
+++ b/tunnel-obfuscation/src/quic.rs
@@ -25,6 +25,8 @@ pub enum Error {
 
 pub struct QuicLocalSocket {
     local_endpoint: SocketAddr,
+    /// Local UDP socket that WireGuard sends to and receives from.
+    local_socket: UdpSocket,
     config: ClientConfig,
     _bypass: BypassGuard,
 }
@@ -125,19 +127,18 @@ impl QuicLocalSocket {
             guard: _bypass,
         } = create_remote_socket(&bypass, settings.quic_endpoint.is_ipv4()).await?;
 
-        let config_builder = ClientConfig::builder()
-            .client_socket(local_socket)
+        let config = ClientConfig::builder()
             .quinn_socket(quic_socket)
             .server_addr(settings.quic_endpoint)
             .server_host(settings.hostname.clone())
             .target_addr(settings.wireguard_endpoint)
             .auth_header(Some(settings.auth_header()))
-            .mtu(settings.mtu.unwrap_or(1500));
-
-        let config = config_builder.build();
+            .mtu(settings.mtu.unwrap_or(1500))
+            .build();
 
         let quic = QuicLocalSocket {
             local_endpoint: local_udp_client_addr,
+            local_socket,
             config,
             _bypass,
         };
@@ -145,8 +146,12 @@ impl QuicLocalSocket {
         Ok(quic)
     }
 
-    async fn run_forwarding(client: Client, cancel_token: CancellationToken) -> Result<()> {
-        let client = client.run();
+    async fn run_forwarding(
+        client: Client,
+        local_socket: UdpSocket,
+        cancel_token: CancellationToken,
+    ) -> Result<()> {
+        let client = client.proxy_socket(local_socket);
         log::trace!("QUIC client is running! QUIC Obfuscator is serving traffic 🎉");
         tokio::select! {
             _ = cancel_token.cancelled() => log::trace!("Stopping QUIC obfuscation"),
@@ -182,20 +187,30 @@ impl LocalSocketObfuscator for QuicLocalSocket {
     }
 
     async fn run(self: Box<Self>) -> crate::Result<()> {
+        let Self {
+            config,
+            local_socket,
+            ..
+        } = *self;
+
         let token = CancellationToken::new();
         let child_token = token.child_token();
         // This will always cancel `child_token` as soon as `run` is finished or aborted.
         let _drop_guard = token.drop_guard();
 
-        let client = Client::connect(self.config)
+        let client = Client::connect(config)
             .await
             .map_err(Error::MasqueProxyError)
             .map_err(crate::Error::RunQuicObfuscator)?;
 
-        tokio::spawn(QuicLocalSocket::run_forwarding(client, child_token))
-            .await
-            .unwrap()
-            .map_err(crate::Error::RunQuicObfuscator)
+        tokio::spawn(QuicLocalSocket::run_forwarding(
+            client,
+            local_socket,
+            child_token,
+        ))
+        .await
+        .unwrap()
+        .map_err(crate::Error::RunQuicObfuscator)
     }
 
     fn packet_overhead(&self) -> u16 {

--- a/tunnel-obfuscation/src/quic.rs
+++ b/tunnel-obfuscation/src/quic.rs
@@ -1,7 +1,7 @@
 //! Quic obfuscation
 
 use async_trait::async_trait;
-use mullvad_masque_proxy::client::{Client, ClientConfig};
+use mullvad_masque_proxy::client::ClientConfig;
 use std::{
     io,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
@@ -11,6 +11,11 @@ use talpid_net::bypass::{BypassGuard, BypassSocket, SocketBypass};
 use tokio::net::UdpSocket;
 use tokio_util::sync::CancellationToken;
 
+pub use mullvad_masque_proxy::{
+    HTTP_MASQUE_DATAGRAM_CONTEXT_ID, MAX_INFLIGHT_PACKETS,
+    client::{Client, RunningClient},
+};
+
 use crate::{LocalSocketObfuscator, socket::create_remote_socket};
 
 type Result<T> = std::result::Result<T, Error>;
@@ -18,9 +23,9 @@ type Result<T> = std::result::Result<T, Error>;
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("Failed to bind UDP socket")]
-    BindError(#[source] io::Error),
+    BindError(#[from] io::Error),
     #[error("Masque proxy error")]
-    MasqueProxyError(#[source] mullvad_masque_proxy::client::Error),
+    MasqueProxyError(#[from] mullvad_masque_proxy::client::Error),
 }
 
 pub struct QuicLocalSocket {
@@ -76,6 +81,26 @@ impl Settings {
     fn auth_header(&self) -> String {
         format!("Bearer {token}", token = self.token.0)
     }
+
+    /// Build the masque-proxy [`ClientConfig`], including binding the local QUIC endpoint socket.
+    pub fn build_client_config(&self, quinn_socket: UdpSocket) -> ClientConfig {
+        ClientConfig::builder()
+            .quinn_socket(quinn_socket)
+            .server_addr(self.quic_endpoint)
+            .server_host(self.hostname.clone())
+            .target_addr(self.wireguard_endpoint)
+            .auth_header(Some(self.auth_header()))
+            .mtu(self.mtu.unwrap_or(1500))
+            .build()
+    }
+
+    pub fn wireguard_endpoint(&self) -> SocketAddr {
+        self.wireguard_endpoint
+    }
+
+    pub fn quic_endpoint(&self) -> SocketAddr {
+        self.quic_endpoint
+    }
 }
 
 /// Authorization Token used when connecting to a masque-proxy.
@@ -114,27 +139,20 @@ impl QuicLocalSocket {
         bypass: Arc<dyn SocketBypass>,
         settings: &Settings,
     ) -> crate::Result<Self> {
-        let (local_socket, local_udp_client_addr) =
-            QuicLocalSocket::create_local_udp_socket(settings.quic_endpoint.is_ipv4())
-                .await
-                .map_err(crate::Error::CreateQuicObfuscator)?;
         // The address family of the local QUIC client socket has to match the address family
         // of the endpoint we're connecting to. The address itself is not important to consumers
         // wanting to obfuscate traffic. It is solely used by the local proxy client to know
         // where the QUIC obfuscator is running.
+        let (local_socket, local_udp_client_addr) =
+            QuicLocalSocket::create_local_udp_socket(settings.quic_endpoint.is_ipv4())
+                .await
+                .map_err(crate::Error::CreateQuicObfuscator)?;
         let BypassSocket {
             socket: quic_socket,
             guard: _bypass,
         } = create_remote_socket(&bypass, settings.quic_endpoint.is_ipv4()).await?;
 
-        let config = ClientConfig::builder()
-            .quinn_socket(quic_socket)
-            .server_addr(settings.quic_endpoint)
-            .server_host(settings.hostname.clone())
-            .target_addr(settings.wireguard_endpoint)
-            .auth_header(Some(settings.auth_header()))
-            .mtu(settings.mtu.unwrap_or(1500))
-            .build();
+        let config = settings.build_client_config(quic_socket);
 
         let quic = QuicLocalSocket {
             local_endpoint: local_udp_client_addr,

--- a/tunnel-obfuscation/src/quic.rs
+++ b/tunnel-obfuscation/src/quic.rs
@@ -11,7 +11,7 @@ use talpid_net::bypass::{BypassGuard, BypassSocket, SocketBypass};
 use tokio::net::UdpSocket;
 use tokio_util::sync::CancellationToken;
 
-use crate::{Obfuscator, socket::create_remote_socket};
+use crate::{LocalSocketObfuscator, socket::create_remote_socket};
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -23,7 +23,7 @@ pub enum Error {
     MasqueProxyError(#[source] mullvad_masque_proxy::client::Error),
 }
 
-pub struct Quic {
+pub struct QuicLocalSocket {
     local_endpoint: SocketAddr,
     config: ClientConfig,
     _bypass: BypassGuard,
@@ -107,13 +107,13 @@ impl std::str::FromStr for AuthToken {
     }
 }
 
-impl Quic {
+impl QuicLocalSocket {
     pub(crate) async fn new(
         bypass: Arc<dyn SocketBypass>,
         settings: &Settings,
     ) -> crate::Result<Self> {
         let (local_socket, local_udp_client_addr) =
-            Quic::create_local_udp_socket(settings.quic_endpoint.is_ipv4())
+            QuicLocalSocket::create_local_udp_socket(settings.quic_endpoint.is_ipv4())
                 .await
                 .map_err(crate::Error::CreateQuicObfuscator)?;
         // The address family of the local QUIC client socket has to match the address family
@@ -136,7 +136,7 @@ impl Quic {
 
         let config = config_builder.build();
 
-        let quic = Quic {
+        let quic = QuicLocalSocket {
             local_endpoint: local_udp_client_addr,
             config,
             _bypass,
@@ -176,7 +176,7 @@ impl Quic {
 }
 
 #[async_trait]
-impl Obfuscator for Quic {
+impl LocalSocketObfuscator for QuicLocalSocket {
     fn endpoint(&self) -> SocketAddr {
         self.local_endpoint
     }
@@ -192,7 +192,7 @@ impl Obfuscator for Quic {
             .map_err(Error::MasqueProxyError)
             .map_err(crate::Error::RunQuicObfuscator)?;
 
-        tokio::spawn(Quic::run_forwarding(client, child_token))
+        tokio::spawn(QuicLocalSocket::run_forwarding(client, child_token))
             .await
             .unwrap()
             .map_err(crate::Error::RunQuicObfuscator)

--- a/tunnel-obfuscation/src/shadowsocks.rs
+++ b/tunnel-obfuscation/src/shadowsocks.rs
@@ -5,7 +5,7 @@
 
 use crate::socket::create_remote_socket;
 
-use super::Obfuscator;
+use super::LocalSocketObfuscator;
 use async_trait::async_trait;
 use shadowsocks::{
     ProxySocket,
@@ -249,7 +249,7 @@ async fn handle_incoming(
 }
 
 #[async_trait]
-impl Obfuscator for Shadowsocks {
+impl LocalSocketObfuscator for Shadowsocks {
     fn endpoint(&self) -> SocketAddr {
         self.udp_client_addr
     }

--- a/tunnel-obfuscation/src/udp2tcp.rs
+++ b/tunnel-obfuscation/src/udp2tcp.rs
@@ -1,4 +1,4 @@
-use crate::Obfuscator;
+use crate::LocalSocketObfuscator;
 use async_trait::async_trait;
 use std::{net::SocketAddr, sync::Arc};
 use talpid_net::bypass::{BypassGuard, BypassSocket, SocketBypass};
@@ -86,7 +86,7 @@ impl Udp2Tcp {
 }
 
 #[async_trait]
-impl Obfuscator for Udp2Tcp {
+impl LocalSocketObfuscator for Udp2Tcp {
     fn endpoint(&self) -> SocketAddr {
         self.local_addr
     }


### PR DESCRIPTION
Implement a in-process transport for sending packets between GotaTun and the QUIC proxy client, which is currently achieved using only a local socket. This was done for LWO, which showed significant performance improvements https://github.com/mullvad/mullvadvpn-app/pull/10172. We should expect to see a smaller difference as QUIC is more CPU bound
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10574)
<!-- Reviewable:end -->
