### PR TITLE
Ignore jwt vulnerability for fastlane

### DIFF
--- a/ci/ios/upload-vm/osv-scanner.toml
+++ b/ci/ios/upload-vm/osv-scanner.toml
@@ -28,3 +28,9 @@ reason = "This option isn't the default, and since we don't opt-in to use it, we
 id = "CVE-2026-35611"  # GHSA-h27x-rffw-24p4
 ignoreUntil = 2026-10-15
 reason = "We do not supply any URI:s to fastlane, so we're not affected. Once Fastlane has updated Addressable we can update Fastlane and get rid of this ignore."
+
+# jwt library does not validate input when creating new JWT tokens.
+[[IgnoredVulns]]
+id = " CVE-2026-45363 "  # GHSA-c32j-vqhx-rx3x
+ignoreUntil = 2026-12-12
+reason = "fastlane does not generate JWT tokens, it only uses them. This vulnerability does not affect us."

--- a/ios/osv-scanner.toml
+++ b/ios/osv-scanner.toml
@@ -28,3 +28,9 @@ reason = "This option isn't the default, and since we don't opt-in to use it, we
 id = "CVE-2026-35611"  # GHSA-h27x-rffw-24p4
 ignoreUntil = 2026-10-15
 reason = "We do not supply any URI:s to fastlane, so we're not affected. Once Fastlane has updated Addressable we can update Fastlane and get rid of this ignore."
+
+# jwt library does not validate input when creating new JWT tokens.
+[[IgnoredVulns]]
+id = " CVE-2026-45363 "  # GHSA-c32j-vqhx-rx3x
+ignoreUntil = 2026-12-12
+reason = "fastlane does not generate JWT tokens, it only uses them. This vulnerability does not affect us."


### PR DESCRIPTION
Silencing [`ruby-jwt`](https://osv.dev/vulnerability/GHSA-c32j-vqhx-rx3x) library CVE since fastlane does not generate JWTs, only consumes them. We are not affected.
 