### PR TITLE
Exclude gotatun toggle from release builds

### DIFF
--- a/ios/MullvadVPN/View controllers/Account/AccountViewController.swift
+++ b/ios/MullvadVPN/View controllers/Account/AccountViewController.swift
@@ -276,17 +276,19 @@ class AccountViewController: UIViewController, @unchecked Sendable {
                 }
             )
         )
-        let gotaTunEnabled = PacketTunnelDebugSettings.useGotaTun
-        sheetController.addAction(
-            UIAlertAction(
-                title: "Use GotaTun: \(gotaTunEnabled ? "ON" : "OFF")",
-                style: .default,
-                handler: { [weak self] _ in
-                    PacketTunnelDebugSettings.useGotaTun = !gotaTunEnabled
-                    self?.interactor.tunnelManager.reapplyTunnelConfiguration()
-                }
+        #if NEVER_IN_PRODUCTION
+            let gotaTunEnabled = PacketTunnelDebugSettings.useGotaTun
+            sheetController.addAction(
+                UIAlertAction(
+                    title: "Use GotaTun: \(gotaTunEnabled ? "ON" : "OFF")",
+                    style: .default,
+                    handler: { [weak self] _ in
+                        PacketTunnelDebugSettings.useGotaTun = !gotaTunEnabled
+                        self?.interactor.tunnelManager.reapplyTunnelConfiguration()
+                    }
+                )
             )
-        )
+        #endif
 
         sheetController.addAction(
             UIAlertAction(


### PR DESCRIPTION
Somewhere along the way, a DEBUG flag check went missing. This broke the release/mockrelease builds since the code was trying to use an option that is only available in debug builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10639)
<!-- Reviewable:end -->
