### PR TITLE
Improve testConnectWithoutInTunnelIpv6 test

### DIFF
--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/ConnectPage.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/ConnectPage.kt
@@ -12,6 +12,7 @@ import net.mullvad.mullvadvpn.lib.ui.tag.TOP_BAR_SETTINGS_BUTTON_TEST_TAG
 import net.mullvad.mullvadvpn.test.common.constant.VERY_LONG_TIMEOUT
 import net.mullvad.mullvadvpn.test.common.extension.findObjectByCaseInsensitiveText
 import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
+import net.mullvad.mullvadvpn.test.common.extension.hasObjectWithTimeout
 
 class ConnectPage internal constructor() : Page() {
     private val disconnectSelector = By.text("Disconnect")
@@ -122,5 +123,20 @@ class ConnectPage internal constructor() : Page() {
                 VERY_LONG_TIMEOUT,
             )
             .text
+    }
+
+    /**
+     * Makes sure the conection card does not have an IPv6 out address. It is a prerequisite that
+     * the connection card is in an expanded state.
+     */
+    fun ensureNoOutIpv6Address() {
+        val hasObject =
+            uiDevice.hasObjectWithTimeout(
+                // Text exist and contains IPv6 address
+                By.res(LOCATION_INFO_CONNECTION_OUT_TEST_TAG).textContains(":")
+            )
+        if (hasObject) {
+            error("Expected to not find an out IPv6 address, but one was found.")
+        }
     }
 }

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/ConnectionTest.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/ConnectionTest.kt
@@ -415,12 +415,28 @@ class ConnectionTest : EndToEndTest() {
     fun testConnectWithoutInTunnelIpv6() = runTest {
         // Given
         app.launchAndLogIn(accountTestRule.validAccountNumber)
+        // This is to check for a regression when enabling local network sharing without IPv6 in the
+        // tunnel.
+        app.applySettings(localNetworkSharing = true)
 
         on<ConnectPage> { toggleInTunnelIpv6Story() }
         on<ConnectPage> { clickConnect() }
         device.acceptVpnPermissionDialog()
 
         on<ConnectPage> { waitForConnectedLabel() }
+
+        var outIpv4Address = ""
+        on<ConnectPage> {
+            waitForConnectedLabel()
+            outIpv4Address = extractOutIpv4Address()
+            ensureNoOutIpv6Address()
+        }
+
+        val result = connCheckClient.connectionCheck()
+
+        // Check IPs match
+        assertEquals(result.ip, outIpv4Address)
+        assert(result.mullvadExitIp)
     }
 
     @Test


### PR DESCRIPTION
This improves the connect without IPv6 E2E to be more in line with the linear issue so that we can remove the manual step from the test sequence.

To test that this test finds the IPv6 configuration error please run the following:
```
git revert fde04b51be6b541f890abb1bbc0dabc3e995607a
```


<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10600)
<!-- Reviewable:end -->
