### PR TITLE
Make relay selector not depend on custom lists

### DIFF
--- a/mullvad-daemon/src/api.rs
+++ b/mullvad-daemon/src/api.rs
@@ -4,7 +4,7 @@ use std::net::SocketAddr;
 use crate::DaemonCommand;
 #[cfg(target_os = "android")]
 use crate::DaemonEventSender;
-use crate::relay_selector::RelaySelector;
+use crate::relay_selector::RelaySelectorIO;
 use futures::{StreamExt, channel::mpsc};
 use mullvad_api::AddressCache;
 use mullvad_api::FileAddressCacheBacking;
@@ -24,14 +24,14 @@ use talpid_types::net::TransportProtocol;
 use talpid_types::net::{AllowedClients, Connectivity, proxy::CustomProxy};
 
 pub struct DaemonAccessMethodResolver {
-    relay_selector: RelaySelector,
+    relay_selector: RelaySelectorIO,
     encrypted_dns_proxy_cache: EncryptedDnsProxyState,
     address_cache: AddressCache<FileAddressCacheBacking>,
 }
 
 impl DaemonAccessMethodResolver {
     pub fn new(
-        relay_selector: RelaySelector,
+        relay_selector: RelaySelectorIO,
         encrypted_dns_proxy_cache: EncryptedDnsProxyState,
         address_cache: AddressCache<FileAddressCacheBacking>,
     ) -> Self {

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -31,7 +31,7 @@ mod tunnel;
 pub mod version;
 
 use crate::{
-    relay_list::parsed_relays::parse_relays_from_file, relay_selector::RelaySelector,
+    relay_list::parsed_relays::parse_relays_from_file, relay_selector::RelaySelectorIO,
     target_state::PersistentTargetState,
 };
 use api::DaemonAccessMethodResolver;
@@ -691,7 +691,7 @@ pub struct Daemon {
     api_runtime: mullvad_api::Runtime,
     api_handle: mullvad_api::rest::MullvadRestHandle,
     version_handle: version::router::VersionRouterHandle,
-    relay_selector: RelaySelector,
+    relay_selector: RelaySelectorIO,
     relay_list_updater: RelayListUpdaterHandle,
     parameters_generator: tunnel::ParametersGenerator,
     shutdown_tasks: Vec<Pin<Box<dyn Future<Output = ()> + Send + Sync>>>,
@@ -768,7 +768,7 @@ impl Daemon {
             // TODO: This should preferably be done once, by the relay list updater.
             let initial_relay_list =
                 initial_relay_list.apply_overrides(settings.relay_overrides.clone());
-            RelaySelector::from_settings(
+            RelaySelectorIO::from_settings(
                 settings.to_settings(),
                 initial_relay_list.clone(),
                 initial_bridge_list.clone(),

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -1,6 +1,6 @@
 use crate::{
     DaemonCommand, DaemonCommandSender, account_history, device,
-    relay_selector::{RelaySelector, RelaySelectorServiceImpl},
+    relay_selector::{RelaySelectorIO, RelaySelectorServiceImpl},
 };
 use futures::{
     StreamExt,
@@ -1367,7 +1367,7 @@ impl ManagementInterfaceServer {
         rpc_socket_path: PathBuf,
         app_upgrade_broadcast: AppUpgradeBroadcast,
         log_reload_handle: crate::logging::LogHandle,
-        relay_selector: RelaySelector,
+        relay_selector: RelaySelectorIO,
     ) -> Result<ManagementInterfaceServer, Error> {
         let subscriptions = Arc::<Mutex<Vec<EventsListenerSender>>>::default();
 

--- a/mullvad-daemon/src/migrations/multihop/settings/v17.rs
+++ b/mullvad-daemon/src/migrations/multihop/settings/v17.rs
@@ -11,6 +11,7 @@ use anyhow::Context;
 use mullvad_relay_selector::query::builder::RelayQueryBuilder;
 use mullvad_relay_selector::query::{Hops, RelayQuery};
 use mullvad_relay_selector::{CustomListProvider, GetRelay, RelaySelector, WireguardConfig};
+use mullvad_types::relay_selector::ResolvedLocationConstraint;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashSet;
@@ -76,11 +77,13 @@ impl From<Settings> for RelayQuery {
         } else {
             builder
         };
-        let builder = if let Constraint::Only(location) = relay_settings.location {
-            builder.location(location)
-        } else {
-            builder
-        };
+        let builder = builder.location(ResolvedLocationConstraint::from_constraint(
+            match relay_settings.location {
+                Constraint::Any => mullvad_types::constraints::Constraint::Any,
+                Constraint::Only(loc) => mullvad_types::constraints::Constraint::Only(loc.into()),
+            },
+            &value.custom_lists.into(),
+        ));
 
         // tunnel options
         let daita = value.tunnel_options.wireguard.daita;
@@ -107,9 +110,8 @@ impl Settings {
 
     /// Run the relay selector to find out if "Magic multihop" is required to connect or not.
     pub fn check_magic_mulithop(mut self) -> anyhow::Result<Self> {
-        let relay_selector = RelaySelector::load()
-            .context("Failed to initialize relay selector. Skipping migration.")?
-            .with_config(self.custom_lists.clone());
+        let relay_selector = RelaySelectorIO::load(self.custom_lists.clone())
+            .context("Failed to initialize relay selector. Skipping migration.")?;
         // Query the relay selector for entry relay
         // If an entry relay needs to be selected even though multihop is not explicitly enabled, the
         // entry might be needed to unblock the user post-migration.

--- a/mullvad-daemon/src/relay_list/mod.rs
+++ b/mullvad-daemon/src/relay_list/mod.rs
@@ -21,7 +21,7 @@ use mullvad_types::relay_list::{BridgeList, RelayList};
 use talpid_future::retry::{ExponentialBackoff, Jittered, retry_future};
 use talpid_types::ErrorExt;
 
-use crate::relay_selector::RelaySelector;
+use crate::relay_selector::RelaySelectorIO;
 
 /// How often the updater should wake up to check the cache of the in-memory cache of relays.
 /// This check is very cheap. The only reason to not have it very often is because if downloading
@@ -88,12 +88,12 @@ pub(crate) struct RelayListUpdater {
     bridge_list: BridgeList,
     overrides: Vec<RelayOverride>,
     // The relay selector will only ever see the relay list with IP overrides applied.
-    relay_selector: RelaySelector,
+    relay_selector: RelaySelectorIO,
 }
 
 impl RelayListUpdater {
     pub fn spawn(
-        selector: RelaySelector,
+        selector: RelaySelectorIO,
         api_handle: MullvadRestHandle,
         cache_dir: &Path,
         overrides: Vec<RelayOverride>,

--- a/mullvad-daemon/src/relay_selector/mod.rs
+++ b/mullvad-daemon/src/relay_selector/mod.rs
@@ -8,8 +8,7 @@ use std::sync::{Arc, Mutex};
 
 use mullvad_relay_selector::query::RelayQuery;
 use mullvad_relay_selector::{
-    CustomListProvider, EntrySpecificConstraints, Error, GetRelay, RETRY_ORDER,
-    RelaySelector as Impl,
+    CustomListProvider, EntrySpecificConstraints, Error, GetRelay, RETRY_ORDER, RelaySelector,
 };
 use mullvad_types::custom_list::CustomListsSettings;
 use mullvad_types::relay_list::{BridgeList, RelayList};
@@ -17,24 +16,22 @@ use mullvad_types::settings::Settings;
 use talpid_types::net::IpAvailability;
 
 #[derive(Clone)]
-pub struct RelaySelector(Impl<Config>);
+pub struct RelaySelectorIO {
+    inner: RelaySelector,
+    config: Config,
+}
 
-impl Deref for RelaySelector {
-    type Target = Impl<Config>;
+impl Deref for RelaySelectorIO {
+    type Target = RelaySelector;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.inner
     }
 }
 
-pub trait RelaySelectorIO {
-    /// Initialize relay selector state from disk, loading any cached relay list.
-    fn load() -> io::Result<Box<Self>>;
-}
-
-impl RelaySelectorIO for Impl {
+impl RelaySelectorIO {
     #[cfg(not(test))]
-    fn load() -> io::Result<Box<Self>> {
+    pub fn load(custom_lists: CustomListsSettings) -> io::Result<Self> {
         use crate::relay_list::parsed_relays::parse_relays_from_file;
 
         let cache_dir = mullvad_paths::get_cache_dir()
@@ -46,23 +43,35 @@ impl RelaySelectorIO for Impl {
         let initial_relay_list = parse_relays_from_file(&cache_dir, &config_dir)
             .inspect_err(|err| log::error!("{err}"))
             .ok();
-        let relay_selector = {
+        let inner = {
             let (initial_relay_list, initial_bridge_list) = initial_relay_list
                 .clone()
                 .map(mullvad_api::CachedRelayList::into_internal_repr)
                 .unwrap_or_default();
-            Impl::new(initial_relay_list.clone(), initial_bridge_list.clone())
+            RelaySelector::new(initial_relay_list.clone(), initial_bridge_list.clone())
         };
-        Ok(Box::new(relay_selector))
+        Ok(RelaySelectorIO {
+            inner,
+            config: Config {
+                query: Default::default(),
+                custom_lists: Arc::new(Mutex::new(custom_lists)),
+            },
+        })
     }
     #[cfg(test)]
-    fn load() -> io::Result<Box<Self>> {
-        let relay_selector = {
+    pub fn load(custom_lists: CustomListsSettings) -> io::Result<Self> {
+        let inner = {
             let (initial_relay_list, initial_bridge_list): (RelayList, BridgeList) =
                 Default::default();
-            Impl::new(initial_relay_list.clone(), initial_bridge_list.clone())
+            RelaySelector::new(initial_relay_list.clone(), initial_bridge_list.clone())
         };
-        Ok(Box::new(relay_selector))
+        Ok(RelaySelectorIO {
+            inner,
+            config: Config {
+                query: Default::default(),
+                custom_lists: Arc::new(Mutex::new(custom_lists)),
+            },
+        })
     }
 }
 
@@ -106,7 +115,7 @@ impl CustomListProvider for Config {
     }
 }
 
-impl RelaySelector {
+impl RelaySelectorIO {
     pub fn create() -> Option<Self> {
         todo!("implement")
     }
@@ -115,22 +124,22 @@ impl RelaySelector {
         settings: Settings,
         relays: RelayList,
         bridges: BridgeList,
-    ) -> RelaySelector {
+    ) -> RelaySelectorIO {
         let config = Config::from(settings);
-        let relay_selector = Impl::new(relays, bridges).with_config(config);
-        RelaySelector(relay_selector)
+        let inner = RelaySelector::new(relays, bridges);
+        RelaySelectorIO { inner, config }
     }
 
     /// Update the relay selector config.
     pub fn set_config(&self, settings: Settings) {
-        let config = &self.0.config;
+        let config = &self.config;
         *config.custom_lists.lock().unwrap() = settings.custom_lists.clone();
         *config.query.lock().unwrap() = RelayQuery::from(settings);
     }
 
     /// Update only the custom list settings used for location filtering.
     pub fn set_custom_lists(&self, custom_lists: CustomListsSettings) {
-        let config = &self.0.config;
+        let config = &self.config;
         *config.custom_lists.lock().unwrap() = custom_lists;
     }
 

--- a/mullvad-daemon/src/relay_selector/service.rs
+++ b/mullvad-daemon/src/relay_selector/service.rs
@@ -2,15 +2,15 @@
 
 use mullvad_management_interface::types::relay_selector as proto;
 use mullvad_management_interface::{RelaySelectorService, Request, Response, Status};
-use mullvad_types::relay_selector::Predicate;
+use mullvad_relay_selector::CustomListProvider;
 
-use crate::relay_selector::RelaySelector;
+use crate::relay_selector::RelaySelectorIO;
 
 /// The relay selector exposed as a gRPC service. See `relay_selector.proto` for API.
-pub struct RelaySelectorServiceImpl(RelaySelector);
+pub struct RelaySelectorServiceImpl(RelaySelectorIO);
 
 impl RelaySelectorServiceImpl {
-    pub fn new(relay_selector: RelaySelector) -> Self {
+    pub fn new(relay_selector: RelaySelectorIO) -> Self {
         RelaySelectorServiceImpl(relay_selector)
     }
 }
@@ -22,7 +22,7 @@ impl RelaySelectorService for RelaySelectorServiceImpl {
         predicate: Request<proto::Predicate>,
     ) -> Result<Response<proto::RelayPartitions>, Status> {
         let predicate = predicate.into_inner();
-        let predicate = Predicate::try_from(predicate)?;
+        let predicate = predicate.into_domain(&self.0.config.custom_lists())?;
         let partitions = self.0.partition_relays(predicate);
         let partitions = proto::RelayPartitions::from(partitions);
         Ok(Response::new(partitions))

--- a/mullvad-daemon/src/tunnel.rs
+++ b/mullvad-daemon/src/tunnel.rs
@@ -17,7 +17,7 @@ use talpid_types::net::{obfuscation::Obfuscators, wireguard};
 use talpid_types::{ErrorExt, net::IpAvailability, tunnel::ParameterGenerationError};
 
 use crate::device::{AccountManagerHandle, Error as DeviceError, PrivateAccountAndDevice};
-use crate::relay_selector::RelaySelector;
+use crate::relay_selector::RelaySelectorIO;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -38,7 +38,7 @@ pub enum Error {
 pub(crate) struct ParametersGenerator(Arc<Mutex<InnerParametersGenerator>>);
 
 struct InnerParametersGenerator {
-    relay_selector: RelaySelector,
+    relay_selector: RelaySelectorIO,
     relay_settings: RelaySettings,
     tunnel_options: TunnelOptions,
     account_manager: AccountManagerHandle,
@@ -50,7 +50,7 @@ impl ParametersGenerator {
     /// Constructs a new tunnel parameters generator.
     pub fn new(
         account_manager: AccountManagerHandle,
-        relay_selector: RelaySelector,
+        relay_selector: RelaySelectorIO,
         relay_settings: RelaySettings,
         tunnel_options: TunnelOptions,
     ) -> Self {

--- a/mullvad-management-interface/src/types/conversions/relay_selector.rs
+++ b/mullvad-management-interface/src/types/conversions/relay_selector.rs
@@ -1,9 +1,10 @@
 use mullvad_types::{
     constraints::Constraint,
+    custom_list::CustomListsSettings,
     relay_list::Relay,
     relay_selector::{
         EntryConstraints, EntrySpecificConstraints, ExitConstraints, MultihopConstraints,
-        Predicate, Reason, RelayPartitions,
+        Predicate, Reason, RelayPartitions, ResolvedLocationConstraint,
     },
 };
 
@@ -12,39 +13,40 @@ use crate::types::{
 };
 use crate::types::{relay_constraints::providers_constraint_from_proto, relay_selector as proto};
 
-impl TryFrom<proto::Predicate> for Predicate {
-    type Error = FromProtobufTypeError;
-
-    fn try_from(predicate: proto::Predicate) -> Result<Self, Self::Error> {
-        let Some(context) = predicate.context else {
+impl proto::Predicate {
+    pub fn into_domain(
+        self,
+        custom_lists: &CustomListsSettings,
+    ) -> Result<Predicate, FromProtobufTypeError> {
+        let Some(context) = self.context else {
             return Err(FromProtobufTypeError::invalid_argument(
                 "context must be provided",
             ));
         };
         match context {
-            proto::predicate::Context::Singlehop(constraints) => {
-                EntryConstraints::try_from(constraints).map(Self::Singlehop)
-            }
-            proto::predicate::Context::Autohop(constraints) => {
-                EntryConstraints::try_from(constraints).map(Self::Autohop)
-            }
+            proto::predicate::Context::Singlehop(constraints) => constraints
+                .into_domain(custom_lists)
+                .map(Predicate::Singlehop),
+            proto::predicate::Context::Autohop(constraints) => constraints
+                .into_domain(custom_lists)
+                .map(Predicate::Autohop),
             proto::predicate::Context::Entry(proto::MultiHopConstraints {
                 entry: Some(entry),
                 exit: Some(exit),
             }) => {
-                let entry = EntryConstraints::try_from(entry)?;
-                let exit = ExitConstraints::try_from(exit)?;
+                let entry = entry.into_domain(custom_lists)?;
+                let exit = exit.into_domain(custom_lists)?;
                 let constraints = MultihopConstraints { entry, exit };
-                Ok(Self::Entry(constraints))
+                Ok(Predicate::Entry(constraints))
             }
             proto::predicate::Context::Exit(proto::MultiHopConstraints {
                 entry: Some(entry),
                 exit: Some(exit),
             }) => {
-                let entry = EntryConstraints::try_from(entry)?;
-                let exit = ExitConstraints::try_from(exit)?;
+                let entry = entry.into_domain(custom_lists)?;
+                let exit = exit.into_domain(custom_lists)?;
                 let constraints = MultihopConstraints { entry, exit };
-                Ok(Self::Exit(constraints))
+                Ok(Predicate::Exit(constraints))
             }
             proto::predicate::Context::Entry(_) | proto::predicate::Context::Exit(_) => Err(
                 FromProtobufTypeError::invalid_argument("entry + exit must be provided"),
@@ -53,19 +55,19 @@ impl TryFrom<proto::Predicate> for Predicate {
     }
 }
 
-impl TryFrom<proto::EntryConstraints> for EntryConstraints {
-    type Error = FromProtobufTypeError;
-
-    fn try_from(
-        proto::EntryConstraints {
+impl proto::EntryConstraints {
+    fn into_domain(
+        self,
+        custom_lists: &CustomListsSettings,
+    ) -> Result<EntryConstraints, FromProtobufTypeError> {
+        let proto::EntryConstraints {
             general_constraints,
             obfuscation_settings,
             daita_settings,
             ip_version,
-        }: proto::EntryConstraints,
-    ) -> Result<Self, Self::Error> {
+        } = self;
         let general = general_constraints
-            .map(ExitConstraints::try_from)
+            .map(|gc| gc.into_domain(custom_lists))
             .transpose()?
             .unwrap_or_default();
 
@@ -100,20 +102,22 @@ impl TryFrom<proto::EntryConstraints> for EntryConstraints {
     }
 }
 
-impl TryFrom<proto::ExitConstraints> for ExitConstraints {
-    type Error = FromProtobufTypeError;
-
-    fn try_from(
-        proto::ExitConstraints {
+impl proto::ExitConstraints {
+    fn into_domain(
+        self,
+        custom_lists: &CustomListsSettings,
+    ) -> Result<ExitConstraints, FromProtobufTypeError> {
+        let proto::ExitConstraints {
             location,
             providers,
             ownership,
-        }: proto::ExitConstraints,
-    ) -> Result<Self, Self::Error> {
-        let location: Constraint<_> = location
+        } = self;
+        let location_constraint: Constraint<_> = location
             .map(mullvad_types::relay_constraints::LocationConstraint::try_from)
             .transpose()?
             .into();
+        let location =
+            ResolvedLocationConstraint::from_constraint(location_constraint, custom_lists);
         let providers = providers_constraint_from_proto(&providers);
         let ownership = try_ownership_constraint_from_i32(ownership)?;
 

--- a/mullvad-relay-selector/src/relay_selector/filter.rs
+++ b/mullvad-relay-selector/src/relay_selector/filter.rs
@@ -1,17 +1,13 @@
-use crate::CustomListProvider;
-
 use super::{
     AnnotatedRelayList, RelaySelector,
     endpoint_set::{RelayEndpointSet, Verdict, VerdictExt},
 };
 use mullvad_types::{
     constraints::{Constraint, Match},
-    custom_list::CustomListsSettings,
-    relay_constraints::{GeographicLocationConstraint, LocationConstraint},
     relay_list::{WireguardRelay, WireguardRelayEndpointData},
     relay_selector::{
         EntryConstraints, EntrySpecificConstraints, ExitConstraints, MultihopConstraints,
-        Predicate, Reason, RelayPartitions,
+        Predicate, Reason, RelayPartitions, ResolvedLocationConstraint,
     },
 };
 
@@ -72,26 +68,23 @@ impl AutohopPartition {
     }
 }
 
-impl<C: CustomListProvider> RelaySelector<C> {
+impl RelaySelector {
     /// As opposed to the prior [`Self::get_relay_by_query`], this function is stateless with
     /// regards to any particular config / settings, but is stateful in the sense that it works with
     /// the [`RelaySelector`]s current relay list. [`RelaySelector::partition_relays`] is idempotent
     /// if the relay list is pinned.
     pub fn partition_relays(&self, predicate: Predicate) -> RelayPartitions {
         let relays = self.relays.read().unwrap();
-        let custom_lists = self.config.custom_lists();
         match predicate {
-            Predicate::Singlehop(constraints) => {
-                partition_entry(&relays, &constraints, &custom_lists)
-            }
+            Predicate::Singlehop(constraints) => partition_entry(&relays, &constraints),
             Predicate::Autohop(constraints) => {
-                partition_autohop(&relays, constraints, &custom_lists).into_relay_partitions()
+                partition_autohop(&relays, constraints).into_relay_partitions()
             }
             Predicate::Entry(multihop_constraints) => {
-                partition_multihop(&relays, &multihop_constraints, &custom_lists).entries
+                partition_multihop(&relays, &multihop_constraints).entries
             }
             Predicate::Exit(multihop_constraints) => {
-                partition_multihop(&relays, &multihop_constraints, &custom_lists).exits
+                partition_multihop(&relays, &multihop_constraints).exits
             }
         }
     }
@@ -118,35 +111,29 @@ fn partition_by_verdict(
 pub(super) fn partition_entry(
     relays: &AnnotatedRelayList,
     constraints: &EntryConstraints,
-    custom_lists: &CustomListsSettings,
 ) -> RelayPartitions {
     partition_by_verdict(relays, |relay, endpoint_set| {
-        usable_as_entry(relay, endpoint_set, &constraints.entry_specific).and(usable_as_exit(
-            relay,
-            &constraints.general,
-            custom_lists,
-        ))
+        usable_as_entry(relay, endpoint_set, &constraints.entry_specific)
+            .and(usable_as_exit(relay, &constraints.general))
     })
 }
 
 pub(super) fn partition_autohop(
     relays: &AnnotatedRelayList,
     singlehop_constraints: EntryConstraints,
-    custom_lists: &CustomListsSettings,
 ) -> AutohopPartition {
     AutohopPartition {
-        singlehop: partition_entry(relays, &singlehop_constraints, custom_lists),
-        multihop: partition_multihop(relays, &singlehop_constraints.into_autohop(), custom_lists),
+        singlehop: partition_entry(relays, &singlehop_constraints),
+        multihop: partition_multihop(relays, &singlehop_constraints.into_autohop()),
     }
 }
 
 pub(super) fn partition_multihop(
     relays: &AnnotatedRelayList,
     MultihopConstraints { entry, exit }: &MultihopConstraints,
-    custom_lists: &CustomListsSettings,
 ) -> MultiHopPartitions {
-    let mut entries = partition_entry(relays, entry, custom_lists);
-    let mut exits = partition_exit(relays, exit, custom_lists);
+    let mut entries = partition_entry(relays, entry);
+    let mut exits = partition_exit(relays, exit);
 
     remove_conflicting_relay(&mut entries, &mut exits);
 
@@ -156,10 +143,9 @@ pub(super) fn partition_multihop(
 pub(super) fn partition_exit(
     relays: &AnnotatedRelayList,
     constraints: &ExitConstraints,
-    custom_lists: &CustomListsSettings,
 ) -> RelayPartitions {
     partition_by_verdict(relays, |relay, _endpoint_set| {
-        usable_as_exit(relay, constraints, custom_lists)
+        usable_as_exit(relay, constraints)
     })
 }
 
@@ -185,11 +171,10 @@ fn usable_as_exit(
         providers,
         ownership,
     }: &ExitConstraints,
-    custom_lists: &CustomListsSettings,
 ) -> Verdict {
     let ownership = ownership.matches(relay).if_false(Reason::Ownership);
     let providers = providers.matches(relay).if_false(Reason::Providers);
-    let location = location_criteria(relay, location, custom_lists);
+    let location = location_criteria(relay, location.as_ref());
     let active = relay.active.if_false(Reason::Inactive);
 
     ownership.and(providers).and(location).and(active)
@@ -197,17 +182,13 @@ fn usable_as_exit(
 
 fn location_criteria(
     relay: &WireguardRelay,
-    location: &Constraint<LocationConstraint>,
-    custom_lists: &CustomListsSettings,
+    location: Constraint<&ResolvedLocationConstraint>,
 ) -> Verdict {
-    let location_constraint =
-        ResolvedLocationConstraint::from_constraint(location.as_ref(), custom_lists);
-
-    if !location_constraint.matches(relay) {
+    if !location.matches(relay) {
         return Verdict::reject(Reason::Location);
     }
 
-    filter_include_in_country(relay, location_constraint)
+    filter_include_in_country(relay, location)
 }
 
 /// Ensure the same relay cannot be chosen as both entry and exit.
@@ -249,7 +230,7 @@ fn filter_on_daita(filter: Constraint<bool>, relay: &WireguardRelay) -> bool {
 /// constraint targets them at city or hostname level.
 fn filter_include_in_country(
     relay: &WireguardRelay,
-    location_constraint: Constraint<ResolvedLocationConstraint<'_>>,
+    location_constraint: Constraint<&ResolvedLocationConstraint>,
 ) -> Verdict {
     if relay.include_in_country {
         return Verdict::Accept;
@@ -263,57 +244,8 @@ fn filter_include_in_country(
     // It is a country-only match as long as none of the matching constraints
     // is more specific than a country (i.e. city or hostname).
     resolved
-        .into_iter()
+        .iter()
         .filter(|loc| loc.matches(relay))
         .any(|loc| !loc.is_country())
         .if_false(Reason::IncludeInCountry)
-}
-
-/// Wrapper around [`GeographicLocationConstraint`].
-/// Useful for iterating over a set of [`GeographicLocationConstraint`] where custom lists
-/// are considered.
-#[derive(Debug, Clone)]
-pub struct ResolvedLocationConstraint<'a>(Vec<&'a GeographicLocationConstraint>);
-
-impl<'a> ResolvedLocationConstraint<'a> {
-    /// Define the mapping from a [location][`LocationConstraint`] and a set of
-    /// [custom lists][`CustomListsSettings`] to [`ResolvedLocationConstraint`].
-    pub fn from_constraint(
-        location_constraint: Constraint<&'a LocationConstraint>,
-        custom_lists: &'a CustomListsSettings,
-    ) -> Constraint<ResolvedLocationConstraint<'a>> {
-        match location_constraint {
-            Constraint::Any => Constraint::Any,
-            Constraint::Only(location) => Constraint::Only(match location {
-                LocationConstraint::Location(location) => {
-                    ResolvedLocationConstraint(vec![location])
-                }
-                LocationConstraint::CustomList { list_id } => custom_lists
-                    .iter()
-                    .find(|list| list.id() == *list_id)
-                    .map(|custom_list| {
-                        ResolvedLocationConstraint(custom_list.locations.iter().collect())
-                    })
-                    .unwrap_or_else(|| {
-                        log::warn!("Resolved non-existent custom list with id {list_id:?}");
-                        ResolvedLocationConstraint(vec![])
-                    }),
-            }),
-        }
-    }
-}
-
-impl<'a> IntoIterator for &'a ResolvedLocationConstraint<'a> {
-    type Item = &'a GeographicLocationConstraint;
-    type IntoIter = std::iter::Copied<std::slice::Iter<'a, &'a GeographicLocationConstraint>>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.iter().copied()
-    }
-}
-
-impl Match<WireguardRelay> for ResolvedLocationConstraint<'_> {
-    fn matches(&self, relay: &WireguardRelay) -> bool {
-        self.into_iter().any(|location| location.matches(relay))
-    }
 }

--- a/mullvad-relay-selector/src/relay_selector/mod.rs
+++ b/mullvad-relay-selector/src/relay_selector/mod.rs
@@ -95,9 +95,7 @@ impl AnnotatedRelayList {
 }
 
 #[derive(Clone)]
-pub struct RelaySelector<C = ()> {
-    /// TODO: Document
-    pub config: C,
+pub struct RelaySelector {
     // Relays are updated very infrequently, but might conceivably be accessed by multiple readers at
     // the same time.
     pub relays: Arc<RwLock<AnnotatedRelayList>>,
@@ -122,25 +120,14 @@ pub struct GetRelay {
     pub inner: WireguardConfig,
 }
 
-impl RelaySelector<()> {
+impl RelaySelector {
     pub fn new(relays: RelayList, bridges: BridgeList) -> Self {
         RelaySelector {
-            config: (),
             relays: Arc::new(RwLock::new(AnnotatedRelayList::new(relays))),
             bridges: Arc::new(RwLock::new(bridges)),
         }
     }
 
-    pub fn with_config<C: CustomListProvider>(self, config: C) -> RelaySelector<C> {
-        RelaySelector {
-            config,
-            relays: self.relays,
-            bridges: self.bridges,
-        }
-    }
-}
-
-impl<C: CustomListProvider> RelaySelector<C> {
     /// Peek the relay list.
     pub fn relay_list<T>(&self, f: impl Fn(&RelayList) -> T) -> T {
         let relays = self.relays.read().unwrap();
@@ -190,9 +177,8 @@ impl<C: CustomListProvider> RelaySelector<C> {
         // Hold a single read lock for the whole call so the relay we choose during
         // partitioning is the same one we look up in `endpoint_sets` afterwards.
         let annotated = self.relays.read().unwrap();
-        let custom_lists = self.config.custom_lists();
 
-        let inner = select_wireguard_relay(&annotated, &custom_lists, &query)?;
+        let inner = select_wireguard_relay(&annotated, &query)?;
 
         let entry = match &inner {
             WireguardConfig::Singlehop { exit } => exit,
@@ -225,19 +211,18 @@ impl<C: CustomListProvider> RelaySelector<C> {
 /// Select relay(s) matching the constraints, handling singlehop, autohop, and multihop routing.
 fn select_wireguard_relay(
     relays: &AnnotatedRelayList,
-    custom_lists: &CustomListsSettings,
     query: &RelayQuery,
 ) -> Result<WireguardConfig, Error> {
     match &query.hops {
         Hops::Single(constraints) => {
-            let partitions = filter::partition_entry(relays, constraints, custom_lists);
+            let partitions = filter::partition_entry(relays, constraints);
             match helpers::pick_random_relay(&partitions.matches) {
                 Some(exit) => Ok(WireguardConfig::from(Singlehop::new(exit.clone()))),
                 None => Err(Error::NoRelay(Box::new(query.clone()))),
             }
         }
         Hops::Auto(constraints) => {
-            let autohop = filter::partition_autohop(relays, constraints.clone(), custom_lists);
+            let autohop = filter::partition_autohop(relays, constraints.clone());
             // Attempt to pick a single relay that matches all constraints
             if let Some(exit) = helpers::pick_random_relay(&autohop.singlehop.matches) {
                 return Ok(WireguardConfig::from(Singlehop::new(exit.clone())));
@@ -247,7 +232,7 @@ fn select_wireguard_relay(
             select_from_multihop_partitions(autohop.multihop, multihop_constraints)
         }
         Hops::Multi(constraints) => {
-            let partitions = filter::partition_multihop(relays, constraints, custom_lists);
+            let partitions = filter::partition_multihop(relays, constraints);
             select_from_multihop_partitions(partitions, constraints.clone())
         }
     }

--- a/mullvad-relay-selector/src/relay_selector/query.rs
+++ b/mullvad-relay-selector/src/relay_selector/query.rs
@@ -17,12 +17,10 @@ pub use mullvad_types::relay_constraints::{
 use mullvad_types::{
     Intersection,
     constraints::Constraint,
-    relay_constraints::{
-        AllowedIps, Multihop, ObfuscationSettings, RelayConstraints, RelaySettings,
-        WireguardConstraints,
-    },
+    relay_constraints::{AllowedIps, Multihop, RelaySettings},
     relay_selector::{
         EntryConstraints, EntrySpecificConstraints, ExitConstraints, MultihopConstraints,
+        ResolvedLocationConstraint,
     },
     settings::Settings,
     wireguard::QuantumResistantState,
@@ -161,7 +159,10 @@ impl From<Settings> for RelayQuery {
             ip_version: wg.ip_version,
         };
         let exit = ExitConstraints {
-            location: relay_settings.location,
+            location: ResolvedLocationConstraint::from_constraint(
+                relay_settings.location,
+                &settings.custom_lists,
+            ),
             providers: relay_settings.providers,
             ownership: relay_settings.ownership,
         };
@@ -179,7 +180,10 @@ impl From<Settings> for RelayQuery {
             entry: EntryConstraints {
                 entry_specific,
                 general: ExitConstraints {
-                    location: wg.entry_location.clone(),
+                    location: ResolvedLocationConstraint::from_constraint(
+                        wg.entry_location.clone(),
+                        &settings.custom_lists,
+                    ),
                     providers: wg.entry_providers.clone(),
                     ownership: wg.entry_ownership,
                 },
@@ -199,73 +203,6 @@ impl From<Settings> for RelayQuery {
             quantum_resistant: Constraint::Only(
                 settings.tunnel_options.wireguard.quantum_resistant,
             ),
-        }
-    }
-}
-
-impl RelayQuery {
-    /// Convert the query into RelayConstraints and ObfuscationSettings.
-    /// Currently only used by the e2e tests via gRPC.
-    pub fn into_settings(self) -> (RelayConstraints, ObfuscationSettings) {
-        let RelayQuery {
-            hops,
-            allowed_ips,
-            quantum_resistant: _,
-        } = self;
-
-        match hops {
-            Hops::Single(entry) => {
-                let constraints = RelayConstraints {
-                    location: entry.general.location,
-                    providers: entry.general.providers,
-                    ownership: entry.general.ownership,
-                    wireguard_constraints: WireguardConstraints {
-                        ip_version: entry.entry_specific.ip_version,
-                        allowed_ips,
-                        multihop: Multihop::Never,
-                        entry_location: Constraint::Any,
-                        entry_providers: Constraint::Any,
-                        entry_ownership: Constraint::Any,
-                    },
-                };
-                let obfuscation = obfuscation_to_settings(entry.entry_specific.obfuscation);
-                (constraints, obfuscation)
-            }
-            Hops::Auto(entry) => {
-                let constraints = RelayConstraints {
-                    location: entry.general.location,
-                    providers: entry.general.providers,
-                    ownership: entry.general.ownership,
-                    wireguard_constraints: WireguardConstraints {
-                        ip_version: entry.entry_specific.ip_version,
-                        allowed_ips,
-                        multihop: Multihop::Auto,
-                        entry_location: Constraint::Any,
-                        entry_providers: Constraint::Any,
-                        entry_ownership: Constraint::Any,
-                    },
-                };
-                let obfuscation = obfuscation_to_settings(entry.entry_specific.obfuscation);
-                (constraints, obfuscation)
-            }
-            Hops::Multi(MultihopConstraints { entry, exit }) => {
-                let constraints = RelayConstraints {
-                    location: exit.location,
-                    providers: exit.providers,
-                    ownership: exit.ownership,
-                    wireguard_constraints: WireguardConstraints {
-                        ip_version: entry.entry_specific.ip_version,
-                        allowed_ips,
-                        // TODO: Check which variant is true here.
-                        multihop: Multihop::Always,
-                        entry_location: entry.general.location,
-                        entry_providers: entry.general.providers,
-                        entry_ownership: entry.general.ownership,
-                    },
-                };
-                let obfuscation = obfuscation_to_settings(entry.entry_specific.obfuscation);
-                (constraints, obfuscation)
-            }
         }
     }
 }
@@ -292,11 +229,11 @@ pub mod builder {
     use mullvad_types::{
         constraints::Constraint,
         relay_constraints::{
-            LocationConstraint, LwoSettings, ShadowsocksSettings, Udp2TcpObfuscationSettings,
-            WireguardPortSettings,
+            LwoSettings, ShadowsocksSettings, Udp2TcpObfuscationSettings, WireguardPortSettings,
         },
         relay_selector::{
             EntryConstraints, EntrySpecificConstraints, ExitConstraints, MultihopConstraints,
+            ResolvedLocationConstraint,
         },
         wireguard::QuantumResistantState,
     };
@@ -370,8 +307,11 @@ pub mod builder {
     impl<Multihop, Obfuscation> RelayQueryBuilder<Multihop, Obfuscation> {
         /// Configure the exit relay's location. (For singlehop/autohop, the exit is
         /// the only relay; for multihop, the exit is the second hop.)
-        pub fn location(mut self, location: impl Into<LocationConstraint>) -> Self {
-            self.exit.location = Constraint::Only(location.into());
+        pub fn location(
+            mut self,
+            location: impl Into<Constraint<ResolvedLocationConstraint>>,
+        ) -> Self {
+            self.exit.location = location.into();
             self
         }
 
@@ -457,7 +397,7 @@ pub mod builder {
 
     // `.entry_*` only available after `.multihop()`.
     impl<Obfuscation> RelayQueryBuilder<bool, Obfuscation> {
-        pub fn entry(mut self, location: impl Into<LocationConstraint>) -> Self {
+        pub fn entry(mut self, location: impl Into<ResolvedLocationConstraint>) -> Self {
             self.multihop_entry.location = Constraint::Only(location.into());
             self
         }

--- a/mullvad-relay-selector/tests/relay_selector.rs
+++ b/mullvad-relay-selector/tests/relay_selector.rs
@@ -30,7 +30,6 @@ use mullvad_types::{
         RelayListCity, RelayListCountry, ShadowsocksEndpointData, WireguardRelay,
         WireguardRelayEndpointData,
     },
-    settings::Settings,
 };
 use vec1::vec1;
 
@@ -233,7 +232,7 @@ fn unwrap_endpoint(get_result: GetRelay) -> MullvadEndpoint {
 }
 
 fn default_relay_selector() -> RelaySelector {
-    RelaySelector::from_settings(&Settings::default(), RELAYS.clone(), BRIDGES.clone())
+    RelaySelector::new(RELAYS.clone(), BRIDGES.clone())
 }
 
 fn supports_daita(relay: &WireguardRelay) -> bool {
@@ -403,7 +402,7 @@ mod relay_selection {
 
         let bridges = BridgeList::default();
 
-        let relay_selector = RelaySelector::from_settings(&Settings::default(), relays, bridges);
+        let relay_selector = RelaySelector::new(relays, bridges);
         let specific_hostname = "se10-wireguard";
         let specific_location =
             GeographicLocationConstraint::hostname("se", "got", specific_hostname);
@@ -479,8 +478,7 @@ mod relay_selection {
     /// selected.
     #[test]
     fn test_selecting_over_shadowsocks() {
-        let relay_selector =
-            RelaySelector::from_settings(&Settings::default(), RELAYS.clone(), BRIDGES.clone());
+        let relay_selector = RelaySelector::new(RELAYS.clone(), BRIDGES.clone());
 
         let query = RelayQueryBuilder::new().shadowsocks().build();
         assert!(!matches!(query.hops, Hops::Multi(_)));
@@ -501,8 +499,7 @@ mod relay_selection {
     /// Test whether extra Shadowsocks IPs are selected when available
     #[test]
     fn test_selecting_over_shadowsocks_extra_ips() {
-        let relay_selector =
-            RelaySelector::from_settings(&Settings::default(), RELAYS.clone(), BRIDGES.clone());
+        let relay_selector = RelaySelector::new(RELAYS.clone(), BRIDGES.clone());
 
         let query = RelayQueryBuilder::new()
             .location(SHADOWSOCKS_RELAY_LOCATION.clone())
@@ -534,8 +531,7 @@ mod relay_selection {
     /// Test whether Quic is always selected as the obfuscation protocol when Quic is selected.
     #[test]
     fn test_selecting_over_quic() {
-        let relay_selector =
-            RelaySelector::from_settings(&Settings::default(), RELAYS.clone(), BRIDGES.clone());
+        let relay_selector = RelaySelector::new(RELAYS.clone(), BRIDGES.clone());
 
         let query = RelayQueryBuilder::new().quic().build();
         assert!(!matches!(query.hops, Hops::Multi(_)));
@@ -556,8 +552,7 @@ mod relay_selection {
     /// Test LWO relay selection
     #[test]
     fn test_selecting_over_lwo() {
-        let relay_selector =
-            RelaySelector::from_settings(&Settings::default(), RELAYS.clone(), BRIDGES.clone());
+        let relay_selector = RelaySelector::new(RELAYS.clone(), BRIDGES.clone());
 
         let query = RelayQueryBuilder::new().lwo().build();
         assert!(!matches!(query.hops, Hops::Multi(_)));
@@ -586,8 +581,7 @@ mod relay_selection {
             ipv6_addr_in: None,
         }]);
 
-        let relay_selector =
-            RelaySelector::from_settings(&Settings::default(), relay_list, BRIDGES.clone());
+        let relay_selector = RelaySelector::new(relay_list, BRIDGES.clone());
 
         let query_v4 = RelayQueryBuilder::new()
             .location(SHADOWSOCKS_RELAY_LOCATION.clone())
@@ -625,8 +619,7 @@ mod relay_selection {
             ipv6_addr_in: Some(OVERRIDE_IPV6),
         }]);
 
-        let relay_selector =
-            RelaySelector::from_settings(&Settings::default(), relay_list, BRIDGES.clone());
+        let relay_selector = RelaySelector::new(relay_list, BRIDGES.clone());
 
         let query_v6 = RelayQueryBuilder::new()
             .location(SHADOWSOCKS_RELAY_LOCATION.clone())
@@ -822,8 +815,7 @@ mod relay_selection {
     /// to be filtered out.
     #[test]
     fn test_daita() {
-        let relay_selector =
-            RelaySelector::from_settings(&Settings::default(), RELAYS.clone(), BRIDGES.clone());
+        let relay_selector = RelaySelector::new(RELAYS.clone(), BRIDGES.clone());
 
         // Only pick relays that support DAITA
         let query = RelayQueryBuilder::new().daita().build();
@@ -1059,8 +1051,7 @@ mod relay_selection {
                 wireguard,
             }
         };
-        let relay_selector =
-            RelaySelector::from_settings(&Settings::default(), relays, BridgeList::default());
+        let relay_selector = RelaySelector::new(relays, BridgeList::default());
 
         // Country-level multihop must fail: only one relay (`se-sto-wg-204`) is
         // selectable at country level, so no entry/exit pair can be formed.
@@ -1088,7 +1079,8 @@ mod partition_relays {
     use itertools::Itertools;
     use mullvad_relay_selector::{EntryConstraints, ExitConstraints, RelayPartitions};
     use mullvad_types::constraints::Constraint;
-    use mullvad_types::relay_constraints::{LocationConstraint, ShadowsocksSettings};
+    use mullvad_types::relay_constraints::ShadowsocksSettings;
+    use mullvad_types::relay_selector::ResolvedLocationConstraint;
     use std::collections::HashSet;
 
     use super::*;
@@ -1106,11 +1098,7 @@ mod partition_relays {
     fn relay_selector() -> RelaySelector {
         static RELAY_SELECTOR: LazyLock<RelaySelector> = LazyLock::new(|| {
             let (relay_list, bridge_list) = &*RELAYS;
-            RelaySelector::from_settings(
-                &Settings::default(),
-                relay_list.clone(),
-                bridge_list.clone(),
-            )
+            RelaySelector::new(relay_list.clone(), bridge_list.clone())
         });
         RELAY_SELECTOR.clone()
     }
@@ -1207,12 +1195,12 @@ mod partition_relays {
     fn entry_hostname_collision() {
         let relay_selector = relay_selector();
         // Define two distinct Wireguard relays.
-        let wg101 = LocationConstraint::from(GeographicLocationConstraint::hostname(
+        let wg101 = ResolvedLocationConstraint::from(GeographicLocationConstraint::hostname(
             "se",
             "got",
             "se-got-wg-101",
         ));
-        let wg001 = LocationConstraint::from(GeographicLocationConstraint::hostname(
+        let wg001 = ResolvedLocationConstraint::from(GeographicLocationConstraint::hostname(
             "se",
             "got",
             "se-got-wg-001",
@@ -1526,7 +1514,7 @@ mod partition_relays {
             let mut constraints = daita_constraints.clone();
             // Force the entry relay to be a relay without DAITA.
             constraints.general.location =
-                LocationConstraint::from(GeographicLocationConstraint::hostname(
+                ResolvedLocationConstraint::from(GeographicLocationConstraint::hostname(
                     non_daita_relay.location.country.clone(),
                     non_daita_relay.location.city.clone(),
                     non_daita_relay.hostname.clone(),
@@ -1707,7 +1695,7 @@ mod partition_relays {
         let relay_selector = RelaySelector::from(relay_list);
         let results = relay_selector.partition_relays(Predicate::Autohop(EntryConstraints {
             general: ExitConstraints {
-                location: Constraint::Only(LocationConstraint::Location(
+                location: Constraint::Only(ResolvedLocationConstraint::from(
                     GeographicLocationConstraint::Hostname(
                         "country".into(),
                         "city".into(),
@@ -1975,7 +1963,6 @@ mod relay_list_builder {
             BridgeList, EndpointData, RelayList, RelayListCity, RelayListCountry, WireguardRelay,
             WireguardRelayEndpointData,
         },
-        settings::Settings,
     };
     use talpid_types::net::wireguard::PublicKey;
 
@@ -1986,7 +1973,7 @@ mod relay_list_builder {
 
     impl From<RelayListBuilder> for RelaySelector {
         fn from(val: RelayListBuilder) -> Self {
-            RelaySelector::from_settings(&Settings::default(), val.finish(), BridgeList::default())
+            RelaySelector::new(val.finish(), BridgeList::default())
         }
     }
 

--- a/mullvad-types/src/constraints/mod.rs
+++ b/mullvad-types/src/constraints/mod.rs
@@ -133,6 +133,7 @@ impl_intersection_partialeq!(relay_constraints::Ownership);
 impl_intersection_partialeq!(talpid_types::net::TransportProtocol);
 impl_intersection_partialeq!(talpid_types::net::IpVersion);
 impl_intersection_partialeq!(relay_constraints::AllowedIps);
+impl_intersection_partialeq!(crate::relay_selector::ResolvedLocationConstraint);
 
 #[cfg(test)]
 mod tests {

--- a/mullvad-types/src/relay_selector/mod.rs
+++ b/mullvad-types/src/relay_selector/mod.rs
@@ -7,13 +7,67 @@ use talpid_types::net::IpVersion;
 
 use crate::{
     Intersection,
-    constraints::Constraint,
+    constraints::{Constraint, Match},
+    custom_list::CustomListsSettings,
     relay_constraints::{
         GeographicLocationConstraint, LocationConstraint, LwoSettings, ObfuscationMode, Ownership,
         Providers, ShadowsocksSettings, Udp2TcpObfuscationSettings,
     },
     relay_list::WireguardRelay,
 };
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedLocationConstraint(Vec<GeographicLocationConstraint>);
+
+impl ResolvedLocationConstraint {
+    /// Define the mapping from a [location][`LocationConstraint`] and a set of
+    /// [custom lists][`CustomListsSettings`] to [`ResolvedLocationConstraint`].
+    pub fn from_constraint(
+        location_constraint: Constraint<LocationConstraint>,
+        custom_lists: &CustomListsSettings,
+    ) -> Constraint<ResolvedLocationConstraint> {
+        match location_constraint {
+            Constraint::Any => Constraint::Any,
+            Constraint::Only(location) => Constraint::Only(match location {
+                LocationConstraint::Location(location) => {
+                    ResolvedLocationConstraint(vec![location])
+                }
+                LocationConstraint::CustomList { list_id } => custom_lists
+                    .iter()
+                    .find(|list| list.id() == list_id)
+                    .map(|custom_list| {
+                        ResolvedLocationConstraint(custom_list.locations.iter().cloned().collect())
+                    })
+                    .unwrap_or_else(|| {
+                        log::warn!("Resolved non-existent custom list with id {list_id:?}");
+                        ResolvedLocationConstraint(vec![])
+                    }),
+            }),
+        }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &GeographicLocationConstraint> {
+        self.0.iter()
+    }
+}
+
+impl From<GeographicLocationConstraint> for ResolvedLocationConstraint {
+    fn from(value: GeographicLocationConstraint) -> Self {
+        Self(vec![value])
+    }
+}
+
+impl From<GeographicLocationConstraint> for Constraint<ResolvedLocationConstraint> {
+    fn from(value: GeographicLocationConstraint) -> Self {
+        Self::Only(ResolvedLocationConstraint::from(value))
+    }
+}
+
+impl Match<WireguardRelay> for &ResolvedLocationConstraint {
+    fn matches(&self, relay: &WireguardRelay) -> bool {
+        self.iter().any(|location| location.matches(relay))
+    }
+}
 
 /// Specify the constraints that should be applied when selecting relays,
 /// along with a context that may affect the selection behavior.
@@ -41,7 +95,7 @@ pub struct EntrySpecificConstraints {
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Intersection)]
 pub struct ExitConstraints {
-    pub location: Constraint<LocationConstraint>,
+    pub location: Constraint<ResolvedLocationConstraint>,
     pub providers: Constraint<Providers>,
     pub ownership: Constraint<Ownership>,
 }
@@ -176,7 +230,7 @@ impl EntrySpecificConstraints {
 }
 
 impl ExitConstraints {
-    pub fn location(mut self, location: impl Into<LocationConstraint>) -> Self {
+    pub fn location(mut self, location: impl Into<ResolvedLocationConstraint>) -> Self {
         self.location = Constraint::Only(location.into());
         self
     }


### PR DESCRIPTION
Make the relay selector not depend on custom list settings. Instead, it only accepts `ResolvedLocationConstraint` by changing the underlying types in the relay predicates.

The custom list settings get moved to `RelaySelectorIO`.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10620)
<!-- Reviewable:end -->
