### PR TITLE
Bump Slack action to 3.0.3

### DIFF
--- a/.github/workflows/ios-end-to-end-tests-nightly-notification.yml
+++ b/.github/workflows/ios-end-to-end-tests-nightly-notification.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Send custom event details to a Slack workflow
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a  # v2.1.1
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
         with:
           webhook: ${{ secrets.IOS_SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger

--- a/.github/workflows/ios-screenshot-tests-notification.yml
+++ b/.github/workflows/ios-screenshot-tests-notification.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Send custom event details to a Slack workflow
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a  # v2.1.1
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
         with:
           webhook: ${{ secrets.IOS_SLACK_SCREENSHOT_TESTS_WEBHOOK_URL }}
           webhook-type: webhook-trigger


### PR DESCRIPTION
Node 24 will be the default on [June 16th][0], so we are bumping the version to ensure continuity.

[0]: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10583)
<!-- Reviewable:end -->
