### PR TITLE
Add resizable image sizing with dynamic size support in UIKit

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -977,6 +977,7 @@
 		F0164EC32B4C49D30020268D /* ShadowsocksLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0164EC22B4C49D30020268D /* ShadowsocksLoaderStub.swift */; };
 		F017F8E02D78AC020076EC01 /* RelayFilterDataSourceItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F017F8DF2D78ABE90076EC01 /* RelayFilterDataSourceItem.swift */; };
 		F01DAE332C2B032A00521E46 /* RelaySelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01DAE322C2B032A00521E46 /* RelaySelection.swift */; };
+		F01FE62A2FDBFD550008E85C /* DynamicImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01FE6292FDBFD4E0008E85C /* DynamicImageView.swift */; };
 		F022EBA62CF0C6AE009484B9 /* ConsolidatedApplicationLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5871FB95254ADE4E0051A0A4 /* ConsolidatedApplicationLog.swift */; };
 		F028A56A2A34D4E700C0CAA3 /* RedeemVoucherViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F028A5692A34D4E700C0CAA3 /* RedeemVoucherViewController.swift */; };
 		F028A56C2A34D8E600C0CAA3 /* AddCreditSucceededViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F028A56B2A34D8E600C0CAA3 /* AddCreditSucceededViewController.swift */; };
@@ -2565,6 +2566,7 @@
 		F01765962E4A324F00262F54 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		F017F8DF2D78ABE90076EC01 /* RelayFilterDataSourceItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayFilterDataSourceItem.swift; sourceTree = "<group>"; };
 		F01DAE322C2B032A00521E46 /* RelaySelection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelaySelection.swift; sourceTree = "<group>"; };
+		F01FE6292FDBFD4E0008E85C /* DynamicImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicImageView.swift; sourceTree = "<group>"; };
 		F027E0982E4A325C00090D26 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		F028A5692A34D4E700C0CAA3 /* RedeemVoucherViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedeemVoucherViewController.swift; sourceTree = "<group>"; };
 		F028A56B2A34D8E600C0CAA3 /* AddCreditSucceededViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddCreditSucceededViewController.swift; sourceTree = "<group>"; };
@@ -4391,6 +4393,7 @@
 		58EFC76F2AFB3FA800E9F4CB /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				F01FE6292FDBFD4E0008E85C /* DynamicImageView.swift */,
 				58CEB2E72AFBB9F300E6E088 /* APIAccess */,
 				7A8A19082CE5FFD7000BCB5B /* DAITA */,
 				7ABBE0122F1A2CDE00AD8176 /* IncludeAllNetworks */,
@@ -6576,6 +6579,7 @@
 				4422C0712CCFF6790001A385 /* UDPOverTCPObfuscationSettingsView.swift in Sources */,
 				7A96E4A52FD2DD9B004B78D7 /* AboutView.swift in Sources */,
 				7A95B67D2D5F7C5B00687524 /* DAITASettingsCoordinator.swift in Sources */,
+				F01FE62A2FDBFD550008E85C /* DynamicImageView.swift in Sources */,
 				7A9CCCC42A96302800DD6A34 /* TunnelCoordinator.swift in Sources */,
 				5827B0A42B0F38FD00CCBBA1 /* EditAccessMethodInteractorProtocol.swift in Sources */,
 				F95CDD9E2EE02A6F000E9D97 /* Hop.swift in Sources */,

--- a/ios/MullvadVPN/Coordinators/Settings/DynamicImageView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/DynamicImageView.swift
@@ -1,0 +1,32 @@
+//
+//  DynamicImageView.swift
+//  MullvadVPN
+//
+//  Created by Mojgan on 2026-06-12.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+import UIKit
+
+class DynamicImageView: UIImageView {
+    private let baseSize: CGFloat
+    private let textStyle: UIFont.TextStyle
+
+    init(image: UIImage?, baseSize: CGFloat = 24.0, textStyle: UIFont.TextStyle = .body) {
+        self.baseSize = baseSize
+        self.textStyle = textStyle
+        super.init(image: image)
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) {
+            (self: Self, previousTraitCollection: UITraitCollection) in
+            self.invalidateIntrinsicContentSize()
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var intrinsicContentSize: CGSize {
+        let scaledSize = UIFontMetrics(forTextStyle: textStyle).scaledValue(for: baseSize)
+        return CGSize(width: scaledSize, height: scaledSize)
+    }
+}

--- a/ios/MullvadVPN/Coordinators/Settings/SettingsFieldValidationErrorContentView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/SettingsFieldValidationErrorContentView.swift
@@ -11,11 +11,11 @@ import UIKit
 class SettingsFieldValidationErrorContentView: UIView, UIContentView {
     let contentView = UIStackView()
 
-    var icon: UIImageView {
-        let view = UIImageView(image: UIImage.Buttons.alert.withTintColor(.dangerColor))
-        view.heightAnchor.constraint(equalToConstant: 18).isActive = true
-        view.widthAnchor.constraint(equalTo: view.heightAnchor, multiplier: 1).isActive = true
-        return view
+    var icon: DynamicImageView {
+        let imageView = DynamicImageView(
+            image: UIImage.Buttons.alert.withTintColor(.dangerColor), baseSize: 18, textStyle: .subheadline)
+        imageView.contentMode = .scaleAspectFit
+        return imageView
     }
 
     var configuration: UIContentConfiguration {
@@ -75,7 +75,12 @@ class SettingsFieldValidationErrorContentView: UIView, UIContentView {
             label.numberOfLines = 0
             label.adjustsFontForContentSizeCategory = true
             label.font = .mullvadTiny
+            label.setContentHuggingPriority(.defaultLow, for: .horizontal)  // Allow growing
+            label.setContentCompressionResistancePriority(.required, for: .horizontal)
             label.textColor = .white
+
+            icon.setContentHuggingPriority(.defaultHigh, for: .horizontal)  // Resist growing
+            icon.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
             let stackView = UIStackView(arrangedSubviews: [icon, label])
             stackView.alignment = .center


### PR DESCRIPTION
This PR introduces the ability to scale the image size with dynamic type support in UIKit when either adding or updating a custom list. clearly, It can be eliminated when we completely migrate to SwiftUI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10592)
<!-- Reviewable:end -->
