### PR TITLE
Ignore unrequested DAITA responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Line wrap the file at 100 chars.                                              Th
 - Align ciphers for custom shadowsocks API access methods between clients and `mullvad-daemon`. Any
   existing, invalid access method is removed with a settings migration.
 - Reject invalid DAITA fraction limits in tunnel config responses before starting the tunnel.
+- Ignore DAITA tunnel config responses unless DAITA was requested.
 
 #### Windows
 - Fix misleading "split tunneling" error when offline.

--- a/talpid-tunnel-config-client/src/lib.rs
+++ b/talpid-tunnel-config-client/src/lib.rs
@@ -227,11 +227,20 @@ pub async fn request_ephemeral_peer_with(
         None
     };
 
-    let daita = response.daita.map(parse_daita_response).transpose()?;
-    if daita.is_none() && enable_daita {
-        return Err(Error::MissingDaitaResponse);
-    }
+    let daita = parse_daita_response_if_requested(response.daita, enable_daita)?;
     Ok(EphemeralPeer { psk, daita })
+}
+
+fn parse_daita_response_if_requested(
+    daita: Option<proto::DaitaResponseV2>,
+    enable_daita: bool,
+) -> Result<Option<DaitaSettings>, Error> {
+    if !enable_daita {
+        return Ok(None);
+    }
+
+    let daita = daita.ok_or(Error::MissingDaitaResponse)?;
+    parse_daita_response(daita).map(Some)
 }
 
 fn parse_daita_response(daita: proto::DaitaResponseV2) -> Result<DaitaSettings, Error> {
@@ -348,6 +357,42 @@ mod tests {
             Ok(_) => panic!("expected DAITA response parsing to fail"),
             Err(error) => error,
         }
+    }
+
+    fn parse_daita_response_if_requested_error(
+        daita: Option<proto::DaitaResponseV2>,
+        enable_daita: bool,
+    ) -> Error {
+        match parse_daita_response_if_requested(daita, enable_daita) {
+            Ok(_) => panic!("expected optional DAITA response parsing to fail"),
+            Err(error) => error,
+        }
+    }
+
+    #[test]
+    fn parse_daita_response_if_requested_ignores_unrequested_response() {
+        let daita =
+            parse_daita_response_if_requested(Some(daita_response(f64::NAN, f64::INFINITY)), false)
+                .unwrap();
+
+        assert!(daita.is_none());
+    }
+
+    #[test]
+    fn parse_daita_response_if_requested_requires_requested_response() {
+        let error = parse_daita_response_if_requested_error(None, true);
+
+        assert!(matches!(error, Error::MissingDaitaResponse));
+    }
+
+    #[test]
+    fn parse_daita_response_if_requested_parses_requested_response() {
+        let settings = parse_daita_response_if_requested(Some(daita_response(0.25, 0.75)), true)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(settings.max_decoy_frac, 0.25);
+        assert_eq!(settings.max_delay_frac, 0.75);
     }
 
     #[test]


### PR DESCRIPTION
## what

Ignore `DaitaResponseV2` unless DAITA was requested, while still requiring it when DAITA is enabled

## why

The client only sends `daita_v2` when DAITA is requested, but it used to parse and return any DAITA response anyway. That could pass DAITA settings into callers that did not ask for them, including paths where the selected tunnel backend does not support DAITA

## testing

- `ci/cargo-ci.sh test -p talpid-tunnel-config-client`
- `cargo test -p talpid-tunnel-config-client --all-features`
- `cargo test -p talpid-tunnel-config-client --no-default-features`
- `ci/cargo-ci.sh clippy -p talpid-tunnel-config-client --all-targets --no-default-features`
- `ci/cargo-ci.sh clippy -p talpid-tunnel-config-client --all-targets --all-features`
- `ci/cargo-ci.sh check -p talpid-wireguard`
- `cargo fmt --check -p talpid-tunnel-config-client`
- `cargo fmt -- --check`
- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10700)
<!-- Reviewable:end -->
