### PR TITLE
Pin `taiki-e/install-action` by commit hash

### DIFF
--- a/.github/pinact.yml
+++ b/.github/pinact.yml
@@ -13,9 +13,6 @@ min_age:
 separator: "  # "
 # Actions that intentionally aren't pinned to a verifiable version tag.
 ignore_actions:
-  # Ships per-tool branches (e.g. cargo-shear), not semver release tags.
-  - name: taiki-e/install-action
-    ref: cargo-shear
   # Pinned to a master-branch commit SHA; there's no release tag to verify
   # the version comment against. ref: .* so bumping the SHA needs no edit here.
   - name: mristin/opinionated-commit-message

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -5,7 +5,8 @@ on:
     paths:
       - "**"
       - "!**/**.md"
-      - "!.github/workflows/**"
+      - "!.github/**"
+      - ".github/actions/mullvad-build-env"
       - ".github/workflows/daemon.yml"
       - "!.github/CODEOWNERS"
       - "!android/**"

--- a/.github/workflows/rust-unused-dependencies.yml
+++ b/.github/workflows/rust-unused-dependencies.yml
@@ -18,7 +18,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install cargo-shear
-        uses: taiki-e/install-action@cargo-shear
+        uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154  # v2.81.8
+        with:
+          tool: cargo-shear
 
       - name: Run cargo shear in all workspaces
         shell: bash


### PR DESCRIPTION
Allows us to pin the `taiki-e/install-action` and avoid the pinact ignore on it. This is cleaner and safer.

Related to #10530

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10605)
<!-- Reviewable:end -->
