### PR TITLE
Remove unused "obfuscator hostname"

### DIFF
--- a/desktop/packages/management-interface/dist/management_interface_pb.d.ts
+++ b/desktop/packages/management-interface/dist/management_interface_pb.d.ts
@@ -988,11 +988,6 @@ export class GeoIpLocation extends jspb.Message {
     getEntryHostname(): string | undefined;
     setEntryHostname(value: string): GeoIpLocation;
 
-    hasObfuscatorHostname(): boolean;
-    clearObfuscatorHostname(): void;
-    getObfuscatorHostname(): string | undefined;
-    setObfuscatorHostname(value: string): GeoIpLocation;
-
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): GeoIpLocation.AsObject;
     static toObject(includeInstance: boolean, msg: GeoIpLocation): GeoIpLocation.AsObject;
@@ -1014,7 +1009,6 @@ export namespace GeoIpLocation {
         mullvadExitIp: boolean,
         hostname?: string,
         entryHostname?: string,
-        obfuscatorHostname?: string,
     }
 }
 

--- a/desktop/packages/management-interface/dist/management_interface_pb.js
+++ b/desktop/packages/management-interface/dist/management_interface_pb.js
@@ -8696,8 +8696,7 @@ proto.mullvad_daemon.management_interface.GeoIpLocation.toObject = function(incl
     longitude: jspb.Message.getFloatingPointFieldWithDefault(msg, 6, 0.0),
     mullvadExitIp: jspb.Message.getBooleanFieldWithDefault(msg, 7, false),
     hostname: jspb.Message.getFieldWithDefault(msg, 8, ""),
-    entryHostname: jspb.Message.getFieldWithDefault(msg, 10, ""),
-    obfuscatorHostname: jspb.Message.getFieldWithDefault(msg, 11, "")
+    entryHostname: jspb.Message.getFieldWithDefault(msg, 10, "")
   };
 
   if (includeInstance) {
@@ -8769,10 +8768,6 @@ proto.mullvad_daemon.management_interface.GeoIpLocation.deserializeBinaryFromRea
     case 10:
       var value = /** @type {string} */ (reader.readString());
       msg.setEntryHostname(value);
-      break;
-    case 11:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setObfuscatorHostname(value);
       break;
     default:
       reader.skipField();
@@ -8863,13 +8858,6 @@ proto.mullvad_daemon.management_interface.GeoIpLocation.serializeBinaryToWriter 
   if (f != null) {
     writer.writeString(
       10,
-      f
-    );
-  }
-  f = /** @type {string} */ (jspb.Message.getField(message, 11));
-  if (f != null) {
-    writer.writeString(
-      11,
       f
     );
   }
@@ -9125,42 +9113,6 @@ proto.mullvad_daemon.management_interface.GeoIpLocation.prototype.clearEntryHost
  */
 proto.mullvad_daemon.management_interface.GeoIpLocation.prototype.hasEntryHostname = function() {
   return jspb.Message.getField(this, 10) != null;
-};
-
-
-/**
- * optional string obfuscator_hostname = 11;
- * @return {string}
- */
-proto.mullvad_daemon.management_interface.GeoIpLocation.prototype.getObfuscatorHostname = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 11, ""));
-};
-
-
-/**
- * @param {string} value
- * @return {!proto.mullvad_daemon.management_interface.GeoIpLocation} returns this
- */
-proto.mullvad_daemon.management_interface.GeoIpLocation.prototype.setObfuscatorHostname = function(value) {
-  return jspb.Message.setField(this, 11, value);
-};
-
-
-/**
- * Clears the field making it undefined.
- * @return {!proto.mullvad_daemon.management_interface.GeoIpLocation} returns this
- */
-proto.mullvad_daemon.management_interface.GeoIpLocation.prototype.clearObfuscatorHostname = function() {
-  return jspb.Message.setField(this, 11, undefined);
-};
-
-
-/**
- * Returns whether this field is set.
- * @return {boolean}
- */
-proto.mullvad_daemon.management_interface.GeoIpLocation.prototype.hasObfuscatorHostname = function() {
-  return jspb.Message.getField(this, 11) != null;
 };
 
 

--- a/mullvad-daemon/src/tunnel.rs
+++ b/mullvad-daemon/src/tunnel.rs
@@ -88,13 +88,9 @@ impl ParametersGenerator {
 
         let relays = inner.last_generated_relays.as_ref()?;
 
-        let (entry, exit, obfuscator) = match &relays.config {
-            WireguardConfig::Singlehop { exit } => {
-                (None, exit, relays.has_obfuscator.then_some(exit))
-            }
-            WireguardConfig::Multihop { exit, entry } => {
-                (Some(entry), exit, relays.has_obfuscator.then_some(entry))
-            }
+        let (entry, exit) = match &relays.config {
+            WireguardConfig::Singlehop { exit } => (None, exit),
+            WireguardConfig::Multihop { exit, entry } => (Some(entry), exit),
         };
         let location = exit.location.clone();
 
@@ -108,7 +104,6 @@ impl ParametersGenerator {
             mullvad_exit_ip: true,
             hostname: Some(exit.hostname.clone()),
             entry_hostname: entry.map(|relay| relay.hostname.clone()),
-            obfuscator_hostname: obfuscator.map(|relay| relay.hostname.clone()),
         })
     }
 }
@@ -154,7 +149,6 @@ impl InnerParametersGenerator {
 
         self.last_generated_relays = Some(LastSelectedRelays {
             config: inner,
-            has_obfuscator: obfuscator.is_some(),
             server_override,
         });
 
@@ -257,6 +251,5 @@ impl From<Error> for ParameterGenerationError {
 ///     client -> entry -> internet
 struct LastSelectedRelays {
     config: WireguardConfig,
-    has_obfuscator: bool,
     server_override: bool,
 }

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -407,7 +407,6 @@ message GeoIpLocation {
   bool mullvad_exit_ip = 7;
   optional string hostname = 8;
   optional string entry_hostname = 10;
-  optional string obfuscator_hostname = 11;
 }
 
 message TunnelMetadata { string tunnel_interface = 1; }

--- a/mullvad-management-interface/src/types/conversions/location.rs
+++ b/mullvad-management-interface/src/types/conversions/location.rs
@@ -12,7 +12,6 @@ impl From<mullvad_types::location::GeoIpLocation> for proto::GeoIpLocation {
             mullvad_exit_ip: geoip.mullvad_exit_ip,
             hostname: geoip.hostname,
             entry_hostname: geoip.entry_hostname,
-            obfuscator_hostname: geoip.obfuscator_hostname,
         }
     }
 }
@@ -37,7 +36,6 @@ impl TryFrom<proto::GeoIpLocation> for mullvad_types::location::GeoIpLocation {
             mullvad_exit_ip: geoip.mullvad_exit_ip,
             hostname: geoip.hostname,
             entry_hostname: geoip.entry_hostname,
-            obfuscator_hostname: geoip.obfuscator_hostname,
         })
     }
 }

--- a/mullvad-types/src/location.rs
+++ b/mullvad-types/src/location.rs
@@ -160,7 +160,6 @@ pub struct GeoIpLocation {
     pub mullvad_exit_ip: bool,
     pub hostname: Option<String>,
     pub entry_hostname: Option<String>,
-    pub obfuscator_hostname: Option<String>,
 }
 
 impl From<AmIMullvad> for GeoIpLocation {
@@ -180,7 +179,6 @@ impl From<AmIMullvad> for GeoIpLocation {
             mullvad_exit_ip: location.mullvad_exit_ip,
             hostname: None,
             entry_hostname: None,
-            obfuscator_hostname: None,
         }
     }
 }


### PR DESCRIPTION
The `GeoIpLocation` contains this unused field when obfuscation is enabled. Whatever the original motivation for adding this was, it's no longer relevant. So let's remove it.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10584)
<!-- Reviewable:end -->
