### PR TITLE
Pass tunnel state by copying

### DIFF
--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -718,8 +718,9 @@ final class TunnelManager: @unchecked Sendable {
         }
 
         DispatchQueue.main.async {
-            self.observerList.notify { observer in
-                observer.tunnelManager(self, didUpdateTunnelStatus: newTunnelStatus)
+            self.observerList.notify { [tunnelStatus = self.tunnelStatus] observer in
+                observer
+                    .tunnelManager(self, didUpdateTunnelStatus: tunnelStatus)
             }
         }
 


### PR DESCRIPTION
When updating the UI from the Tunnel Manager, we should pass a good, sendable copy of the tunnel state. These changes are required by Xcode 26.5. Thanks to @daneov for coming up with the fix on the spot.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10586)
<!-- Reviewable:end -->
