### PR TITLE
Change default MultihopStateV2 in Settings init to .whenNeeded

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -33,6 +33,9 @@ Line wrap the file at 100 chars.                                              Th
 - Stop logging access method credentials in logs.
 - UI crash when interacting with the tunnel.
 
+### Changed
+- "When needed" is now the default multihop setting
+
 ## [2026.2 - 2026-04-21]
 ### Add
 - Add support for "Force all apps", which mitigates [TunnelCrack] attacks.

--- a/ios/MullvadSettings/TunnelSettingsV8.swift
+++ b/ios/MullvadSettings/TunnelSettingsV8.swift
@@ -51,7 +51,7 @@ public struct TunnelSettingsV8: Codable, Equatable, TunnelSettings, Sendable {
         dnsSettings: DNSSettings = DNSSettings(),
         wireGuardObfuscation: WireGuardObfuscationSettings = WireGuardObfuscationSettings(),
         tunnelQuantumResistance: TunnelQuantumResistance = .on,
-        tunnelMultihopState: MultihopStateV2 = .never,
+        tunnelMultihopState: MultihopStateV2 = .whenNeeded,
         daita: DAITASettings = DAITASettings(),
         includeAllNetworks: IncludeAllNetworksSettings = IncludeAllNetworksSettings(),
         ipVersion: IPVersion = .automatic

--- a/ios/MullvadVPNTests/MullvadREST/Relay/MultihopValidatorTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/MultihopValidatorTests.swift
@@ -78,7 +78,8 @@ class MultihopValidatorTests: XCTestCase {
 
     func testSelectRelayWithMultihopWhenNeededAndFiltersWillOverride() throws {
         let settings = LatestTunnelSettings(
-            relayConstraints: multihopWithFiltersConstraints
+            relayConstraints: multihopWithFiltersConstraints,
+            tunnelMultihopState: .never
         )
 
         let validator = MultihopValidator(tunnelSettings: settings, relaySelector: relaySelector)
@@ -90,7 +91,8 @@ class MultihopValidatorTests: XCTestCase {
         constraints.entryLocations = .any
 
         let settings = LatestTunnelSettings(
-            relayConstraints: constraints
+            relayConstraints: constraints,
+            tunnelMultihopState: .never
         )
 
         let validator = MultihopValidator(tunnelSettings: settings, relaySelector: relaySelector)
@@ -133,7 +135,8 @@ class MultihopValidatorTests: XCTestCase {
 
     func testSelectAutomaticEntryRelayWithFiltersWillOverride() throws {
         let settings = LatestTunnelSettings(
-            relayConstraints: multihopWithFiltersConstraints
+            relayConstraints: multihopWithFiltersConstraints,
+            tunnelMultihopState: .never
         )
 
         let validator = MultihopValidator(tunnelSettings: settings, relaySelector: relaySelector)

--- a/ios/MullvadVPNTests/MullvadREST/Relay/RelayPickingTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/RelayPickingTests.swift
@@ -46,7 +46,7 @@ class RelayPickingTests: XCTestCase {
             exitLocations: .only(UserSelectedRelays(locations: [.hostname("se", "got", "se10-wireguard")]))
         )
 
-        var settings = LatestTunnelSettings()
+        var settings = LatestTunnelSettings(tunnelMultihopState: .always)
         settings.relayConstraints = constraints
 
         let picker = MultihopPicker(
@@ -67,7 +67,7 @@ class RelayPickingTests: XCTestCase {
             exitLocations: .only(UserSelectedRelays(locations: [.hostname("se", "got", "se10-wireguard")]))
         )
 
-        var settings = LatestTunnelSettings()
+        var settings = LatestTunnelSettings(tunnelMultihopState: .always)
         settings.relayConstraints = constraints
 
         let picker = MultihopPicker(
@@ -118,7 +118,7 @@ class RelayPickingTests: XCTestCase {
             exitLocations: .only(UserSelectedRelays(locations: [.hostname("se", "got", "se10-wireguard")]))
         )
 
-        var settings = LatestTunnelSettings()
+        var settings = LatestTunnelSettings(tunnelMultihopState: .never)
         settings.relayConstraints = constraints
         settings.daita = DAITASettings(daitaState: .on)
 

--- a/ios/MullvadVPNTests/MullvadVPN/View controllers/Filter/FilterDescriptorTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/View controllers/Filter/FilterDescriptorTests.swift
@@ -83,14 +83,14 @@ struct FilterDescriptorTests {
             ),
             // DAITA on: exit needs DAITA description (no auto routing, no multihop)
             (
-                LatestTunnelSettings(daita: DAITASettings(daitaState: .on)),
+                LatestTunnelSettings(tunnelMultihopState: .never, daita: DAITASettings(daitaState: .on)),
                 RelayCandidates(entryRelays: nil, exitRelays: [esMad1]),
                 true,
                 [FilterDescription.daita],
                 MultihopContext.exit
             ),
             (
-                LatestTunnelSettings(daita: DAITASettings(daitaState: .off)),
+                LatestTunnelSettings(tunnelMultihopState: .never, daita: DAITASettings(daitaState: .off)),
                 RelayCandidates(entryRelays: nil, exitRelays: [esMad1, seSto6]),
                 true,
                 [FilterDescription.none],

--- a/ios/MullvadVPNUITests/SelectLocationTests.swift
+++ b/ios/MullvadVPNUITests/SelectLocationTests.swift
@@ -56,7 +56,7 @@ class SelectLocationTests: LoggedInWithTimeUITestCase {
             .tapSettingsButton()
 
         SettingsPage(app)
-            .verifyMultihop(state: .never)
+            .verifyMultihop(state: .whenNeeded)
             .tapDoneButton()
 
         TunnelControlPage(app)
@@ -64,7 +64,7 @@ class SelectLocationTests: LoggedInWithTimeUITestCase {
 
         SelectLocationPage(app)
             .tapMenuButton()
-            .verifyMultihopState(.never)
+            .verifyMultihopState(.whenNeeded)
             .setMultihopState(.always)
             .tapDoneButton()
 
@@ -72,7 +72,7 @@ class SelectLocationTests: LoggedInWithTimeUITestCase {
             .tapSettingsButton()
 
         SettingsPage(app)
-            .verifyMultihop(state: .never)
+            .verifyMultihop(state: .always)
             .tapDoneButton()
     }
 


### PR DESCRIPTION
This changes the default multihop mode in a newly constructed tunnel settings from `.never` to `.whenNeeded`. It has been verified that, on a new install, this results in the multihop mode being When Needed.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10612)
<!-- Reviewable:end -->
