### PR TITLE
Fix incorrectly returning zero exit relays when no entries are found

### DIFF
--- a/ios/MullvadREST/Relay/RelaySelectorWrapper.swift
+++ b/ios/MullvadREST/Relay/RelaySelectorWrapper.swift
@@ -64,50 +64,52 @@ public final class RelaySelectorWrapper: RelaySelectorProtocol, Sendable {
                     )
                 }
 
+        // It's important that we try "softly" here so that we can still try to find exit candidates
+        // even if there are no entry candidates.
         return if tunnelSettings.automaticMultihopIsEnabled {
             RelayCandidates(
-                entryRelays: try findCandidates(
+                entryRelays: (try? findCandidates(
                     relays,
                     tunnelSettings.daita.isEnabled,
                     tunnelSettings.relayConstraints.entryLocations,
                     tunnelSettings.relayConstraints.entryFilter,
                     obfuscation
-                ),
-                exitRelays: try findCandidates(
+                )) ?? [],
+                exitRelays: (try? findCandidates(
                     relays,
                     false,
                     tunnelSettings.relayConstraints.exitLocations,
                     tunnelSettings.relayConstraints.exitFilter,
                     nil
-                )
+                )) ?? []
             )
         } else if tunnelSettings.tunnelMultihopState.isAlways {
             RelayCandidates(
-                entryRelays: try findCandidates(
+                entryRelays: (try? findCandidates(
                     relays,
                     tunnelSettings.daita.isEnabled,
                     tunnelSettings.relayConstraints.entryLocations,
                     tunnelSettings.relayConstraints.entryFilter,
                     obfuscation
-                ),
-                exitRelays: try findCandidates(
+                )) ?? [],
+                exitRelays: (try? findCandidates(
                     relays,
                     false,
                     tunnelSettings.relayConstraints.exitLocations,
                     tunnelSettings.relayConstraints.exitFilter,
                     nil
-                )
+                )) ?? []
             )
         } else {
             RelayCandidates(
                 entryRelays: nil,
-                exitRelays: try findCandidates(
+                exitRelays: (try? findCandidates(
                     relays,
                     tunnelSettings.daita.isEnabled,
                     tunnelSettings.relayConstraints.exitLocations,
                     tunnelSettings.relayConstraints.exitFilter,
                     obfuscation
-                )
+                )) ?? []
             )
         }
     }


### PR DESCRIPTION
**What is being observed?**

Tested with both LWO and QUIC.

**Reproduction steps**

1. Filter entry server to a provider that does not support your chosen anti-censorship method
2. Select that anti-censorship method
3. Agree to get blocked in spite of the warning you receive
4. Entry filter view now shows erroneous compatibility for providers?
5. Change anti-censorship to automatic
6. Filter to a non-compatible provider via the filter view
7. Now change anti-censorship to your chosen anti-censorship method
8. Select location view is now borked. No choices can be made for either entry or exit.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10692)
<!-- Reviewable:end -->
