### PR TITLE
Reduce the timeouts for API calls used in UITests

### DIFF
--- a/ios/MullvadVPNUITests/Networking/FirewallClient.swift
+++ b/ios/MullvadVPNUITests/Networking/FirewallClient.swift
@@ -56,7 +56,7 @@ class FirewallClient: TestRouterAPIClient {
 
             dataTask.resume()
 
-            let waitResult = XCTWaiter.wait(for: [completionHandlerInvokedExpectation], timeout: 30)
+            let waitResult = XCTWaiter.wait(for: [completionHandlerInvokedExpectation], timeout: 5)
 
             if waitResult != .completed {
                 XCTFail("Failed to create firewall rule - timeout")
@@ -99,7 +99,7 @@ class FirewallClient: TestRouterAPIClient {
 
         dataTask.resume()
 
-        let waitResult = XCTWaiter.wait(for: [completionHandlerInvokedExpectation], timeout: 30)
+        let waitResult = XCTWaiter.wait(for: [completionHandlerInvokedExpectation], timeout: 5)
 
         if waitResult != .completed {
             XCTFail("Failed to remove firewall rules - timeout")

--- a/ios/MullvadVPNUITests/Networking/Networking.swift
+++ b/ios/MullvadVPNUITests/Networking/Networking.swift
@@ -196,7 +196,7 @@ class Networking {
 
             dataTask.resume()
 
-            let waitResult = XCTWaiter.wait(for: [completionHandlerInvokedExpectation], timeout: 30)
+            let waitResult = XCTWaiter.wait(for: [completionHandlerInvokedExpectation], timeout: 5)
 
             if waitResult != .completed {
                 XCTFail("Failed to verify DNS server provider - timeout")
@@ -282,7 +282,7 @@ class Networking {
 
         dataTask.resume()
 
-        let waitResult = XCTWaiter.wait(for: [completionHandlerInvokedExpectation], timeout: 30)
+        let waitResult = XCTWaiter.wait(for: [completionHandlerInvokedExpectation], timeout: 5)
 
         if waitResult != .completed {
             XCTFail("Request to connection check API failed - timeout")

--- a/ios/MullvadVPNUITests/Networking/PacketCapture.swift
+++ b/ios/MullvadVPNUITests/Networking/PacketCapture.swift
@@ -323,7 +323,7 @@ class PacketCaptureClient: TestRouterAPIClient {
 
         dataTask.resume()
 
-        let waitResult = XCTWaiter.wait(for: [completionHandlerInvokedExpectation], timeout: 30)
+        let waitResult = XCTWaiter.wait(for: [completionHandlerInvokedExpectation], timeout: 5)
 
         if waitResult != .completed {
             XCTFail("Failed to send packet capture API request - timeout")

--- a/ios/MullvadVPNUITests/Networking/PartnerAPIClient.swift
+++ b/ios/MullvadVPNUITests/Networking/PartnerAPIClient.swift
@@ -115,7 +115,7 @@ class PartnerAPIClient {
         }
 
         task.resume()
-        let waitResult = XCTWaiter().wait(for: [completionHandlerInvokedExpectation], timeout: 10)
+        let waitResult = XCTWaiter().wait(for: [completionHandlerInvokedExpectation], timeout: 5)
         XCTAssertEqual(waitResult, .completed, "Waiting for partner API request expectation did not complete in time")
         XCTAssertNil(requestError)
 

--- a/ios/MullvadVPNUITests/Networking/TestRouterAPIClient.swift
+++ b/ios/MullvadVPNUITests/Networking/TestRouterAPIClient.swift
@@ -33,7 +33,7 @@ class TestRouterAPIClient {
 
         dataTask.resume()
 
-        let waitResult = XCTWaiter.wait(for: [completionHandlerInvokedExpectation], timeout: 30)
+        let waitResult = XCTWaiter.wait(for: [completionHandlerInvokedExpectation], timeout: 5)
         if waitResult != .completed {
             XCTFail("Failed to get device IP address - timeout")
         }


### PR DESCRIPTION
**Why this needs to be done**

The timeouts in the end to end tests are rather long, which usually means that failing tests take a lot of time to fail. This makes the test suite slower than needed, we should try and make it faster by making it fail faster.

**How do we implement this feature?**

We want to look at all the APIs that are used to account handling in the UITests, and reduce all the timeout values to acceptable, but still fast, values.

For example, TestRouterAPIClient is using a 30 seconds timeout in its getDeviceIPAddress call. A 5 seconds timeout is probably more than enough given that the device under test is constantly connected to WiFi in a stable environment. 

Look into the Networking folder of the Xcode project as a good starting point if you don't know where to look.

**Acceptance criteria**

Most timeouts are reduced when talking to the firewall, or using mullvad-api from within the UITests.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10678)
<!-- Reviewable:end -->
