### PR TITLE
Ignore `esbuild` vulnerabilities for 2 months

### DIFF
--- a/desktop/osv-scanner.toml
+++ b/desktop/osv-scanner.toml
@@ -5,3 +5,15 @@
 id = "CVE-2024-21528"  # GHSA-g974-hxvm-x689
 ignoreUntil = 2026-08-16  # The vulnerability is ignored for 4 months as no patch for the affected library exists and we can not address the vulnerability without migrating to another library, which is no minor feat.
 reason = "There is no fix yet and we don't send untrusted input to the first argument of addTranslations"
+
+# esbuild: Missing binary integrity verification in Deno module enables remote code execution via NPM_CONFIG_REGISTRY
+[[IgnoredVulns]]
+id = "GHSA-gv7w-rqvm-qjhr"  # GHSA-gv7w-rqvm-qjhr
+ignoreUntil = 2026-08-16  # The vulnerability is ignored for 2 months as we do not use Deno and as such are not affected. We can not upgrade esbuild until we have first upgraded vite from 7 to 8.
+reason = "We do not use Deno."
+
+# esbuild: esbuild allows arbitrary file read when running the development server on Windows
+[[IgnoredVulns]]
+id = " GHSA-g7r4-m6w7-qqqr "  # GHSA-g7r4-m6w7-qqqr
+ignoreUntil = 2026-08-16  # The vulnerability is ignored for 2 months as any files readable by the user account are available to read by a process invoked by the user, without using esbuild to achieve it. We can not upgrade esbuild until we have first upgraded vite from 7 to 8.
+reason = "The esbuild development server is run on developer systems where dependencies can already directly read all the files that the user account has access to. Using esbuild to achieve this is not necessary."


### PR DESCRIPTION
Note: No `CVE` number was assigned to these vulnerabilities, hence why I'm only using the GHSA id.

Ignore two `esbuild` vulnerabilities as we are unable to address them before upgrading `vite` to version 8, which will happen in: DES-2929

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10611)
<!-- Reviewable:end -->
