### PR TITLE
Reduce SplitFilterMigration gRPC to precise migration scenarios

### DIFF
--- a/desktop/packages/management-interface/dist/management_interface_pb.d.ts
+++ b/desktop/packages/management-interface/dist/management_interface_pb.d.ts
@@ -3433,12 +3433,8 @@ export namespace LogMessage {
 }
 
 export class SplitFilterMigration extends jspb.Message { 
-    getMultihopMigration(): SplitFilterMigration.MultihopMigrationState;
-    setMultihopMigration(value: SplitFilterMigration.MultihopMigrationState): SplitFilterMigration;
-    getFiltersSet(): boolean;
-    setFiltersSet(value: boolean): SplitFilterMigration;
-    getDaitaMigration(): SplitFilterMigration.PreviousDaitaState;
-    setDaitaMigration(value: SplitFilterMigration.PreviousDaitaState): SplitFilterMigration;
+    getScenario(): SplitFilterMigration.Scenario;
+    setScenario(value: SplitFilterMigration.Scenario): SplitFilterMigration;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): SplitFilterMigration.AsObject;
@@ -3452,22 +3448,23 @@ export class SplitFilterMigration extends jspb.Message {
 
 export namespace SplitFilterMigration {
     export type AsObject = {
-        multihopMigration: SplitFilterMigration.MultihopMigrationState,
-        filtersSet: boolean,
-        daitaMigration: SplitFilterMigration.PreviousDaitaState,
+        scenario: SplitFilterMigration.Scenario,
     }
 
-    export enum MultihopMigrationState {
-    ON_TO_ALWAYS = 0,
-    OFF_TO_NEVER = 1,
-    OFF_TO_WHEN_NEEDED = 2,
-    OFF_TO_ALWAYS = 3,
-    }
-
-    export enum PreviousDaitaState {
-    ON = 0,
-    DIRECT_ONLY = 1,
-    OFF = 2,
+    export enum Scenario {
+    ONEA = 0,
+    ONEB = 1,
+    TWO = 2,
+    THREEA = 3,
+    THREEB = 4,
+    FOURA = 5,
+    FOURB = 6,
+    FIVEA = 7,
+    FIVEB = 8,
+    SIXA = 9,
+    SIXB = 10,
+    SEVENA = 11,
+    SEVENB = 12,
     }
 
 }

--- a/desktop/packages/management-interface/dist/management_interface_pb.js
+++ b/desktop/packages/management-interface/dist/management_interface_pb.js
@@ -143,8 +143,7 @@ goog.exportSymbol('proto.mullvad_daemon.management_interface.Socks5Local', null,
 goog.exportSymbol('proto.mullvad_daemon.management_interface.Socks5Remote', null, global);
 goog.exportSymbol('proto.mullvad_daemon.management_interface.SocksAuth', null, global);
 goog.exportSymbol('proto.mullvad_daemon.management_interface.SplitFilterMigration', null, global);
-goog.exportSymbol('proto.mullvad_daemon.management_interface.SplitFilterMigration.MultihopMigrationState', null, global);
-goog.exportSymbol('proto.mullvad_daemon.management_interface.SplitFilterMigration.PreviousDaitaState', null, global);
+goog.exportSymbol('proto.mullvad_daemon.management_interface.SplitFilterMigration.Scenario', null, global);
 goog.exportSymbol('proto.mullvad_daemon.management_interface.SplitTunnelSettings', null, global);
 goog.exportSymbol('proto.mullvad_daemon.management_interface.SuggestedUpgrade', null, global);
 goog.exportSymbol('proto.mullvad_daemon.management_interface.TransportPort', null, global);
@@ -26411,9 +26410,7 @@ proto.mullvad_daemon.management_interface.SplitFilterMigration.prototype.toObjec
  */
 proto.mullvad_daemon.management_interface.SplitFilterMigration.toObject = function(includeInstance, msg) {
   var f, obj = {
-    multihopMigration: jspb.Message.getFieldWithDefault(msg, 1, 0),
-    filtersSet: jspb.Message.getBooleanFieldWithDefault(msg, 2, false),
-    daitaMigration: jspb.Message.getFieldWithDefault(msg, 3, 0)
+    scenario: jspb.Message.getFieldWithDefault(msg, 1, 0)
   };
 
   if (includeInstance) {
@@ -26451,16 +26448,8 @@ proto.mullvad_daemon.management_interface.SplitFilterMigration.deserializeBinary
     var field = reader.getFieldNumber();
     switch (field) {
     case 1:
-      var value = /** @type {!proto.mullvad_daemon.management_interface.SplitFilterMigration.MultihopMigrationState} */ (reader.readEnum());
-      msg.setMultihopMigration(value);
-      break;
-    case 2:
-      var value = /** @type {boolean} */ (reader.readBool());
-      msg.setFiltersSet(value);
-      break;
-    case 3:
-      var value = /** @type {!proto.mullvad_daemon.management_interface.SplitFilterMigration.PreviousDaitaState} */ (reader.readEnum());
-      msg.setDaitaMigration(value);
+      var value = /** @type {!proto.mullvad_daemon.management_interface.SplitFilterMigration.Scenario} */ (reader.readEnum());
+      msg.setScenario(value);
       break;
     default:
       reader.skipField();
@@ -26491,100 +26480,50 @@ proto.mullvad_daemon.management_interface.SplitFilterMigration.prototype.seriali
  */
 proto.mullvad_daemon.management_interface.SplitFilterMigration.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
-  f = message.getMultihopMigration();
+  f = message.getScenario();
   if (f !== 0.0) {
     writer.writeEnum(
       1,
       f
     );
   }
-  f = message.getFiltersSet();
-  if (f) {
-    writer.writeBool(
-      2,
-      f
-    );
-  }
-  f = message.getDaitaMigration();
-  if (f !== 0.0) {
-    writer.writeEnum(
-      3,
-      f
-    );
-  }
 };
 
 
 /**
  * @enum {number}
  */
-proto.mullvad_daemon.management_interface.SplitFilterMigration.MultihopMigrationState = {
-  ON_TO_ALWAYS: 0,
-  OFF_TO_NEVER: 1,
-  OFF_TO_WHEN_NEEDED: 2,
-  OFF_TO_ALWAYS: 3
+proto.mullvad_daemon.management_interface.SplitFilterMigration.Scenario = {
+  ONEA: 0,
+  ONEB: 1,
+  TWO: 2,
+  THREEA: 3,
+  THREEB: 4,
+  FOURA: 5,
+  FOURB: 6,
+  FIVEA: 7,
+  FIVEB: 8,
+  SIXA: 9,
+  SIXB: 10,
+  SEVENA: 11,
+  SEVENB: 12
 };
 
 /**
- * @enum {number}
+ * optional Scenario scenario = 1;
+ * @return {!proto.mullvad_daemon.management_interface.SplitFilterMigration.Scenario}
  */
-proto.mullvad_daemon.management_interface.SplitFilterMigration.PreviousDaitaState = {
-  ON: 0,
-  DIRECT_ONLY: 1,
-  OFF: 2
-};
-
-/**
- * optional MultihopMigrationState multihop_migration = 1;
- * @return {!proto.mullvad_daemon.management_interface.SplitFilterMigration.MultihopMigrationState}
- */
-proto.mullvad_daemon.management_interface.SplitFilterMigration.prototype.getMultihopMigration = function() {
-  return /** @type {!proto.mullvad_daemon.management_interface.SplitFilterMigration.MultihopMigrationState} */ (jspb.Message.getFieldWithDefault(this, 1, 0));
+proto.mullvad_daemon.management_interface.SplitFilterMigration.prototype.getScenario = function() {
+  return /** @type {!proto.mullvad_daemon.management_interface.SplitFilterMigration.Scenario} */ (jspb.Message.getFieldWithDefault(this, 1, 0));
 };
 
 
 /**
- * @param {!proto.mullvad_daemon.management_interface.SplitFilterMigration.MultihopMigrationState} value
+ * @param {!proto.mullvad_daemon.management_interface.SplitFilterMigration.Scenario} value
  * @return {!proto.mullvad_daemon.management_interface.SplitFilterMigration} returns this
  */
-proto.mullvad_daemon.management_interface.SplitFilterMigration.prototype.setMultihopMigration = function(value) {
+proto.mullvad_daemon.management_interface.SplitFilterMigration.prototype.setScenario = function(value) {
   return jspb.Message.setProto3EnumField(this, 1, value);
-};
-
-
-/**
- * optional bool filters_set = 2;
- * @return {boolean}
- */
-proto.mullvad_daemon.management_interface.SplitFilterMigration.prototype.getFiltersSet = function() {
-  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 2, false));
-};
-
-
-/**
- * @param {boolean} value
- * @return {!proto.mullvad_daemon.management_interface.SplitFilterMigration} returns this
- */
-proto.mullvad_daemon.management_interface.SplitFilterMigration.prototype.setFiltersSet = function(value) {
-  return jspb.Message.setProto3BooleanField(this, 2, value);
-};
-
-
-/**
- * optional PreviousDaitaState daita_migration = 3;
- * @return {!proto.mullvad_daemon.management_interface.SplitFilterMigration.PreviousDaitaState}
- */
-proto.mullvad_daemon.management_interface.SplitFilterMigration.prototype.getDaitaMigration = function() {
-  return /** @type {!proto.mullvad_daemon.management_interface.SplitFilterMigration.PreviousDaitaState} */ (jspb.Message.getFieldWithDefault(this, 3, 0));
-};
-
-
-/**
- * @param {!proto.mullvad_daemon.management_interface.SplitFilterMigration.PreviousDaitaState} value
- * @return {!proto.mullvad_daemon.management_interface.SplitFilterMigration} returns this
- */
-proto.mullvad_daemon.management_interface.SplitFilterMigration.prototype.setDaitaMigration = function(value) {
-  return jspb.Message.setProto3EnumField(this, 3, value);
 };
 
 

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -892,44 +892,79 @@ message LogFilter { string log_filter = 1; }
 message LogMessage { string message = 1; }
 
 // The great multihop migration of 2026
-
+//
+// The migration has to consider the following scenarios:
+//
+// | Scenario | Multihop | DAITA | Direct Only | Magic Multihop | Filters |
+// |----------|----------|-------|-------------|----------------|---------|
+// |    1A    |    ❌    |   ❌  |      ❔     |       ❔       |    ❌   |
+// |    1B    |    ❌    |   ❌  |      ❔     |       ❔       |    ✅   |
+// |    2     |    ❌    |   ✅  |      ❌     |       ❔       |    ❌   |
+// |    3A    |    ❌    |   ✅  |      ❌     |       ❌       |    ✅   |
+// |    3A    |    ❌    |   ✅  |      ❌     |       ✅       |    ✅   |
+// |    4A    |    ❌    |   ✅  |      ✅     |       ❔       |    ❌   |
+// |    4B    |    ❌    |   ✅  |      ✅     |       ❔       |    ✅   |
+// |    5A    |    ✅    |   ❌  |      ❔     |       ❔       |    ❌   |
+// |    5B    |    ✅    |   ❌  |      ❔     |       ❔       |    ✅   |
+// |    6A    |    ✅    |   ✅  |      ❌     |       ❔       |    ❌   |
+// |    6B    |    ✅    |   ✅  |      ❌     |       ❔       |    ✅   |
+// |    7A    |    ✅    |   ✅  |      ✅     |       ❔       |    ❌   |
+// |    7B    |    ✅    |   ✅  |      ✅     |       ❔       |    ✅   |
+//
+// The legends have the following meaning:
+// - ✅ : The setting was enabled.
+// - ❌ : The setting was disabled.
+// - ❔ : The setting did not contribute to detecting which migration to run ("Scenario").
+//
+// Clarification of some settings:
+// - Direct only: DAITA specific setting which prevented Magic Multihop from taking effect.
+// - Magic Multihop: If DAITA was enabled but Direct only was disabled, the relay selector might
+// have
+//   chosen an entry relay automatically. If that was the case, Magic Multihop was enabled.
+// - Filters: If any ownership or provider filter was enabled, the Filters box is ticked with ✅.
+//
+// # Notes on updated settings post-migration.
+//
+// * In the same update as the SplitFilterMigration is run, the Multihop setting transitions from
+// being a boolean state (on/off) to now being a tri-state:
+//
+// - Always
+// - When needed
+// - Never
+//
+// * If any filters were previously set, they were copied and applied as both entry + exit filters.
+//
+// * "Daita: Directy only" does not exist anymore. If Daita was turned off, it is still off.
+// Otherwise Daita is enabled.
 message SplitFilterMigration {
-  // In the same update as the SplitFilterMigration is run, the Multihop setting transitions from
-  // being a boolean state (on/off) to now being a tri-state:
-  // * Always
-  // * When needed
-  // * Never
-  MultihopMigrationState multihop_migration = 1;
-  // If any filters were previously set, they were copied and applied as both entry + exit filters.
-  //
-  // true: Previous filters were applied as both entry and exit filters.
-  // false: No previous filters were set, no filters are set for either entry or exit.
-  bool filters_set = 2;
-  // "Daita: Directy only" does not exist anymore, but it is relevant to know if it was enabled.
-  // If Daita was turned off, it is still off. Otherwise Daita is enabled.
-  PreviousDaitaState daita_migration = 3;
-
-  // This enum value defines all valid transitions from the previous state to the new tri-state,
-  // which necessarily depend on additional settings beyond Multihop.
-  enum MultihopMigrationState {
-    // "On" is always mapped to "Always".
-    on_to_always = 0;
-    // "Off" has been renamed to "Never".
-    off_to_never = 1;
-    // "When needed" is the new default value.
-    off_to_when_needed = 2;
-    // "Magic multihop" - one leaf node in the giga-migration tree.
-    off_to_always = 3;
+  enum Scenario {
+    // 1A
+    OneA = 0;
+    // 1B
+    OneB = 1;
+    // 2
+    Two = 2;
+    // 3A
+    ThreeA = 3;
+    // 3B
+    ThreeB = 4;
+    // 4A
+    FourA = 5;
+    // 4B
+    FourB = 6;
+    // 5A
+    FiveA = 7;
+    // 5B
+    FiveB = 8;
+    // 6A
+    SixA = 9;
+    // 6B
+    SixB = 10;
+    // 7A
+    SevenA = 11;
+    // 7B
+    SevenB = 12;
   }
 
-  // This enum value defines all previous Daita states (tri-state) which is mapped to either on or
-  // off post-migration.
-  enum PreviousDaitaState {
-    // Daita was previoiusly enabled without "direct only"
-    on = 0;
-    // Daita was previoiusly enabled with "direct only"
-    direct_only = 1;
-    // Daita was previously off.
-    off = 2;
-  }
+  Scenario scenario = 1;
 }


### PR DESCRIPTION
Replace the previous SplitFilterMigration containing previous settings to only convey which scenario the multihop/split-filter migration ran. It was discovered that the previous settings did not contribute any extra information other than deducing which scenario was run, so simply sending the scenario to the client is more straight forward. The previous solution had several drawbacks, one of them being that the state space was larger than the amount of migration scenarios. Another big drawback was that each client had to implement the deducing logic themselves, which is *already* implemented in the daemon.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10576)
<!-- Reviewable:end -->
