### PR TITLE
Remove extraneous whitespace in OSV ignore for `esbuild`

### DIFF
--- a/desktop/osv-scanner.toml
+++ b/desktop/osv-scanner.toml
@@ -14,6 +14,6 @@ reason = "We do not use Deno."
 
 # esbuild: esbuild allows arbitrary file read when running the development server on Windows
 [[IgnoredVulns]]
-id = " GHSA-g7r4-m6w7-qqqr "  # GHSA-g7r4-m6w7-qqqr
+id = "GHSA-g7r4-m6w7-qqqr"  # GHSA-g7r4-m6w7-qqqr
 ignoreUntil = 2026-08-16  # The vulnerability is ignored for 2 months as any files readable by the user account are available to read by a process invoked by the user, without using esbuild to achieve it. We can not upgrade esbuild until we have first upgraded vite from 7 to 8.
 reason = "The esbuild development server is run on developer systems where dependencies can already directly read all the files that the user account has access to. Using esbuild to achieve this is not necessary."


### PR DESCRIPTION
The extra whitespace in `id` for the ignore of `GHSA-g7r4-m6w7-qqqr` causes the entry to not match its identifier, meaning the ignore is not having an effect.

Removing the extra whitespace causes the entry to be matched correctly and the ignoring coming into effect.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10624)
<!-- Reviewable:end -->
