### PR TITLE
Remove language identifier from blog post URL

### DIFF
--- a/ios/MullvadVPN/Coordinators/Settings/IncludeAllNetworks/IncludeAllNetworksSettingsView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/IncludeAllNetworks/IncludeAllNetworksSettingsView.swift
@@ -156,8 +156,7 @@ extension IncludeAllNetworksSettingsView {
 extension IncludeAllNetworksSettingsView {
     private var dataViewModel: SettingsInfoViewModel {
         let blogUrl = URL(
-            string: "https://\(ApplicationConfiguration.hostName)/"
-                + "\(ApplicationLanguage.currentLanguage.id)"
+            string: "https://\(ApplicationConfiguration.hostName)"
                 + "/blog/why-we-still-dont-use-includeallnetworks"
         )!
 

--- a/ios/MullvadVPN/Coordinators/SetupAccountCompletedCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/SetupAccountCompletedCoordinator.swift
@@ -38,7 +38,7 @@ extension SetupAccountCompletedCoordinator: @preconcurrency SetupAccountComplete
     func didRequestToSeePrivacy(controller: SetupAccountCompletedController) {
         presentChild(
             SafariCoordinator(
-                url: ApplicationConfiguration.privacyGuidesURL(for: ApplicationLanguage.currentLanguage.id)),
+                url: ApplicationConfiguration.privacyGuidesURL()),
             animated: true)
     }
 

--- a/ios/MullvadVPN/View controllers/ProblemReport/ReduceAnonymityWarningView.swift
+++ b/ios/MullvadVPN/View controllers/ProblemReport/ReduceAnonymityWarningView.swift
@@ -135,7 +135,7 @@ class ReduceAnonymityWarningView: UIView {
 
     @objc func openPrivacyPolicy() {
         UIApplication.shared.open(
-            URL(string: ApplicationConfiguration.privacyPolicyLink(for: ApplicationLanguage.currentLanguage.id))!)
+            URL(string: ApplicationConfiguration.privacyPolicyLink())!)
     }
 
     required init?(coder: NSCoder) {

--- a/ios/MullvadVPN/View controllers/TermsOfService/TermsOfServiceView.swift
+++ b/ios/MullvadVPN/View controllers/TermsOfService/TermsOfServiceView.swift
@@ -47,7 +47,7 @@ struct TermsOfServiceView: View {
                 Text(
                     LocalizedStringKey(
                         stringLiteral:
-                            "[\(privacyPolicyText)](\(ApplicationConfiguration.privacyPolicyLink(for :ApplicationLanguage.currentLanguage.id)))"
+                            "[\(privacyPolicyText)](\(ApplicationConfiguration.privacyPolicyLink()))"
                     )
                 )
                 .font(.mullvadSmall)

--- a/ios/Shared/ApplicationConfiguration.swift
+++ b/ios/Shared/ApplicationConfiguration.swift
@@ -63,13 +63,13 @@ enum ApplicationConfiguration {
     static let logMaximumFileSize: UInt64 = 131_072  // 128 kB.
 
     /// Privacy policy URL.
-    static func privacyPolicyLink(for language: String) -> String {
-        "https://\(Self.hostName)/\(language)/help/privacy-policy/"
+    static func privacyPolicyLink() -> String {
+        "https://\(Self.hostName)/help/privacy-policy/"
     }
 
     /// Make a start regarding  policy URL.
-    static func privacyGuidesURL(for language: String) -> URL {
-        URL(string: "https://\(Self.hostName)/\(language)/help/first-steps-towards-online-privacy/")!
+    static func privacyGuidesURL() -> URL {
+        URL(string: "https://\(Self.hostName)/help/first-steps-towards-online-privacy/")!
     }
 
     /// FAQ & Guides URL.


### PR DESCRIPTION
Removing the last remnants of locale identifiers from URLs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10652)
<!-- Reviewable:end -->
