### PR TITLE
iOS UITest improvements

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -967,6 +967,9 @@
 		BF434ABF6F9543C9BABD3CBA /* FloatingSearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B364DC07F3CF4B63A5B1BB6C /* FloatingSearchBar.swift */; };
 		C1EA193A1103489C981B6E59 /* EnvironmentValues+DismissSearchFocus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323AB4F0478E4995ABAF99AF /* EnvironmentValues+DismissSearchFocus.swift */; };
 		D56CD86C4435C3F6AF2A2662 /* WireGuardGoTunnelImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD68970B0A1DEEA01FB25D9E /* WireGuardGoTunnelImplementation.swift */; };
+		D59CB43F2FE40B80000B06FB /* BaseUITestCase+ApplogCaptureObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59CB43E2FE40B76000B06FB /* BaseUITestCase+ApplogCaptureObserver.swift */; };
+		D5A6A9D92FE01E40001E4796 /* AppLogCaptureObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A6A9D82FE01E40001E4796 /* AppLogCaptureObserver.swift */; };
+		D5A6A9DC2FE021B8001E4796 /* TestObservationConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A6A9DB2FE021B8001E4796 /* TestObservationConfiguration.swift */; };
 		E10A0001000000000000AB01 /* GotaTunActor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10A0001000000000000AA01 /* GotaTunActor.swift */; };
 		E10A0002000000000000AB01 /* PacketTunnelDebugSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10A0002000000000000AA01 /* PacketTunnelDebugSettings.swift */; };
 		E10A0002000000000000AB02 /* PacketTunnelDebugSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10A0002000000000000AA01 /* PacketTunnelDebugSettings.swift */; };
@@ -2576,6 +2579,9 @@
 		A9F360332AAB626300F53531 /* VPNConnectionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNConnectionProtocol.swift; sourceTree = "<group>"; };
 		B24C2F93919B5526A741ADA8 /* TunnelImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelImplementation.swift; sourceTree = "<group>"; };
 		B364DC07F3CF4B63A5B1BB6C /* FloatingSearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingSearchBar.swift; sourceTree = "<group>"; };
+		D59CB43E2FE40B76000B06FB /* BaseUITestCase+ApplogCaptureObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BaseUITestCase+ApplogCaptureObserver.swift"; sourceTree = "<group>"; };
+		D5A6A9D82FE01E40001E4796 /* AppLogCaptureObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLogCaptureObserver.swift; sourceTree = "<group>"; };
+		D5A6A9DB2FE021B8001E4796 /* TestObservationConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestObservationConfiguration.swift; sourceTree = "<group>"; };
 		D702C13944A82CAF175A4443 /* RustLoggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustLoggingTests.swift; sourceTree = "<group>"; };
 		DD68970B0A1DEEA01FB25D9E /* WireGuardGoTunnelImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireGuardGoTunnelImplementation.swift; sourceTree = "<group>"; };
 		E10A0001000000000000AA01 /* GotaTunActor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunActor.swift; sourceTree = "<group>"; };
@@ -4808,6 +4814,8 @@
 		852969262B4D9C1F007EAD4C /* MullvadVPNUITests */ = {
 			isa = PBXGroup;
 			children = (
+				D5A6A9DA2FE021B0001E4796 /* Configuration */,
+				D5A6A9D72FE01E36001E4796 /* Concerns */,
 				8556EB512B9A1C6900D26DD4 /* MullvadApi.swift */,
 				01C981EA2F45D5C20002D284 /* TunnelControlPageTests.swift */,
 				7A9F29342CAA8823005F2089 /* AccessMethodsTests.swift */,
@@ -4943,6 +4951,23 @@
 				016EE0392F850C5A0035B25C /* WireGuardKeyTests.swift */,
 			);
 			path = MullvadRustRuntimeTests;
+			sourceTree = "<group>";
+		};
+		D5A6A9D72FE01E36001E4796 /* Concerns */ = {
+			isa = PBXGroup;
+			children = (
+				D59CB43E2FE40B76000B06FB /* BaseUITestCase+ApplogCaptureObserver.swift */,
+				D5A6A9D82FE01E40001E4796 /* AppLogCaptureObserver.swift */,
+			);
+			path = Concerns;
+			sourceTree = "<group>";
+		};
+		D5A6A9DA2FE021B0001E4796 /* Configuration */ = {
+			isa = PBXGroup;
+			children = (
+				D5A6A9DB2FE021B8001E4796 /* TestObservationConfiguration.swift */,
+			);
+			path = Configuration;
 			sourceTree = "<group>";
 		};
 		F00C8C4E2FC9DBBA00B760BB /* Previews */ = {
@@ -7359,6 +7384,7 @@
 				7AB4018D2DA790DA00522E17 /* SelectLocationTests.swift in Sources */,
 				85E3BDE52B70E18C00FA71FD /* Networking.swift in Sources */,
 				856952E22BD6B04C008C1F84 /* XCUIElement+Extensions.swift in Sources */,
+				D5A6A9D92FE01E40001E4796 /* AppLogCaptureObserver.swift in Sources */,
 				85C7A2E92B89024B00035D5A /* SettingsLoggedOutTests.swift in Sources */,
 				8590896F2B61763B003AF5F5 /* LoggedOutUITestCase.swift in Sources */,
 				85557B202B5FBBD700795FE1 /* AccountPage.swift in Sources */,
@@ -7371,6 +7397,7 @@
 				A9BFAFFF2BD004ED00F2BCA1 /* CustomListsTests.swift in Sources */,
 				85557B102B59215F00795FE1 /* FirewallRule.swift in Sources */,
 				7AFE63332ED9D10400D27DC7 /* SetUpAccountCompletedPage.swift in Sources */,
+				D5A6A9DC2FE021B8001E4796 /* TestObservationConfiguration.swift in Sources */,
 				85557B0E2B591B2600795FE1 /* FirewallClient.swift in Sources */,
 				852969282B4D9C1F007EAD4C /* AccountTests.swift in Sources */,
 				8587A05D2B84D43100152938 /* ChangeLogAlert.swift in Sources */,
@@ -7384,6 +7411,7 @@
 				855D9F5B2B63E56B00D7C64D /* ProblemReportPage.swift in Sources */,
 				8529693A2B4F0238007EAD4C /* TermsOfServicePage.swift in Sources */,
 				7A9519952EBE1FA200AA8B19 /* PaymentTests.swift in Sources */,
+				D59CB43F2FE40B80000B06FB /* BaseUITestCase+ApplogCaptureObserver.swift in Sources */,
 				85978A542BE0F10E00F999A7 /* PacketCapture.swift in Sources */,
 				8555C6602D1030040092DAD0 /* LeakCheck.swift in Sources */,
 				85A42B882BB44D31007BABF7 /* DeviceManagementPage.swift in Sources */,

--- a/ios/MullvadVPNUITests/Base/BaseUITestCase.swift
+++ b/ios/MullvadVPNUITests/Base/BaseUITestCase.swift
@@ -40,13 +40,6 @@ class BaseUITestCase: XCTestCase {
     static let testsDefaultQuicCityName = "Frankfurt"
     static let testsDefaultQuicRelayName = "de-fra-wg-001"
 
-    /// True when the current test case is capturing packets
-    private var currentTestCaseShouldCapturePackets = false
-
-    /// True when a packet capture session is active
-    private var packetCaptureSessionIsActive = false
-    private var packetCaptureSession: PacketCaptureSession?
-
     let displayName =
         Bundle(for: BaseUITestCase.self)
         .infoDictionary?["DisplayName"] as! String
@@ -153,26 +146,39 @@ class BaseUITestCase: XCTestCase {
     }
 
     /// Start packet capture for this test case
-    func startPacketCapture() {
-        currentTestCaseShouldCapturePackets = true
-        packetCaptureSessionIsActive = true
-        let packetCaptureClient = PacketCaptureClient()
-        packetCaptureSession = packetCaptureClient.startCapture()
-    }
+    @discardableResult
+    func performPacketCapture(closure: (PacketCaptureSession) throws -> Void) rethrows -> [Stream] {
+        let client = PacketCaptureClient()
+        let session = client.startCapture()
 
-    /// Stop the current packet capture and return captured traffic
-    func stopPacketCapture() -> [Stream] {
-        packetCaptureSessionIsActive = false
-        guard let packetCaptureSession else {
-            XCTFail("Trying to stop capture when there is no active capture")
-            return []
+        try XCTContext.runActivity(named: "Packet Capture") { activity in
+            var captureError: Error?
+            do {
+                try closure(session)
+            } catch {
+                captureError = error
+            }
+
+            client.stopCapture(session: session)
+            let pcap = client.getPCAP(session: session)
+            let parsed = client.getParsedCapture(session: session)
+
+            let pcapAttachment = XCTAttachment(data: pcap)
+            pcapAttachment.name = self.name + ".pcap"
+            pcapAttachment.lifetime = .keepAlways
+            activity.add(pcapAttachment)
+
+            let jsonAttachment = XCTAttachment(data: parsed)
+            jsonAttachment.name = self.name + ".json"
+            jsonAttachment.lifetime = .keepAlways
+            activity.add(jsonAttachment)
+
+            if let captureError = captureError {
+                throw captureError
+            }
         }
 
-        let packetCaptureAPIClient = PacketCaptureClient()
-        packetCaptureAPIClient.stopCapture(session: packetCaptureSession)
-        let capturedData = packetCaptureAPIClient.getParsedCaptureObjects(session: packetCaptureSession)
-
-        return capturedData
+        return client.getParsedCaptureObjects(session: session)
     }
 
     // MARK: - Setup & teardown
@@ -190,7 +196,6 @@ class BaseUITestCase: XCTestCase {
 
     /// Test level setup
     override func setUp() async throws {
-        currentTestCaseShouldCapturePackets = false  // Reset for each test case run
         continueAfterFailure = false
         let argumentsJsonString = try? LaunchArguments(
             target: Self.executableTarget,
@@ -223,39 +228,6 @@ class BaseUITestCase: XCTestCase {
         if app.otherElements[.revokedDeviceView].existsAfterWait(timeout: .short) {
             RevokedDevicePage(app)
                 .tapGoToLogin()
-        }
-
-    }
-
-    /// Test level teardown
-    override func tearDown() async throws {
-        if currentTestCaseShouldCapturePackets {
-            guard let packetCaptureSession = packetCaptureSession else {
-                XCTFail("Packet capture session unexpectedly not set up")
-                return
-            }
-
-            let packetCaptureClient = PacketCaptureClient()
-
-            // If there's a an active session due to cancelled/failed test run make sure to end it
-            if packetCaptureSessionIsActive {
-                packetCaptureSessionIsActive = false
-                packetCaptureClient.stopCapture(session: packetCaptureSession)
-            }
-
-            let pcapFileContents = packetCaptureClient.getPCAP(session: packetCaptureSession)
-            let parsedCapture = packetCaptureClient.getParsedCapture(session: packetCaptureSession)
-            self.packetCaptureSession = nil
-
-            let pcapAttachment = XCTAttachment(data: pcapFileContents)
-            pcapAttachment.name = self.name + ".pcap"
-            pcapAttachment.lifetime = .keepAlways
-            self.add(pcapAttachment)
-
-            let jsonAttachment = XCTAttachment(data: parsedCapture)
-            jsonAttachment.name = self.name + ".json"
-            jsonAttachment.lifetime = .keepAlways
-            self.add(jsonAttachment)
         }
     }
 

--- a/ios/MullvadVPNUITests/Base/BaseUITestCase.swift
+++ b/ios/MullvadVPNUITests/Base/BaseUITestCase.swift
@@ -257,34 +257,6 @@ class BaseUITestCase: XCTestCase {
             jsonAttachment.lifetime = .keepAlways
             self.add(jsonAttachment)
         }
-
-        app.terminate()
-
-        if let testRun = self.testRun, testRun.failureCount > 0, attachAppLogsOnFailure == true {
-            try app.relaunch(Self.executableTarget)
-
-            HeaderBar(app)
-                .tapSettingsButton()
-
-            SettingsPage(app)
-                .tapReportAProblemCell()
-
-            ProblemReportPage(app)
-                .tapViewAppLogsButton()
-
-            let logText = AppLogsPage(app)
-                .getAppLogText()
-
-            // Attach app log to result
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
-            let dateString = dateFormatter.string(from: Date())
-            let attachment = XCTAttachment(string: logText)
-            attachment.name = "app-log-\(dateString).log"
-            add(attachment)
-
-            app.terminate()
-        }
     }
 
     /// Check if currently logged on to an account. Note that it is assumed that we are logged in if login view isn't currently shown.

--- a/ios/MullvadVPNUITests/Concerns/AppLogCaptureObserver.swift
+++ b/ios/MullvadVPNUITests/Concerns/AppLogCaptureObserver.swift
@@ -7,6 +7,7 @@
 
 import XCTest
 
+@MainActor
 protocol AppLogConfigurable {
     var attachAppLogsOnFailure: Bool { get }
     var app: XCUIApplication { get }

--- a/ios/MullvadVPNUITests/Concerns/AppLogCaptureObserver.swift
+++ b/ios/MullvadVPNUITests/Concerns/AppLogCaptureObserver.swift
@@ -1,0 +1,51 @@
+//
+//  AppLogCaptureObserver.swift
+//  MullvadVPN
+//
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+import XCTest
+
+protocol AppLogConfigurable {
+    var attachAppLogsOnFailure: Bool { get }
+    var app: XCUIApplication { get }
+    var target: MullvadExecutableTarget { get }
+}
+
+class AppLogCaptureObserver: NSObject, @preconcurrency XCTestObservation {
+
+    @MainActor
+    func testCaseDidFinish(_ testCase: XCTestCase) {
+        guard
+            let testRun = testCase.testRun,
+            testRun.failureCount > 0,
+            let configurable = testCase as? AppLogConfigurable,
+            configurable.attachAppLogsOnFailure
+        else {
+            return
+        }
+
+        XCTContext.runActivity(named: "Record app logs") { activity in
+            let app = configurable.app
+            do {
+                try app.relaunch(configurable.target)
+            } catch {
+                return
+            }
+
+            HeaderBar(app).tapSettingsButton()
+            SettingsPage(app).tapReportAProblemCell()
+            ProblemReportPage(app).tapViewAppLogsButton()
+
+            let text = AppLogsPage(app).getAppLogText()
+
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
+            let dateString = dateFormatter.string(from: Date())
+            let attachment = XCTAttachment(string: text)
+            attachment.name = "app-log-\(dateString).log"
+            activity.add(attachment)
+        }
+    }
+}

--- a/ios/MullvadVPNUITests/Concerns/BaseUITestCase+ApplogCaptureObserver.swift
+++ b/ios/MullvadVPNUITests/Concerns/BaseUITestCase+ApplogCaptureObserver.swift
@@ -1,0 +1,12 @@
+//
+//  BaseUITestCase+ApplogCaptureObserver.swift
+//  MullvadVPN
+//
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+extension BaseUITestCase: @MainActor AppLogConfigurable {
+    var target: MullvadExecutableTarget {
+        Self.executableTarget
+    }
+}

--- a/ios/MullvadVPNUITests/Concerns/BaseUITestCase+ApplogCaptureObserver.swift
+++ b/ios/MullvadVPNUITests/Concerns/BaseUITestCase+ApplogCaptureObserver.swift
@@ -5,7 +5,8 @@
 //  Copyright © 2026 Mullvad VPN AB. All rights reserved.
 //
 
-extension BaseUITestCase: @MainActor AppLogConfigurable {
+@MainActor
+extension BaseUITestCase: AppLogConfigurable {
     var target: MullvadExecutableTarget {
         Self.executableTarget
     }

--- a/ios/MullvadVPNUITests/Configuration/TestObservationConfiguration.swift
+++ b/ios/MullvadVPNUITests/Configuration/TestObservationConfiguration.swift
@@ -1,0 +1,13 @@
+//
+//  TestObservationConfiguration.swift
+//  MullvadVPN
+//
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+import XCTest
+
+final class TestObservationConfiguration: NSObject {
+    override init() {
+        XCTestObservationCenter.shared.addTestObserver(AppLogCaptureObserver())
+    }
+}

--- a/ios/MullvadVPNUITests/Info.plist
+++ b/ios/MullvadVPNUITests/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrincipalClass</key>
+	<string>$(PRODUCT_MODULE_NAME).TestObservationConfiguration</string>
 	<key>AdServingDomain</key>
 	<string>$(AD_SERVING_DOMAIN)</string>
 	<key>AmIJSONUrl</key>

--- a/ios/MullvadVPNUITests/LeakTests.swift
+++ b/ios/MullvadVPNUITests/LeakTests.swift
@@ -26,27 +26,27 @@ class LeakTests: LoggedInWithTimeUITestCase {
             """
         try XCTSkipIf(true, skipReason)
         let targetIPAddress = Networking.getAlwaysReachableIPAddress()
-        startPacketCapture()
-        let trafficGenerator = TrafficGenerator(destinationHost: targetIPAddress, port: 80)
-        trafficGenerator.startGeneratingUDPTraffic(interval: 1.0)
+        var capturedStreams = performPacketCapture { session in
+            let trafficGenerator = TrafficGenerator(destinationHost: targetIPAddress, port: 80)
+            trafficGenerator.startGeneratingUDPTraffic(interval: 1.0)
 
-        TunnelControlPage(app)
-            .tapConnectButton()
+            TunnelControlPage(app)
+                .tapConnectButton()
 
-        allowAddVPNConfigurationsIfAsked()
+            allowAddVPNConfigurationsIfAsked()
 
-        TunnelControlPage(app)
-            .waitForConnectedLabel()
+            TunnelControlPage(app)
+                .waitForConnectedLabel()
 
-        // Keep the tunnel connection for a while
-        RunLoop.current.run(until: .now + 30)
+            // Keep the tunnel connection for a while
+            RunLoop.current.run(until: .now + 30)
 
-        TunnelControlPage(app)
-            .tapDisconnectButton()
+            TunnelControlPage(app)
+                .tapDisconnectButton()
 
-        trafficGenerator.stopGeneratingUDPTraffic()
+            trafficGenerator.stopGeneratingUDPTraffic()
+        }
 
-        var capturedStreams = stopPacketCapture()
         // For now cut the beginning and and end of the stream to trim out the part where the tunnel connection was not up
         capturedStreams = PacketCaptureClient.trimPackets(
             streams: capturedStreams,
@@ -59,40 +59,40 @@ class LeakTests: LoggedInWithTimeUITestCase {
     /// Send UDP traffic to a host, connect to relay and then disconnect to intentionally leak traffic and make sure that the test catches the leak
     func testTrafficCapturedOutsideOfTunnelShouldLeak() throws {
         let targetIPAddress = Networking.getAlwaysReachableIPAddress()
-        startPacketCapture()
-        let trafficGenerator = TrafficGenerator(destinationHost: targetIPAddress, port: 80)
-        trafficGenerator.startGeneratingUDPTraffic(interval: 1.0)
+        var capturedStreams = performPacketCapture { session in
+            let trafficGenerator = TrafficGenerator(destinationHost: targetIPAddress, port: 80)
+            trafficGenerator.startGeneratingUDPTraffic(interval: 1.0)
 
-        TunnelControlPage(app)
-            .tapConnectButton()
+            TunnelControlPage(app)
+                .tapConnectButton()
 
-        allowAddVPNConfigurationsIfAsked()
+            allowAddVPNConfigurationsIfAsked()
 
-        TunnelControlPage(app)
-            .waitForConnectedLabel()
+            TunnelControlPage(app)
+                .waitForConnectedLabel()
 
-        RunLoop.current.run(until: .now + 2)
+            RunLoop.current.run(until: .now + 2)
 
-        TunnelControlPage(app)
-            .tapDisconnectButton()
+            TunnelControlPage(app)
+                .tapDisconnectButton()
 
-        // Give it some time to generate traffic outside of tunnel
-        RunLoop.current.run(until: .now + 5)
+            // Give it some time to generate traffic outside of tunnel
+            RunLoop.current.run(until: .now + 5)
 
-        TunnelControlPage(app)
-            .tapConnectButton()
+            TunnelControlPage(app)
+                .tapConnectButton()
 
-        // Keep the tunnel connection for a while
-        RunLoop.current.run(until: .now + 5)
+            // Keep the tunnel connection for a while
+            RunLoop.current.run(until: .now + 5)
 
-        TunnelControlPage(app)
-            .tapDisconnectButton()
+            TunnelControlPage(app)
+                .tapDisconnectButton()
 
-        // Keep the capture open for a while
-        RunLoop.current.run(until: .now + 15)
-        trafficGenerator.stopGeneratingUDPTraffic()
+            // Keep the capture open for a while
+            RunLoop.current.run(until: .now + 15)
+            trafficGenerator.stopGeneratingUDPTraffic()
+        }
 
-        var capturedStreams = stopPacketCapture()
         // For now cut the beginning and and end of the stream to trim out the part where the tunnel connection was not up
         capturedStreams = PacketCaptureClient.trimPackets(
             streams: capturedStreams,

--- a/ios/MullvadVPNUITests/Networking/FirewallClient.swift
+++ b/ios/MullvadVPNUITests/Networking/FirewallClient.swift
@@ -14,8 +14,12 @@ import XCTest
 class FirewallClient: TestRouterAPIClient {
     let testDeviceIdentifier = Bundle(for: FirewallClient.self).infoDictionary?["TestDeviceIdentifier"] as! String
 
-    lazy var sessionIdentifier = "urn:uuid:" + testDeviceIdentifier
-
+    lazy var sessionIdentifier = {
+        guard let uuid = UUID(uuidString: self.testDeviceIdentifier)?.uuidString else {
+            fatalError("Check your test device identifier in the Info.plist")
+        }
+        return "urn:uuid:" + uuid
+    }()
     /// Create a new rule associated to the device under test
     public func createRule(_ firewallRule: FirewallRule) {
         let createRuleURL = TestRouterAPIClient.baseURL.appendingPathComponent("rule")

--- a/ios/MullvadVPNUITests/Networking/PartnerAPIClient.swift
+++ b/ios/MullvadVPNUITests/Networking/PartnerAPIClient.swift
@@ -116,7 +116,7 @@ class PartnerAPIClient {
 
         task.resume()
         let waitResult = XCTWaiter().wait(for: [completionHandlerInvokedExpectation], timeout: 10)
-        XCTAssertEqual(waitResult, .completed, "Waiting for partner API request expectation completed")
+        XCTAssertEqual(waitResult, .completed, "Waiting for partner API request expectation did not complete in time")
         XCTAssertNil(requestError)
 
         return jsonResponse

--- a/ios/MullvadVPNUITests/Pages/Page.swift
+++ b/ios/MullvadVPNUITests/Pages/Page.swift
@@ -24,7 +24,7 @@ class Page {
         if let pageElement {
             XCTAssertTrue(
                 pageElement.existsAfterWait(timeout: .extremelyLong),
-                "Page is shown"
+                "Page is not shown"
             )
         }
     }

--- a/ios/MullvadVPNUITests/Pages/TunnelControlPage.swift
+++ b/ios/MullvadVPNUITests/Pages/TunnelControlPage.swift
@@ -135,7 +135,7 @@ class TunnelControlPage: Page {
     @discardableResult func waitForConnectedLabel() -> Self {
         let labelFound = app.staticTexts[.connectionStatusConnectedLabel]
             .existsAfterWait(timeout: .extremelyLong)
-        XCTAssertTrue(labelFound, "Secure connection label presented")
+        XCTAssertTrue(labelFound, "Secure connection label not presented")
 
         return self
     }

--- a/ios/MullvadVPNUITests/RelayTests.swift
+++ b/ios/MullvadVPNUITests/RelayTests.swift
@@ -123,25 +123,39 @@ class RelayTests: LoggedInWithTimeUITestCase {
         SettingsPage(app)
             .tapDoneButton()
 
+        let expectedPort = 80
+        var destinationAddress: String?
+
         // The packet capture has to start before the tunnel is up,
         // otherwise the device cannot reach the in-house router anymore
-        startPacketCapture()
+        let capturedData = try performPacketCapture { session in
+            TunnelControlPage(app)
+                .tapConnectButton()
 
-        TunnelControlPage(app)
-            .tapConnectButton()
+            allowAddVPNConfigurationsIfAsked()
 
-        allowAddVPNConfigurationsIfAsked()
+            TunnelControlPage(app)
+                .waitForConnectedLabel()
 
-        TunnelControlPage(app)
-            .waitForConnectedLabel()
+            let (connectedToIPAddress, _) = TunnelControlPage(app)
+                .tapRelayStatusExpandCollapseButton()
+                .getInIPAddressAndPortFromConnectionStatus()
 
-        let (connectedToIPAddress, _) = TunnelControlPage(app)
-            .tapRelayStatusExpandCollapseButton()
-            .getInIPAddressAndPortFromConnectionStatus()
+            try Networking.verifyCanAccessInternet()
 
-        try Networking.verifyCanAccessInternet()
+            try generateTrafficAndDisconnect(
+                from: connectedToIPAddress,
+                searchForPort: expectedPort
+            )
 
-        try generateTrafficAndDisconnect(from: connectedToIPAddress, searchForPort: 80, assertProtocol: .TCP)
+            destinationAddress = connectedToIPAddress
+        }
+
+        try assertCapturedProtocol(
+            .UDP,
+            destinationAddress: destinationAddress,
+            destinationPort: expectedPort,
+            in: capturedData)
     }
 
     func testWireGuardOverShadowsocksCustomPort() throws {
@@ -169,23 +183,36 @@ class RelayTests: LoggedInWithTimeUITestCase {
 
         // The packet capture has to start before the tunnel is up,
         // otherwise the device cannot reach the in-house router anymore
-        startPacketCapture()
+        let expectedPort = 51900
+        var destinationAddress: String?
+        let capturedData = try performPacketCapture { session in
+            TunnelControlPage(app)
+                .tapConnectButton()
 
-        TunnelControlPage(app)
-            .tapConnectButton()
+            allowAddVPNConfigurationsIfAsked()
 
-        allowAddVPNConfigurationsIfAsked()
+            TunnelControlPage(app)
+                .waitForConnectedLabel()
 
-        TunnelControlPage(app)
-            .waitForConnectedLabel()
+            let (connectedToIPAddress, _) = TunnelControlPage(app)
+                .tapRelayStatusExpandCollapseButton()
+                .getInIPAddressAndPortFromConnectionStatus()
 
-        let (connectedToIPAddress, _) = TunnelControlPage(app)
-            .tapRelayStatusExpandCollapseButton()
-            .getInIPAddressAndPortFromConnectionStatus()
+            try Networking.verifyCanAccessInternet()
 
-        try Networking.verifyCanAccessInternet()
+            try generateTrafficAndDisconnect(
+                from: connectedToIPAddress,
+                searchForPort: expectedPort,
+            )
 
-        try generateTrafficAndDisconnect(from: connectedToIPAddress, searchForPort: 51900, assertProtocol: .UDP)
+            destinationAddress = connectedToIPAddress
+        }
+
+        try assertCapturedProtocol(
+            .UDP,
+            destinationAddress: destinationAddress,
+            destinationPort: expectedPort,
+            in: capturedData)
     }
 
     func testWireGuardOverLwoCustomPort() throws {
@@ -211,25 +238,38 @@ class RelayTests: LoggedInWithTimeUITestCase {
         SettingsPage(app)
             .tapDoneButton()
 
+        let expectedPort = 4000
+        var destinationAddress: String?
         // The packet capture has to start before the tunnel is up,
         // otherwise the device cannot reach the in-house router anymore
-        startPacketCapture()
+        let capturedData = try performPacketCapture { session in
+            TunnelControlPage(app)
+                .tapConnectButton()
 
-        TunnelControlPage(app)
-            .tapConnectButton()
+            allowAddVPNConfigurationsIfAsked()
 
-        allowAddVPNConfigurationsIfAsked()
+            TunnelControlPage(app)
+                .waitForConnectedLabel()
 
-        TunnelControlPage(app)
-            .waitForConnectedLabel()
+            let (connectedToIPAddress, _) = TunnelControlPage(app)
+                .tapRelayStatusExpandCollapseButton()
+                .getInIPAddressAndPortFromConnectionStatus()
 
-        let (connectedToIPAddress, _) = TunnelControlPage(app)
-            .tapRelayStatusExpandCollapseButton()
-            .getInIPAddressAndPortFromConnectionStatus()
+            try Networking.verifyCanAccessInternet()
 
-        try Networking.verifyCanAccessInternet()
+            try generateTrafficAndDisconnect(
+                from: connectedToIPAddress,
+                searchForPort: 4000
+            )
 
-        try generateTrafficAndDisconnect(from: connectedToIPAddress, searchForPort: 4000, assertProtocol: .UDP)
+            destinationAddress = connectedToIPAddress
+        }
+
+        try assertCapturedProtocol(
+            .UDP,
+            destinationAddress: destinationAddress,
+            destinationPort: expectedPort,
+            in: capturedData)
     }
 
     func testWireGuardOverTCPManually() throws {
@@ -307,47 +347,60 @@ class RelayTests: LoggedInWithTimeUITestCase {
         SettingsPage(app)
             .tapDoneButton()
 
-        startPacketCapture()
+        let expectedPort = 443
+        var destinationAddress: String?
+        let capturedData = try performPacketCapture { session in
+            TunnelControlPage(app)
+                .tapSelectLocationButton()
 
-        TunnelControlPage(app)
-            .tapSelectLocationButton()
+            SelectLocationPage(app)
+                .tapLocationCellExpandButton(withName: BaseUITestCase.testsDefaultQuicCountryName)
+                .tapLocationCellExpandButton(withName: BaseUITestCase.testsDefaultQuicCityName)
+                .tapLocationCell(withName: BaseUITestCase.testsDefaultQuicRelayName)
 
-        SelectLocationPage(app)
-            .tapLocationCellExpandButton(withName: BaseUITestCase.testsDefaultQuicCountryName)
-            .tapLocationCellExpandButton(withName: BaseUITestCase.testsDefaultQuicCityName)
-            .tapLocationCell(withName: BaseUITestCase.testsDefaultQuicRelayName)
+            allowAddVPNConfigurationsIfAsked()
 
-        allowAddVPNConfigurationsIfAsked()
+            TunnelControlPage(app)
+                .waitForConnectedLabel()
 
-        TunnelControlPage(app)
-            .waitForConnectedLabel()
+            let (connectedToIPAddress, _) = TunnelControlPage(app)
+                .tapRelayStatusExpandCollapseButton()
+                .getInIPAddressAndPortFromConnectionStatus()
 
-        let (connectedToIPAddress, _) = TunnelControlPage(app)
-            .tapRelayStatusExpandCollapseButton()
-            .getInIPAddressAndPortFromConnectionStatus()
+            let (relayIPAddress, _) = TunnelControlPage(app)
+                .getInIPAddressAndPortFromConnectionStatus()
 
-        let (relayIPAddress, _) = TunnelControlPage(app)
-            .getInIPAddressAndPortFromConnectionStatus()
+            // Disconnect in order to create firewall rules, otherwise the test router cannot be reached
+            TunnelControlPage(app)
+                .tapDisconnectButton()
 
-        // Disconnect in order to create firewall rules, otherwise the test router cannot be reached
-        TunnelControlPage(app)
-            .tapDisconnectButton()
-
-        try FirewallClient().createRule(
-            FirewallRule.makeBlockWireGuardTrafficRule(
-                fromIPAddress: deviceIPAddress,
-                toIPAddress: relayIPAddress
+            try FirewallClient().createRule(
+                FirewallRule.makeBlockWireGuardTrafficRule(
+                    fromIPAddress: deviceIPAddress,
+                    toIPAddress: relayIPAddress
+                )
             )
-        )
 
-        // The VPN connects despite the wireguard protocol being blocked, QUIC obfuscation is in the works
-        TunnelControlPage(app)
-            .tapConnectButton()
-            .waitForConnectedLabel()
+            // The VPN connects despite the wireguard protocol being blocked, QUIC obfuscation is in the works
+            TunnelControlPage(app)
+                .tapConnectButton()
+                .waitForConnectedLabel()
 
-        try Networking.verifyCanAccessInternet()
+            try Networking.verifyCanAccessInternet()
 
-        try generateTrafficAndDisconnect(from: connectedToIPAddress, searchForPort: 443, assertProtocol: .UDP)
+            try generateTrafficAndDisconnect(
+                from: connectedToIPAddress,
+                searchForPort: 443
+            )
+
+            destinationAddress = connectedToIPAddress
+        }
+
+        try assertCapturedProtocol(
+            .UDP,
+            destinationAddress: destinationAddress,
+            destinationPort: expectedPort,
+            in: capturedData)
     }
 
     func testWireGuardOverLwoManually() throws {
@@ -790,13 +843,11 @@ extension RelayTests {
         return RelayInfo(name: relayName, ipAddress: relayIPAddress)
     }
 
-    @discardableResult
     private func generateTrafficAndDisconnect(
         from connectedToIPAddress: String,
         searchForPort port: Int,
-        duration: TimeInterval = 1,
-        assertProtocol transportProtocol: NetworkTransportProtocol
-    ) throws -> [Stream] {
+        duration: TimeInterval = 1
+    ) throws {
         let targetIPAddress = Networking.getAlwaysReachableIPAddress()
         let trafficGenerator = TrafficGenerator(destinationHost: targetIPAddress, port: 80)
         trafficGenerator.startGeneratingUDPTraffic(interval: 0.1)
@@ -806,46 +857,45 @@ extension RelayTests {
 
         TunnelControlPage(app)
             .tapDisconnectButton()
-        let capturedStreams = stopPacketCapture()
-
-        // The capture will contain several streams where `other_addr` contains the IP the device connected to
-        // One stream will be for the source port, the other for the destination port
-        let streamFromPeerToRelay = try XCTUnwrap(
-            capturedStreams.filter { $0.destinationAddress == connectedToIPAddress && $0.destinationPort == port }.first
-        )
-
-        XCTAssertTrue(streamFromPeerToRelay.transportProtocol == transportProtocol)
-        return capturedStreams
     }
 
     /// Starts a packet capture, connects to a relay, generates synthetic traffic,
     /// disconnects from the relay, and gets a representation of the captured traffic
     private func generateTrafficSample() throws -> (String, Int, [Stream]) {
-        startPacketCapture()
+        var connectionDetails: (IP: String, port: Int)?
+        let capturedData = try performPacketCapture { session in
+            // Connect
+            TunnelControlPage(app)
+                .tapSelectLocationButton()
 
-        // Connect
-        TunnelControlPage(app)
-            .tapSelectLocationButton()
+            SelectLocationPage(app)
+                .tapLocationCell(withName: BaseUITestCase.testsDefaultDAITACountryName)
 
-        SelectLocationPage(app)
-            .tapLocationCell(withName: BaseUITestCase.testsDefaultDAITACountryName)
+            allowAddVPNConfigurationsIfAsked()
 
-        allowAddVPNConfigurationsIfAsked()
+            // Generate traffic sample
+            let (IPAddress, port) = TunnelControlPage(app)
+                .waitForConnectedLabel()
+                .tapRelayStatusExpandCollapseButton()
+                .getInIPAddressAndPortFromConnectionStatus()
 
-        // Generate traffic sample
-        let (IPAddress, port) = TunnelControlPage(app)
-            .waitForConnectedLabel()
-            .tapRelayStatusExpandCollapseButton()
-            .getInIPAddressAndPortFromConnectionStatus()
+            try generateTrafficAndDisconnect(
+                from: IPAddress,
+                searchForPort: port,
+                duration: 30
+            )
 
-        let stream = try generateTrafficAndDisconnect(
-            from: IPAddress,
-            searchForPort: port,
-            duration: 30,
-            assertProtocol: .UDP
-        )
+            connectionDetails = (IPAddress, port)
+        }
 
-        return (IPAddress, port, stream)
+        let connectedTo = try XCTUnwrap(connectionDetails)
+        try assertCapturedProtocol(
+            .UDP,
+            destinationAddress: connectedTo.IP,
+            destinationPort: connectedTo.port,
+            in: capturedData)
+
+        return (connectedTo.IP, connectedTo.port, capturedData)
     }
 
     func testIPv6Connection() throws {
@@ -881,5 +931,20 @@ extension RelayTests {
 
         TunnelControlPage(app)
             .tapDisconnectButton()
+    }
+
+    func assertCapturedProtocol(
+        _ expectedProtocol: NetworkTransportProtocol,
+        destinationAddress: String?,
+        destinationPort: Int,
+        in result: [Stream]
+    ) throws {
+        let destinationAddress = try XCTUnwrap(destinationAddress)
+        let stream = try XCTUnwrap(
+            result.filter {
+                $0.destinationAddress == destinationAddress && $0.destinationPort == destinationPort
+            }.first
+        )
+        XCTAssertEqual(stream.transportProtocol, expectedProtocol)
     }
 }


### PR DESCRIPTION
- Make capturing packets more natural to use

    Switching to a block-based API removes the need to keep state, and should ensure safe and natural usage of the feature.
    This makes capturing packets simpler to reason about and avoids keeping state because of it.

- Correct failure messages in E2E UITests

    The second string argument to an [`XCTAssertTrue`][0] is an (optional) *failure* message, not success.

- Fail UI tests on an invalid UUID

    `RAAS` responds to invalid UUIDs with an HTTP 400, which is correct but
    a bit opaque. Catching this earlier is helpful.

- Extract capturing of app-logs into `XCTestObservation`

    Extracts the cross-cutting concern of capturing app logs on test
    failure into a dedicated `AppLogCaptureObserver`. This keeps
    `BaseUITestCase` focused on test logic rather than infrastructure.

    The capture strategy remains unchanged: relaunch the app on failure
    and retrieve logs via the app's built-in problem-report UI.

    This is a move, no behavioral change to log capture or
    test execution.

[0]: https://developer.apple.com/documentation/xctest/xctasserttrue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10636)
<!-- Reviewable:end -->
