### PR TITLE
Fix e2e multihop tests

### DIFF
--- a/ios/MullvadVPNUITests/RelayTests.swift
+++ b/ios/MullvadVPNUITests/RelayTests.swift
@@ -525,7 +525,7 @@ class RelayTests: LoggedInWithTimeUITestCase {
             .tapSettingsButton()
 
         SettingsPage(app)
-            .verifyMultihop(state: .never)
+            .verifyMultihop(state: .whenNeeded)
             .tapMultihopCell()
 
         MultihopPage(app)
@@ -560,7 +560,7 @@ class RelayTests: LoggedInWithTimeUITestCase {
             .tapSettingsButton()
 
         SettingsPage(app)
-            .verifyMultihop(state: .never)
+            .verifyMultihop(state: .whenNeeded)
             .tapMultihopCell()
 
         MultihopPage(app)


### PR DESCRIPTION
I've fixed the tests that were affected by the change from defaulting multihop to `.whenNeeded`. Now they seem to pass - https://github.com/mullvad/mullvadvpn-app/actions/runs/27977900840/job/82800888184.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10655)
<!-- Reviewable:end -->
