### PR TITLE
Fix IPv6 obfuscation relay selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Line wrap the file at 100 chars.                                              Th
 - Reject invalid DAITA fraction limits in tunnel config responses before starting the tunnel.
 - Ignore DAITA tunnel config responses unless DAITA was requested.
 - Fix infinite loop of account checks when account ran out of time.
+- Fix IPv6 obfuscation relay selection when the relay's WireGuard endpoint only has IPv4.
 
 #### Linux
 - Fix issue where `gotatun` would fail to start on Linux systems where the

--- a/mullvad-relay-selector/src/relay_selector/endpoint_set.rs
+++ b/mullvad-relay-selector/src/relay_selector/endpoint_set.rs
@@ -224,10 +224,9 @@ impl RelayEndpointSet {
         } else {
             Constraint::Any
         };
-        // QUIC and Shadowsocks choose the public next-hop endpoint from their obfuscator config.
-        // Keep the requested WireGuard IP family when possible so endpoint metadata stays
-        // consistent, but fall back because the peer endpoint is patched to a local obfuscator
-        // before dialing.
+        // QUIC and Shadowsocks do not use the selected WireGuard endpoint, so it does not
+        // need to match the requested IP version. Use the same family when possible so IP
+        // overrides are derived correctly; otherwise, loosen the constraint.
         let wireguard_ip_version = match query {
             Constraint::Only(ObfuscationMode::Shadowsocks(_) | ObfuscationMode::Quic) => {
                 if self.wireguard.supports_ip_version(ip_version) {

--- a/mullvad-relay-selector/src/relay_selector/endpoint_set.rs
+++ b/mullvad-relay-selector/src/relay_selector/endpoint_set.rs
@@ -224,9 +224,23 @@ impl RelayEndpointSet {
         } else {
             Constraint::Any
         };
+        // QUIC and Shadowsocks choose the public next-hop endpoint from their obfuscator config.
+        // Keep the requested WireGuard IP family when possible so endpoint metadata stays
+        // consistent, but fall back because the peer endpoint is patched to a local obfuscator
+        // before dialing.
+        let wireguard_ip_version = match query {
+            Constraint::Only(ObfuscationMode::Shadowsocks(_) | ObfuscationMode::Quic) => {
+                if self.wireguard.supports_ip_version(ip_version) {
+                    ip_version
+                } else {
+                    Constraint::Any
+                }
+            }
+            _ => ip_version,
+        };
         let wireguard_endpoint = self
             .wireguard
-            .random_endpoint(ip_version, port)
+            .random_endpoint(wireguard_ip_version, port)
             .ok_or(Error::NoMatchingAddresses)?;
 
         let mode = match query {

--- a/mullvad-relay-selector/tests/relay_selector.rs
+++ b/mullvad-relay-selector/tests/relay_selector.rs
@@ -537,6 +537,60 @@ mod relay_selection {
         );
     }
 
+    #[test]
+    fn test_selecting_over_shadowsocks_ipv6_extra_ip_without_wireguard_ipv6() {
+        let mut relay_list = RelayListBuilder::new();
+        relay_list
+            .add_relay("shadowsocks-ipv6-extra")
+            .endpoint_data
+            .shadowsocks_extra_addr_in = HashSet::from([IpAddr::V6(Ipv6Addr::LOCALHOST)]);
+
+        let relay_selector = RelaySelector::from(relay_list);
+        let query = RelayQueryBuilder::new()
+            .ip_version(IpVersion::V6)
+            .shadowsocks()
+            .build();
+
+        let relay = relay_selector.get_relay_by_query(query).unwrap();
+        let Some(Obfuscators::Single(ObfuscatorConfig::Shadowsocks { endpoint })) =
+            relay.obfuscator
+        else {
+            panic!("Relay selector expected Shadowsocks obfuscation")
+        };
+        assert_eq!(endpoint.ip(), IpAddr::V6(Ipv6Addr::LOCALHOST));
+    }
+
+    #[test]
+    fn test_selecting_over_shadowsocks_ipv6_keeps_wireguard_ipv6_when_available() {
+        let wireguard_ipv6 = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1);
+        let shadowsocks_ipv6 = Ipv6Addr::LOCALHOST;
+
+        let mut relay_list = RelayListBuilder::new();
+        let relay = relay_list.add_relay("shadowsocks-ipv6");
+        relay.ipv6_addr_in = Some(wireguard_ipv6);
+        relay.endpoint_data.shadowsocks_extra_addr_in =
+            HashSet::from([IpAddr::V6(shadowsocks_ipv6)]);
+
+        let relay_selector = RelaySelector::from(relay_list);
+        let query = RelayQueryBuilder::new()
+            .ip_version(IpVersion::V6)
+            .shadowsocks()
+            .build();
+
+        let relay = relay_selector.get_relay_by_query(query).unwrap();
+        assert_eq!(
+            relay.endpoint.peer.endpoint.ip(),
+            IpAddr::V6(wireguard_ipv6)
+        );
+
+        let Some(Obfuscators::Single(ObfuscatorConfig::Shadowsocks { endpoint })) =
+            relay.obfuscator
+        else {
+            panic!("Relay selector expected Shadowsocks obfuscation")
+        };
+        assert_eq!(endpoint.ip(), IpAddr::V6(shadowsocks_ipv6));
+    }
+
     /// Test whether Quic is always selected as the obfuscation protocol when Quic is selected.
     #[test]
     fn test_selecting_over_quic() {
@@ -557,6 +611,62 @@ mod relay_selection {
             obfuscator,
             Obfuscators::Single(ObfuscatorConfig::Quic { .. }),
         )));
+    }
+
+    #[test]
+    fn test_selecting_over_quic_ipv6_without_wireguard_ipv6() {
+        let mut relay_list = RelayListBuilder::new();
+        relay_list.add_relay("quic-ipv6").endpoint_data.quic = Some(Quic::new(
+            vec1![Ipv6Addr::LOCALHOST.into()],
+            "Bearer test".to_owned(),
+            "quic-ipv6.example".to_owned(),
+        ));
+
+        let relay_selector = RelaySelector::from(relay_list);
+        let query = RelayQueryBuilder::new()
+            .ip_version(IpVersion::V6)
+            .quic()
+            .build();
+
+        let relay = relay_selector.get_relay_by_query(query).unwrap();
+        let Some(Obfuscators::Single(ObfuscatorConfig::Quic { endpoint, .. })) = relay.obfuscator
+        else {
+            panic!("Relay selector expected QUIC obfuscation")
+        };
+        assert_eq!(endpoint.ip(), IpAddr::V6(Ipv6Addr::LOCALHOST));
+    }
+
+    #[test]
+    fn test_selecting_over_quic_ipv6_keeps_wireguard_ipv6_when_available() {
+        let wireguard_ipv6 = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1);
+        let quic_ipv6 = Ipv6Addr::LOCALHOST;
+
+        let mut relay_list = RelayListBuilder::new();
+        let relay = relay_list.add_relay("quic-ipv6");
+        relay.ipv6_addr_in = Some(wireguard_ipv6);
+        relay.endpoint_data.quic = Some(Quic::new(
+            vec1![quic_ipv6.into()],
+            "Bearer test".to_owned(),
+            "quic-ipv6.example".to_owned(),
+        ));
+
+        let relay_selector = RelaySelector::from(relay_list);
+        let query = RelayQueryBuilder::new()
+            .ip_version(IpVersion::V6)
+            .quic()
+            .build();
+
+        let relay = relay_selector.get_relay_by_query(query).unwrap();
+        assert_eq!(
+            relay.endpoint.peer.endpoint.ip(),
+            IpAddr::V6(wireguard_ipv6)
+        );
+
+        let Some(Obfuscators::Single(ObfuscatorConfig::Quic { endpoint, .. })) = relay.obfuscator
+        else {
+            panic!("Relay selector expected QUIC obfuscation")
+        };
+        assert_eq!(endpoint.ip(), IpAddr::V6(quic_ipv6));
     }
 
     /// Test LWO relay selection


### PR DESCRIPTION
## what

Fix explicit IPv6 QUIC and Shadowsocks relay selection when the relay has an IPv6 obfuscator endpoint but no IPv6 WireGuard endpoint

The selected WireGuard endpoint is patched to a local obfuscator before dialing, so for these modes it only needs to identify the relay peer. The public next-hop endpoint still comes from the QUIC/Shadowsocks config and keeps the requested IP family

## why

Filtering already accepts these relays based on the obfuscator endpoint family, but concrete selection could fail first while trying to pick a WireGuard endpoint with the same IP constraint

## testing

- `ci/cargo-ci.sh test -p mullvad-relay-selector`
- `ci/cargo-ci.sh test -p mullvad-relay-selector --all-features`
- `ci/cargo-ci.sh test -p mullvad-relay-selector --no-default-features`
- `ci/cargo-ci.sh clippy -p mullvad-relay-selector --all-targets`
- `ci/cargo-ci.sh clippy -p mullvad-relay-selector --all-targets --all-features`
- `ci/cargo-ci.sh clippy -p mullvad-relay-selector --all-targets --no-default-features`
- `cargo fmt --package mullvad-relay-selector --check`
- `cargo fmt -- --check`
- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10711)
<!-- Reviewable:end -->
