### PR TITLE
Add workaround for DataStore becoming corrupted

### DIFF
--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -21,6 +21,11 @@ Line wrap the file at 100 chars.                                              Th
 * **Fixed**: for any bug fixes.
 * **Security**: in case of vulnerabilities.
 
+## [Unreleased]
+### Fixed
+- Added a workaround for DataStore becoming corrupt due to an upstream issue.
+
+
 ## [android/2026.7] - 2026-06-17
 ### Fixed
 - Fix DAITA performance degradation that occurred when combined with multihop.

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/AppModule.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/AppModule.kt
@@ -5,7 +5,9 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.app.NotificationManagerCompat
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.dataStore
+import co.touchlab.kermit.Logger
 import java.io.File
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
@@ -35,6 +37,7 @@ import net.mullvad.mullvadvpn.lib.repository.UserPreferencesRepository
 import net.mullvad.mullvadvpn.lib.repository.UserPreferencesSerializer
 import net.mullvad.mullvadvpn.lib.usecase.AccountExpiryNotificationActionUseCase
 import net.mullvad.mullvadvpn.repository.UserPreferences
+import net.mullvad.mullvadvpn.repository.copy
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.dsl.createdAtStart
 import org.koin.core.module.dsl.withOptions
@@ -106,6 +109,19 @@ private val Context.userPreferencesStore: DataStore<UserPreferences> by
         fileName = APP_PREFERENCES_NAME,
         serializer = UserPreferencesSerializer,
         produceMigrations = { UserPreferencesMigration.migrations(it, APP_PREFERENCES_NAME) },
+        corruptionHandler =
+            ReplaceFileCorruptionHandler {
+                // HACK: https://issuetracker.google.com/issues/346197747
+                // Due to known issue in DataStore the settings file sometimes get corrupted, to
+                // avoid users getting stuck in a crash loop we reset the settings file.
+                Logger.e(throwable = it) {
+                    "Corruption of DataStore file occurred, restoring preferences file"
+                }
+                UserPreferences.getDefaultInstance().copy {
+                    // We need to mark this as accepted due to otherwise the VPN service won't start
+                    isPrivacyDisclosureAccepted = true
+                }
+            },
     )
 
 class ApplicationScope private constructor(private val cs: CoroutineScope) : CoroutineScope by cs {


### PR DESCRIPTION
Due to a known issue in DataStore the settings file can sometimes become corrupted. When this happens creating and reading from the DataStore will immediately cause an exception causing the app to crash. This means the users will be unable to start the app and VPN. This PR adds a corruption handles that resets the settings file.

https://issuetracker.google.com/issues/346197747

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10631)
<!-- Reviewable:end -->
