### PR TITLE
Use a "Close" button in the Multihop migration

### DIFF
--- a/ios/MullvadVPN/Coordinators/Settings/SettingsMigrationWizard/SettingsMigrationWizardCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/SettingsMigrationWizard/SettingsMigrationWizardCoordinator.swift
@@ -52,16 +52,14 @@ class SettingsMigrationWizardCoordinator: Coordinator, SettingsChildCoordinator,
 
     private func customiseNavigation(on viewController: UIViewController) {
         if route == .settingsMigrationWizard {
-
-            let doneButton = UIBarButtonItem(
-                systemItem: .done,
+            let closeButton = UIBarButtonItem(
+                image: .Buttons.close,
                 primaryAction: UIAction(handler: { [weak self] _ in
                     guard let self else { return }
                     didFinish?(self, false)
                 })
             )
-            viewController.navigationItem.rightBarButtonItem = doneButton
+            viewController.navigationItem.leftBarButtonItem = closeButton
         }
     }
-
 }


### PR DESCRIPTION
As we still show a yellow indicator on the settings menu if this button is used, the exit button seems like a slightly better fit.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10679)
<!-- Reviewable:end -->
