### PR TITLE
Fix Electron upgrade causing unpinned window shifting position upwards when spawned

### DIFF
--- a/desktop/packages/mullvad-vpn/src/main/window-controller.ts
+++ b/desktop/packages/mullvad-vpn/src/main/window-controller.ts
@@ -22,7 +22,7 @@ export interface WindowControllerDelegate {
 
 class StandaloneWindowPositioning implements IWindowPositioning {
   public getPosition(window: BrowserWindow): IPosition {
-    const windowBounds = window.getBounds();
+    const windowBounds = window.getContentBounds();
 
     const primaryDisplay = screen.getPrimaryDisplay();
     const workArea = primaryDisplay.workArea;


### PR DESCRIPTION
Replace `getBounds` with `getContentBounds` to get proper window dimensions as `getBounds` returns the outer bounds of the window, but we only want the inner bounds, i.e. 320x568.

Without this fix, the window's vertical position would move slightly upwards every time the window is spawned.

This fix is similar to what was done in the following commit when we upgraded to Electron 42: b166f343

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10598)
<!-- Reviewable:end -->
