### PR TITLE
Block Hyper-V during disconnecting tunnel state

### DIFF
--- a/talpid-core/src/firewall/linux.rs
+++ b/talpid-core/src/firewall/linux.rs
@@ -712,6 +712,12 @@ impl<'a> PolicyBatch<'a> {
                 self.add_drop_dns_rule();
                 *allow_lan
             }
+            // Linux doesn't take any special actions when disconnecting. The existing firewall rules are sufficient to prevent leaks.
+            FirewallPolicy::Disconnecting { allow_lan } => {
+                // Important to drop DNS before allowing LAN (to stop DNS leaking to the LAN)
+                self.add_drop_dns_rule();
+                *allow_lan
+            }
         };
 
         if allow_lan {

--- a/talpid-core/src/firewall/macos.rs
+++ b/talpid-core/src/firewall/macos.rs
@@ -478,6 +478,17 @@ impl Firewall {
 
                 Ok(rules)
             }
+            FirewallPolicy::Disconnecting { allow_lan } => {
+                let mut rules = Vec::new();
+
+                if *allow_lan {
+                    // Important to block DNS before allow LAN (so DNS does not leak to the LAN)
+                    rules.append(&mut self.get_block_dns_rules()?);
+                    rules.append(&mut self.get_allow_lan_rules()?);
+                }
+
+                Ok(rules)
+            }
         }
     }
 

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -121,6 +121,12 @@ pub enum FirewallPolicy {
         redirect_interface: Option<String>,
     },
 
+    /// Allow traffic only to server
+    Disconnecting {
+        /// Flag setting if communication with LAN networks should be possible.
+        allow_lan: bool,
+    },
+
     /// Block all network traffic in and out from the computer.
     Blocked {
         /// Flag setting if communication with LAN networks should be possible.
@@ -183,7 +189,8 @@ impl FirewallPolicy {
         match self {
             FirewallPolicy::Connecting { allow_lan, .. }
             | FirewallPolicy::Connected { allow_lan, .. }
-            | FirewallPolicy::Blocked { allow_lan, .. } => *allow_lan,
+            | FirewallPolicy::Blocked { allow_lan, .. }
+            | FirewallPolicy::Disconnecting { allow_lan } => *allow_lan,
         }
     }
 
@@ -198,6 +205,7 @@ impl FirewallPolicy {
                 redirect_interface, ..
             } => redirect_interface.as_deref(),
             FirewallPolicy::Blocked { .. } => None,
+            FirewallPolicy::Disconnecting { .. } => None,
         }
     }
 }
@@ -295,6 +303,11 @@ impl fmt::Display for FirewallPolicy {
                     .as_ref()
                     .map(|endpoint| -> &dyn std::fmt::Display { endpoint })
                     .unwrap_or(&"none"),
+            ),
+            FirewallPolicy::Disconnecting { allow_lan, .. } => write!(
+                f,
+                "Disconnecting. {} LAN",
+                if *allow_lan { "Allowing" } else { "Blocking" }
             ),
         }
     }

--- a/talpid-core/src/firewall/windows/mod.rs
+++ b/talpid-core/src/firewall/windows/mod.rs
@@ -123,7 +123,9 @@ impl Firewall {
     pub fn apply_policy(&mut self, policy: FirewallPolicy) -> Result<(), Error> {
         let should_block_hyperv = matches!(
             policy,
-            FirewallPolicy::Connecting { .. } | FirewallPolicy::Blocked { .. }
+            FirewallPolicy::Connecting { .. }
+                | FirewallPolicy::Blocked { .. }
+                | FirewallPolicy::Disconnecting { .. }
         );
 
         let apply_result = match policy {
@@ -171,6 +173,8 @@ impl Firewall {
                     allowed_endpoint.map(WinFwAllowedEndpointContainer::from),
                 )
             }
+            // Windows doesn't need to change any existing firewall rules here. Disconnecting state is purely for the Hyper-V blocking which is done later.
+            FirewallPolicy::Disconnecting { .. } => Ok(()),
         };
 
         with_wmi_if_enabled(|wmi| {

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -56,6 +56,7 @@ impl ConnectedState {
 
         if let Err(error) = connected_state.set_firewall_policy(shared_values) {
             DisconnectingState::enter(
+                shared_values,
                 connected_state.tunnel_close_tx,
                 connected_state.tunnel_close_event,
                 AfterDisconnect::Block(ErrorStateCause::SetFirewallPolicyError(error)),
@@ -63,6 +64,7 @@ impl ConnectedState {
         } else if let Err(error) = connected_state.set_dns(shared_values) {
             log::error!("{}", error.display_chain_with_msg("Failed to set DNS"));
             DisconnectingState::enter(
+                shared_values,
                 connected_state.tunnel_close_tx,
                 connected_state.tunnel_close_event,
                 AfterDisconnect::Block(ErrorStateCause::SetDnsError),
@@ -239,6 +241,7 @@ impl ConnectedState {
         Self::reset_routes(shared_values);
 
         EventConsequence::NewState(DisconnectingState::enter(
+            shared_values,
             self.tunnel_close_tx,
             self.tunnel_close_event,
             after_disconnect,

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -383,6 +383,7 @@ impl ConnectingState {
         Self::reset_routes(shared_values);
 
         EventConsequence::NewState(DisconnectingState::enter(
+            shared_values,
             self.tunnel_close_tx,
             self.tunnel_close_event,
             after_disconnect,

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -1,3 +1,5 @@
+use crate::firewall::FirewallPolicy;
+
 use super::{
     ConnectingState, DisconnectedState, ErrorState, EventConsequence, EventResult,
     SharedTunnelStateValues, TunnelCommand, TunnelCommandReceiver, TunnelState,
@@ -19,6 +21,7 @@ pub struct DisconnectingState {
 
 impl DisconnectingState {
     pub(super) fn enter(
+        shared_values: &mut SharedTunnelStateValues,
         tunnel_close_tx: oneshot::Sender<()>,
         tunnel_close_event: TunnelCloseEvent,
         after_disconnect: AfterDisconnect,
@@ -26,6 +29,7 @@ impl DisconnectingState {
         let _ = tunnel_close_tx.send(());
         let action_after_disconnect = after_disconnect.action();
 
+        Self::set_firewall_policy(shared_values);
         (
             Box::new(DisconnectingState {
                 tunnel_close_event,
@@ -33,6 +37,18 @@ impl DisconnectingState {
             }),
             TunnelStateTransition::Disconnecting(action_after_disconnect),
         )
+    }
+
+    fn set_firewall_policy(shared_values: &mut SharedTunnelStateValues) {
+        let result = shared_values
+            .firewall
+            .apply_policy(FirewallPolicy::Disconnecting {
+                allow_lan: shared_values.allow_lan,
+            });
+
+        if let Err(err) = result {
+            log::error!("{err}")
+        }
     }
 
     fn handle_commands(


### PR DESCRIPTION
Hyper-V could leak packets during the disconnecting tunnel state. Since Hyper-V cannot use WFP we instead just block all outgoing traffic during this state instead.

The code changes were tested by setting up a constant ping in WSL, continually attempting reconnects and verifying that no packets leaked outside the tunnel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10671)
<!-- Reviewable:end -->
