### PR TITLE
Document all uses of `unsafe` in mullvad-ios

### DIFF
--- a/ios/MullvadRustRuntime/MullvadShadowsocksBridgeProvider.swift
+++ b/ios/MullvadRustRuntime/MullvadShadowsocksBridgeProvider.swift
@@ -16,7 +16,7 @@ public func initMullvadShadowsocksBridgeProvider(provider: SwiftShadowsocksBridg
 }
 
 @_cdecl("swift_get_shadowsocks_bridges")
-func getShadowsocksBridges(rawBridgeProvider: UnsafeMutableRawPointer) -> UnsafeRawPointer? {
+func getShadowsocksBridges(rawBridgeProvider: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer? {
     let bridgeProvider = Unmanaged<SwiftShadowsocksBridgeProvider>.fromOpaque(rawBridgeProvider).takeUnretainedValue()
     guard let bridge = bridgeProvider.bridge() else { return nil }
     let bridgeAddress = bridge.address.rawValue.map { $0 }

--- a/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
+++ b/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
@@ -252,7 +252,7 @@ void *convert_builtin_access_method_setting(const char *unique_identifier,
                                             const char *name,
                                             bool is_enabled,
                                             SwiftAccessMethodKind method_kind,
-                                            const void *proxy_configuration);
+                                            void *proxy_configuration);
 
 /**
  * Creates a wrapper around a `Settings` object that can be safely sent across the FFI boundary.
@@ -262,10 +262,10 @@ void *convert_builtin_access_method_setting(const char *unique_identifier,
  * resulting from a call to `convert_builtin_access_method_setting`
  * `custom_methods_raw` is an array of pointers to instances of `AccessMethodSetting`
  */
-struct SwiftAccessMethodSettingsWrapper init_access_method_settings_wrapper(const void *direct_method_raw,
-                                                                            const void *bridges_method_raw,
-                                                                            const void *encrypted_dns_method_raw,
-                                                                            const void *custom_methods_raw,
+struct SwiftAccessMethodSettingsWrapper init_access_method_settings_wrapper(void *direct_method_raw,
+                                                                            void *bridges_method_raw,
+                                                                            void *encrypted_dns_method_raw,
+                                                                            void *custom_methods_raw,
                                                                             uintptr_t custom_method_count);
 
 /**
@@ -563,11 +563,11 @@ struct SwiftCancelHandle mullvad_ios_rotate_device_key(struct SwiftApiContext ap
  * `address` must be a pointer to at least `address_len` bytes.
  * `c_password` and `c_cipher` must be pointers to null terminated strings
  */
-const void *new_shadowsocks_access_method_setting(const uint8_t *address,
-                                                  uintptr_t address_len,
-                                                  uint16_t port,
-                                                  const char *c_password,
-                                                  const char *c_cipher);
+void *new_shadowsocks_access_method_setting(const uint8_t *address,
+                                            uintptr_t address_len,
+                                            uint16_t port,
+                                            const char *c_password,
+                                            const char *c_cipher);
 
 /**
  * Converts parameters into a boxed `Socks5Remote` configuration that is safe
@@ -578,11 +578,11 @@ const void *new_shadowsocks_access_method_setting(const uint8_t *address,
  * `address` must be a pointer to at least `address_len` bytes.
  * `c_username` and `c_password` must be pointers to null terminated strings, or null
  */
-const void *new_socks5_access_method_setting(const uint8_t *address,
-                                             uintptr_t address_len,
-                                             uint16_t port,
-                                             const char *c_username,
-                                             const char *c_password);
+void *new_socks5_access_method_setting(const uint8_t *address,
+                                       uintptr_t address_len,
+                                       uint16_t port,
+                                       const char *c_username,
+                                       const char *c_password);
 
 char *get_shadowsocks_chipers(void);
 

--- a/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
+++ b/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
@@ -899,6 +899,14 @@ void log_redactor_free(struct LogRedactor *redactor);
  */
 void init_rust_logging(LogCallback callback, void *context);
 
+/**
+ * Start a udp2tcp obfuscator proxy.
+ *
+ * # SAFETY
+ * `peer_address` must be a valid pointer to `peer_address_len` bytes, these bytes will be
+ * interpreted  as an IP address. `proxy_handle` must be a valid pointer for a `ProxyHandle`
+ * struct. This function will initialize `proxy_handle` to contain a valid `ProxyHandle` instance.
+ */
 int32_t start_udp2tcp_obfuscator_proxy(const uint8_t *peer_address,
                                        uintptr_t peer_address_len,
                                        uint16_t peer_port,

--- a/mullvad-ios/src/api_client/access_method_settings.rs
+++ b/mullvad-ios/src/api_client/access_method_settings.rs
@@ -124,8 +124,8 @@ pub enum SwiftAccessMethodKind {
 ///
 /// # SAFETY
 /// `direct_method_raw`, `bridges_method_raw` and `encrypted_dns_method_raw` must be raw pointers
-/// resulting from a call to `convert_builtin_access_method_setting`
-/// `custom_methods_raw` is an array of pointers to instances of `AccessMethodSetting`
+/// resulting from a call to `convert_builtin_access_method_setting`.
+/// `custom_methods_raw` is an array of pointers to instances of `AccessMethodSetting`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn init_access_method_settings_wrapper(
     direct_method_raw: *const c_void,
@@ -134,7 +134,8 @@ pub unsafe extern "C" fn init_access_method_settings_wrapper(
     custom_methods_raw: *const c_void,
     custom_method_count: usize,
 ) -> SwiftAccessMethodSettingsWrapper {
-    // SAFETY: See `init_access_method_settings_wrapper`
+    // SAFETY: each of these pointers must be created by a call to
+    // `convert_builtin_access_method_setting`, as per the function docs.
     let (direct, mullvad_bridges, encrypted_dns_proxy) = unsafe {
         (
             *Box::from_raw(direct_method_raw as *mut _),
@@ -143,6 +144,7 @@ pub unsafe extern "C" fn init_access_method_settings_wrapper(
         )
     };
 
+    // SAFETY: custom_methods_raw must be a valid pointer to an AccessMethodSetting.
     let custom =
         unsafe { access_methods_from_raw_array(custom_methods_raw.cast(), custom_method_count) };
     let settings = Settings::new(direct, mullvad_bridges, encrypted_dns_proxy, custom);
@@ -185,7 +187,10 @@ impl SwiftAccessMethodSettingsWrapper {
         SwiftAccessMethodSettingsWrapper(Box::into_raw(Box::new(context)))
     }
 
+    /// SAFETY: self must be constructed via [`SwiftAccessMethodSettingsWrapper::new`].
     pub unsafe fn into_rust_context(self) -> Box<SwiftAccessMethodSettingsContext> {
+        // SAFETY: the self.0 pointer must be valid as per the callee guarantee that `self` was
+        // constructed by [`SwiftAccessMethodSettingsWrapper::new`]
         unsafe { Box::from_raw(self.0) }
     }
 }

--- a/mullvad-ios/src/api_client/access_method_settings.rs
+++ b/mullvad-ios/src/api_client/access_method_settings.rs
@@ -28,7 +28,7 @@ unsafe extern "C" fn convert_builtin_access_method_setting(
     name: *const c_char,
     is_enabled: bool,
     method_kind: SwiftAccessMethodKind,
-    proxy_configuration: *const c_void,
+    proxy_configuration: *mut c_void,
 ) -> *mut c_void {
     match convert_builtin_access_method_setting_inner(
         unique_identifier,
@@ -51,7 +51,7 @@ fn convert_builtin_access_method_setting_inner(
     name: *const c_char,
     enabled: bool,
     method_kind: SwiftAccessMethodKind,
-    proxy_configuration: *const c_void,
+    proxy_configuration: *mut c_void,
 ) -> Option<AccessMethodSetting> {
     // SAFETY: See `convert_builtin_access_method_setting`
     let id = unsafe { Id::from_string(get_string(unique_identifier))? };
@@ -128,19 +128,19 @@ pub enum SwiftAccessMethodKind {
 /// `custom_methods_raw` is an array of pointers to instances of `AccessMethodSetting`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn init_access_method_settings_wrapper(
-    direct_method_raw: *const c_void,
-    bridges_method_raw: *const c_void,
-    encrypted_dns_method_raw: *const c_void,
-    custom_methods_raw: *const c_void,
+    direct_method_raw: *mut c_void,
+    bridges_method_raw: *mut c_void,
+    encrypted_dns_method_raw: *mut c_void,
+    custom_methods_raw: *mut c_void,
     custom_method_count: usize,
 ) -> SwiftAccessMethodSettingsWrapper {
     // SAFETY: each of these pointers must be created by a call to
     // `convert_builtin_access_method_setting`, as per the function docs.
     let (direct, mullvad_bridges, encrypted_dns_proxy) = unsafe {
         (
-            *Box::from_raw(direct_method_raw as *mut _),
-            *Box::from_raw(bridges_method_raw as *mut _),
-            *Box::from_raw(encrypted_dns_method_raw as *mut _),
+            *Box::from_raw(direct_method_raw as *mut AccessMethodSetting),
+            *Box::from_raw(bridges_method_raw as *mut AccessMethodSetting),
+            *Box::from_raw(encrypted_dns_method_raw as *mut AccessMethodSetting),
         )
     };
 

--- a/mullvad-ios/src/api_client/account.rs
+++ b/mullvad-ios/src/api_client/account.rs
@@ -37,6 +37,7 @@ pub unsafe extern "C" fn mullvad_ios_get_account(
     retry_strategy: SwiftRetryStrategy,
     account_number: *const c_char,
 ) -> SwiftCancelHandle {
+    // SAFETY: It is safe to call CompletionCookie::new with a valid completion cookie
     let completion_handler =
         SwiftCompletionHandler::new(unsafe { CompletionCookie::new(completion_cookie) });
 
@@ -93,6 +94,7 @@ pub unsafe extern "C" fn mullvad_ios_create_account(
     completion_cookie: *mut libc::c_void,
     retry_strategy: SwiftRetryStrategy,
 ) -> SwiftCancelHandle {
+    // SAFETY: It is safe to call CompletionCookie::new with a valid completion cookie
     let completion_handler =
         SwiftCompletionHandler::new(unsafe { CompletionCookie::new(completion_cookie) });
 
@@ -141,6 +143,7 @@ pub unsafe extern "C" fn mullvad_ios_delete_account(
     retry_strategy: SwiftRetryStrategy,
     account_number: *const c_char,
 ) -> SwiftCancelHandle {
+    // SAFETY: It is safe to call CompletionCookie::new with a valid completion cookie
     let completion_handler =
         SwiftCompletionHandler::new(unsafe { CompletionCookie::new(completion_cookie) });
 

--- a/mullvad-ios/src/api_client/api.rs
+++ b/mullvad-ios/src/api_client/api.rs
@@ -36,6 +36,7 @@ pub unsafe extern "C" fn mullvad_ios_get_addresses(
     completion_cookie: *mut libc::c_void,
     retry_strategy: SwiftRetryStrategy,
 ) -> SwiftCancelHandle {
+    // SAFETY: It is safe to call CompletionCookie::new with a valid completion cookie
     let completion_handler =
         SwiftCompletionHandler::new(unsafe { CompletionCookie::new(completion_cookie) });
 
@@ -82,6 +83,7 @@ pub unsafe extern "C" fn mullvad_ios_api_addrs_available(
     retry_strategy: SwiftRetryStrategy,
     access_method_setting: *const c_void,
 ) -> SwiftCancelHandle {
+    // SAFETY: It is safe to call CompletionCookie::new with a valid completion cookie
     let completion_handler =
         SwiftCompletionHandler::new(unsafe { CompletionCookie::new(completion_cookie) });
 
@@ -157,6 +159,7 @@ pub unsafe extern "C" fn mullvad_ios_get_relays(
     retry_strategy: SwiftRetryStrategy,
     etag: *const c_char,
 ) -> SwiftCancelHandle {
+    // SAFETY: It is safe to call CompletionCookie::new with a valid completion cookie
     let completion_handler =
         SwiftCompletionHandler::new(unsafe { CompletionCookie::new(completion_cookie) });
 

--- a/mullvad-ios/src/api_client/device.rs
+++ b/mullvad-ios/src/api_client/device.rs
@@ -42,6 +42,7 @@ pub unsafe extern "C" fn mullvad_ios_get_device(
     account_number: *const c_char,
     identifier: *const c_char,
 ) -> SwiftCancelHandle {
+    // SAFETY: It is safe to call CompletionCookie::new with a valid completion cookie
     let completion_handler =
         SwiftCompletionHandler::new(unsafe { CompletionCookie::new(completion_cookie) });
 
@@ -51,9 +52,11 @@ pub unsafe extern "C" fn mullvad_ios_get_device(
     };
 
     let api_context = api_context.rust_context();
-    // Safety: The caller must guarantee that `retry_strategy` is not null and has not been freed
+    // SAFETY: The caller must guarantee that `retry_strategy` is not null and has not been freed
     let retry_strategy = unsafe { retry_strategy.into_rust() };
+    // SAFETY: The caller must guarantee that `account_number` is a valid C string pointer
     let account_number = unsafe { get_string(account_number) };
+    // SAFETY: The caller must guarantee that `identifier` is a valid C string pointer
     let identifier = unsafe { get_string(identifier) };
 
     let completion = completion_handler.clone();
@@ -101,6 +104,7 @@ pub unsafe extern "C" fn mullvad_ios_get_devices(
     retry_strategy: SwiftRetryStrategy,
     account_number: *const c_char,
 ) -> SwiftCancelHandle {
+    // SAFETY: It is safe to call CompletionCookie::new with a valid completion cookie
     let completion_handler =
         SwiftCompletionHandler::new(unsafe { CompletionCookie::new(completion_cookie) });
 
@@ -110,8 +114,9 @@ pub unsafe extern "C" fn mullvad_ios_get_devices(
     };
 
     let api_context = api_context.rust_context();
-    // Safety: The caller must guarantee that `retry_strategy` is not null and has not been freed
+    // SAFETY: The caller must guarantee that `retry_strategy` is not null and has not been freed
     let retry_strategy = unsafe { retry_strategy.into_rust() };
+    // SAFETY: The caller must guarantee that `account_number` is a valid C string pointer
     let account_number = unsafe { get_string(account_number) };
 
     let completion = completion_handler.clone();
@@ -160,6 +165,7 @@ pub unsafe extern "C" fn mullvad_ios_create_device(
     account_number: *const c_char,
     public_key: *const u8,
 ) -> SwiftCancelHandle {
+    // SAFETY: It is safe to call CompletionCookie::new with a valid completion cookie
     let completion_handler =
         SwiftCompletionHandler::new(unsafe { CompletionCookie::new(completion_cookie) });
 
@@ -171,6 +177,7 @@ pub unsafe extern "C" fn mullvad_ios_create_device(
     let api_context = api_context.rust_context();
     // Safety: The caller must guarantee that `retry_strategy` is not null and has not been freed
     let retry_strategy = unsafe { retry_strategy.into_rust() };
+    // SAFETY: The caller must guarantee that `account_number` is a valid C string pointer
     let account_number = unsafe { get_string(account_number) };
     // Safety: `public_key` pointer must be a valid pointer to 32 unsigned bytes.
     let pub_key: [u8; 32] = unsafe { ptr::read(public_key as *const [u8; 32]) };
@@ -221,6 +228,7 @@ pub unsafe extern "C" fn mullvad_ios_delete_device(
     account_number: *const c_char,
     identifier: *const c_char,
 ) -> SwiftCancelHandle {
+    // SAFETY: It is safe to call CompletionCookie::new with a valid completion cookie
     let completion_handler =
         SwiftCompletionHandler::new(unsafe { CompletionCookie::new(completion_cookie) });
 
@@ -230,9 +238,11 @@ pub unsafe extern "C" fn mullvad_ios_delete_device(
     };
 
     let api_context = api_context.rust_context();
-    // Safety: The caller must guarantee that `retry_strategy` is not null and has not been freed
+    // SAFETY: The caller must guarantee that `retry_strategy` is not null and has not been freed
     let retry_strategy = unsafe { retry_strategy.into_rust() };
+    // SAFETY: The caller must guarantee that `account_number` is a valid C string pointer
     let account_number = unsafe { get_string(account_number) };
+    // SAFETY: The caller must guarantee that `identifier` is a valid C string pointer
     let identifier = unsafe { get_string(identifier) };
 
     let completion = completion_handler.clone();
@@ -283,6 +293,7 @@ pub unsafe extern "C" fn mullvad_ios_rotate_device_key(
     identifier: *const c_char,
     public_key: *const u8,
 ) -> SwiftCancelHandle {
+    // SAFETY: It is safe to call CompletionCookie::new with a valid completion cookie
     let completion_handler =
         SwiftCompletionHandler::new(unsafe { CompletionCookie::new(completion_cookie) });
 
@@ -292,11 +303,13 @@ pub unsafe extern "C" fn mullvad_ios_rotate_device_key(
     };
 
     let api_context = api_context.rust_context();
-    // Safety: The caller must guarantee that `retry_strategy` is not null and has not been freed
+    // SAFETY: The caller must guarantee that `retry_strategy` is not null and has not been freed
     let retry_strategy = unsafe { retry_strategy.into_rust() };
+    // SAFETY: The caller must guarantee that `account_number` is a valid C string pointer
     let account_number = unsafe { get_string(account_number) };
+    // SAFETY: The caller must guarantee that `identifier` is a valid C string pointer
     let identifier = unsafe { get_string(identifier) };
-    // Safety: `public_key` pointer must be a valid pointer to 32 unsigned bytes.
+    // SAFETY: `public_key` pointer must be a valid pointer to 32 unsigned bytes.
     let pub_key: [u8; 32] = unsafe { ptr::read(public_key as *const [u8; 32]) };
 
     let completion = completion_handler.clone();

--- a/mullvad-ios/src/api_client/helpers.rs
+++ b/mullvad-ios/src/api_client/helpers.rs
@@ -48,13 +48,16 @@ pub unsafe extern "C" fn new_shadowsocks_access_method_setting(
     c_cipher: *const c_char,
 ) -> *const c_void {
     let endpoint: SocketAddr =
+        // SAFETY: `addr` pointer must be non-null, aligned, and point to at least addr_len bytes
         if let Some(ip_address) = unsafe { parse_ip_addr(address, address_len) } {
             SocketAddr::new(ip_address, port)
         } else {
             return std::ptr::null();
         };
 
+    // SAFETY: `c_password` pointer must be a valid C string pointer
     let password = unsafe { get_string(c_password) };
+    // SAFETY: `c_cipher` pointer must be a valid C string pointer
     let cipher = unsafe { get_string(c_cipher) };
     let cipher = ShadowsocksCipher::new(&cipher).unwrap();
 
@@ -79,6 +82,7 @@ pub unsafe extern "C" fn new_socks5_access_method_setting(
     c_password: *const c_char,
 ) -> *const c_void {
     let endpoint: SocketAddr =
+        // SAFETY: caller guarantees that `address` is valid for at least `address_len` bytes
         if let Some(ip_address) = unsafe { parse_ip_addr(address, address_len) } {
             SocketAddr::new(ip_address, port)
         } else {
@@ -89,7 +93,9 @@ pub unsafe extern "C" fn new_socks5_access_method_setting(
         if c_username.is_null() || c_password.is_null() {
             None
         } else {
+            // SAFETY: The caller must guarantee that `c_username` is a valid C string pointer
             let username = unsafe { get_string(c_username) };
+            // SAFETY: The caller must guarantee that `c_password` is a valid C string pointer
             let password = unsafe { get_string(c_password) };
             SocksAuth::new(username, password).ok()
         }
@@ -114,5 +120,6 @@ pub extern "C" fn get_shadowsocks_chipers() -> *mut libc::c_char {
 /// `cstr_ptr` must be a pointer to a string allocated by another `mullvad_api` function.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn mullvad_api_cstring_drop(cstr_ptr: *mut libc::c_char) {
+    // SAFETY: caller guarantees that `cstr_ptr` is a valid C string pointer
     let _ = unsafe { CString::from_raw(cstr_ptr) };
 }

--- a/mullvad-ios/src/api_client/helpers.rs
+++ b/mullvad-ios/src/api_client/helpers.rs
@@ -46,13 +46,13 @@ pub unsafe extern "C" fn new_shadowsocks_access_method_setting(
     port: u16,
     c_password: *const c_char,
     c_cipher: *const c_char,
-) -> *const c_void {
+) -> *mut c_void {
     let endpoint: SocketAddr =
         // SAFETY: `addr` pointer must be non-null, aligned, and point to at least addr_len bytes
         if let Some(ip_address) = unsafe { parse_ip_addr(address, address_len) } {
             SocketAddr::new(ip_address, port)
         } else {
-            return std::ptr::null();
+            return std::ptr::null_mut();
         };
 
     // SAFETY: `c_password` pointer must be a valid C string pointer
@@ -80,13 +80,13 @@ pub unsafe extern "C" fn new_socks5_access_method_setting(
     port: u16,
     c_username: *const c_char,
     c_password: *const c_char,
-) -> *const c_void {
+) -> *mut c_void {
     let endpoint: SocketAddr =
         // SAFETY: caller guarantees that `address` is valid for at least `address_len` bytes
         if let Some(ip_address) = unsafe { parse_ip_addr(address, address_len) } {
             SocketAddr::new(ip_address, port)
         } else {
-            return std::ptr::null();
+            return std::ptr::null_mut();
         };
 
     let auth = {

--- a/mullvad-ios/src/api_client/mod.rs
+++ b/mullvad-ios/src/api_client/mod.rs
@@ -97,6 +97,8 @@ struct ForeignPtr {
     ptr: *const c_void,
 }
 /// allow this to be passed across thread boundaries
+/// SAFETY: the user of `ForeignPtr` must ensure that it is safe to use the pointer from different
+/// threads.
 unsafe impl Send for ForeignPtr {}
 
 /// Called by Swift to set the available access methods
@@ -105,6 +107,7 @@ pub unsafe extern "C" fn mullvad_api_update_access_methods(
     api_context: SwiftApiContext,
     settings_wrapper: SwiftAccessMethodSettingsWrapper,
 ) {
+    // SAFETY: `settings_wrapper` must be a valid instance of SwiftAccessMethodSettingsWrapper
     let access_methods = unsafe { settings_wrapper.into_rust_context().settings };
     api_context
         .rust_context()

--- a/mullvad-ios/src/api_client/problem_report.rs
+++ b/mullvad-ios/src/api_client/problem_report.rs
@@ -42,6 +42,7 @@ pub unsafe extern "C" fn mullvad_ios_send_problem_report(
     retry_strategy: SwiftRetryStrategy,
     request: SwiftProblemReportRequest,
 ) -> SwiftCancelHandle {
+    // SAFETY: It is safe to call CompletionCookie::new with a valid completion cookie
     let completion_handler =
         SwiftCompletionHandler::new(unsafe { CompletionCookie::new(completion_cookie) });
     let completion = completion_handler.clone();
@@ -123,8 +124,11 @@ struct ProblemReportRequest {
 impl ProblemReportRequest {
     // SAFETY: the members of `SwiftProblemReportRequest` must point to null-terminated strings
     unsafe fn from_swift_parameters(request: SwiftProblemReportRequest) -> Option<Self> {
+        // SAFETY: caller guarantees that `request.address` is a valid C string pointer
         let address = unsafe { get_string(request.address) };
+        // SAFETY: caller guarantees that `request.message` is a valid C string pointer
         let message = unsafe { get_string(request.message) };
+        // SAFETY: caller guarantees that `request.log` is a valid C string pointer
         let log = unsafe { get_string(request.log) }.into();
 
         let metadata = if request.metadata.inner.is_null() {
@@ -133,6 +137,7 @@ impl ProblemReportRequest {
             let swift_map = &request.metadata;
             let mut converted_map = BTreeMap::new();
 
+            // SAFETY: caller guarantees that `swift_map.inner` is a valid pointer to a [`Map`]
             if let Some(inner) = unsafe { swift_map.inner.as_ref() } {
                 for (key, value) in &inner.0 {
                     converted_map.insert(key.clone(), value.clone());

--- a/mullvad-ios/src/api_client/response.rs
+++ b/mullvad-ios/src/api_client/response.rs
@@ -144,6 +144,8 @@ impl SwiftMullvadApiResponse {
 /// is not safe to call multiple times with the same `SwiftMullvadApiResponse`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn mullvad_response_drop(response: SwiftMullvadApiResponse) {
+    // SAFETY: `response` must be a valid instance of `SwiftMullvadApiResponse`, i.e. it has to
+    // have been constructed by any of the static functions that create the struct.
     unsafe {
         if !response.body.is_null() {
             let _ = Vec::from_raw_parts(response.body, response.body_size, response.body_size);

--- a/mullvad-ios/src/api_client/retry_strategy.rs
+++ b/mullvad-ios/src/api_client/retry_strategy.rs
@@ -9,6 +9,7 @@ impl SwiftRetryStrategy {
     /// # Safety
     /// The pointer must be a pointing to a valid instance of a `Box<RetryStrategy>`.
     pub unsafe fn into_rust(self) -> RetryStrategy {
+        // SAFETY: the pointer must be pointing to a valid instance of a `Box<RetryStrategy>`
         unsafe { *Box::from_raw(self.0) }
     }
 }

--- a/mullvad-ios/src/api_client/storekit.rs
+++ b/mullvad-ios/src/api_client/storekit.rs
@@ -37,6 +37,7 @@ pub unsafe extern "C" fn mullvad_ios_init_storekit_payment(
     retry_strategy: SwiftRetryStrategy,
     account_number: *const c_char,
 ) -> SwiftCancelHandle {
+    // SAFETY: It is safe to call CompletionCookie::new with a valid completion cookie
     let completion_handler =
         SwiftCompletionHandler::new(unsafe { CompletionCookie::new(completion_cookie) });
 
@@ -111,6 +112,7 @@ pub unsafe extern "C" fn mullvad_ios_check_storekit_payment(
     body: *const u8,
     body_size: usize,
 ) -> SwiftCancelHandle {
+    // SAFETY: It is safe to call CompletionCookie::new with a valid completion cookie
     let completion_handler =
         SwiftCompletionHandler::new(unsafe { CompletionCookie::new(completion_cookie) });
 

--- a/mullvad-ios/src/api_client/swift_data.rs
+++ b/mullvad-ios/src/api_client/swift_data.rs
@@ -30,6 +30,7 @@ impl Drop for SwiftData {
     // SAFETY: swift_data_drop is a deterministic function that releases and
     // zeroes the pointer to any data held, if present. It is idempotent.
     fn drop(&mut self) {
+        // SAFETY: `self` must be a valid instance of `SwiftData`
         unsafe { swift_data_drop(self) }
     }
 }

--- a/mullvad-ios/src/lib.rs
+++ b/mullvad-ios/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg(target_os = "ios")]
-#![allow(clippy::undocumented_unsafe_blocks)]
 use libc::c_char;
 use std::ffi::CStr;
 use std::sync::OnceLock;

--- a/mullvad-ios/src/log_redactor.rs
+++ b/mullvad-ios/src/log_redactor.rs
@@ -158,6 +158,7 @@ unsafe fn ptr_array_to_vec(ptr: *const *const libc::c_char, count: usize) -> Vec
         return Vec::new();
     }
 
+    // SAFETY: as per the caller docs, `ptr` must be a valid array for at least `count` pointers
     unsafe { std::slice::from_raw_parts(ptr, count) }
         .iter()
         .filter_map(|&p| {
@@ -165,7 +166,7 @@ unsafe fn ptr_array_to_vec(ptr: *const *const libc::c_char, count: usize) -> Vec
                 return None;
             }
 
-            // # Safety
+            // SAFETY:
             // - `p` must point to a valid, null-terminated C string.
             // - The pointed-to string must contain valid UTF-8.
             unsafe { CStr::from_ptr(p) }
@@ -191,7 +192,9 @@ pub unsafe extern "C" fn log_redactor_redact(
         return std::ptr::null_mut();
     }
 
+    // SAFETY: `redactor` pointer must point to a valid `LogRedactor` instance
     let redactor = unsafe { &*redactor };
+    // SAFETY: `input` must be a valid C string pointer
     let input_str = match unsafe { CStr::from_ptr(input) }.to_str() {
         Ok(s) => s,
         Err(_) => return std::ptr::null_mut(),
@@ -215,6 +218,7 @@ pub unsafe extern "C" fn log_redactor_redact(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn log_redactor_free_string(ptr: *mut libc::c_char) {
     if !ptr.is_null() {
+        // SAFETY: `ptr` must be a valid C string pointer
         drop(unsafe { CString::from_raw(ptr) });
     }
 }
@@ -233,7 +237,9 @@ pub extern "C" fn log_redactor_add_custom_string(
         return;
     }
 
+    // SAFETY: `redactor` must be a valid pointer to a [`LogRedactor`] instance
     let redactor = unsafe { &mut *redactor };
+    // SAFETY: `input` must be a valid C string pointer
     let Ok(input_str) = unsafe { CStr::from_ptr(input) }.to_str() else {
         return;
     };
@@ -250,6 +256,7 @@ pub extern "C" fn log_redactor_add_custom_string(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn log_redactor_free(redactor: *mut LogRedactor) {
     if !redactor.is_null() {
+        // SAFETY: `redactor` must be a valid pointer to a `Box<LogRedactor>`
         drop(unsafe { Box::from_raw(redactor) });
     }
 }

--- a/mullvad-ios/src/logging.rs
+++ b/mullvad-ios/src/logging.rs
@@ -85,6 +85,10 @@ struct SwiftLayer {
 // by the Swift side for the lifetime of the program. The callback is a static
 // function pointer. Both are safe to send across threads.
 unsafe impl Send for SwiftLayer {}
+
+// SAFETY: The context pointer points to a Swift Logger instance that is retained
+// by the Swift side for the lifetime of the program. The callback is a static
+// function pointer. Both are safe to send across threads.
 unsafe impl Sync for SwiftLayer {}
 
 impl SwiftLayer {

--- a/mullvad-ios/src/tunnel_obfuscator_proxy/ffi.rs
+++ b/mullvad-ios/src/tunnel_obfuscator_proxy/ffi.rs
@@ -16,6 +16,12 @@ macro_rules! throw_int_error {
     };
 }
 
+/// Start a udp2tcp obfuscator proxy.
+///
+/// # SAFETY
+/// `peer_address` must be a valid pointer to `peer_address_len` bytes, these bytes will be
+/// interpreted  as an IP address. `proxy_handle` must be a valid pointer for a `ProxyHandle`
+/// struct. This function will initialize `proxy_handle` to contain a valid `ProxyHandle` instance.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn start_udp2tcp_obfuscator_proxy(
     peer_address: *const u8,
@@ -23,10 +29,13 @@ pub unsafe extern "C" fn start_udp2tcp_obfuscator_proxy(
     peer_port: u16,
     proxy_handle: *mut ProxyHandle,
 ) -> i32 {
+    // SAFETY: `peer_address` must be a valid pointer to `peer_address_len` bytes, representing an
+    // IP address
     let peer_sock_addr =
         throw_int_error!(unsafe { get_socket_address(peer_address, peer_address_len, peer_port) });
     let result = TunnelObfuscatorRuntime::new_udp2tcp(peer_sock_addr).run();
 
+    // SAFETY: `proxy_handle` must be a valid pointer to enough memory for a `ProxyHandle` struct
     unsafe { start(proxy_handle, result) }
 }
 
@@ -37,10 +46,12 @@ pub unsafe extern "C" fn start_shadowsocks_obfuscator_proxy(
     peer_port: u16,
     proxy_handle: *mut ProxyHandle,
 ) -> i32 {
+    // SAFETY: `peer_address` must be a valid pointer to `peer_address_len` bytes, representing an
     let peer_sock_addr =
         throw_int_error!(unsafe { get_socket_address(peer_address, peer_address_len, peer_port) });
     let result = TunnelObfuscatorRuntime::new_shadowsocks(peer_sock_addr).run();
 
+    // SAFETY: `proxy_handle` must be a valid pointer to enough memory for a `ProxyHandle` struct
     unsafe { start(proxy_handle, result) }
 }
 
@@ -53,12 +64,16 @@ pub unsafe extern "C" fn start_quic_obfuscator_proxy(
     token: *const c_char,
     proxy_handle: *mut ProxyHandle,
 ) -> i32 {
+    // SAFETY: `peer_address` must be a valid pointer to `peer_address_len` bytes, representing an
     let peer_sock_addr =
         throw_int_error!(unsafe { get_socket_address(peer_address, peer_address_len, peer_port) });
+    // SAFETY: `hostname` must be a valid pointer to a C string
     let hostname = unsafe { get_string(hostname) };
+    // SAFETY: `token` must be a valid pointer to a C string
     let token = unsafe { get_string(token) };
     let result = TunnelObfuscatorRuntime::new_quic(peer_sock_addr, hostname, token).run();
 
+    // SAFETY: `proxy_handle` must be a valid pointer to enough memory for a `ProxyHandle` struct
     unsafe { start(proxy_handle, result) }
 }
 
@@ -71,12 +86,13 @@ pub unsafe extern "C" fn start_lwo_obfuscator_proxy(
     server_public_key: *const u8,
     proxy_handle: *mut ProxyHandle,
 ) -> i32 {
+    // SAFETY: `peer_address` must be a valid pointer to `peer_address_len` bytes, representing an
     let peer_sock_addr =
         throw_int_error!(unsafe { get_socket_address(peer_address, peer_address_len, peer_port) });
 
-    // Safety: `client_public_key` must be a valid pointer to 32 bytes.
+    // SAFETY: `client_public_key` must be a valid pointer to 32 bytes.
     let client_key: [u8; 32] = unsafe { std::ptr::read(client_public_key as *const [u8; 32]) };
-    // Safety: `server_public_key` must be a valid pointer to 32 bytes.
+    // SAFETY: `server_public_key` must be a valid pointer to 32 bytes.
     let server_key: [u8; 32] = unsafe { std::ptr::read(server_public_key as *const [u8; 32]) };
 
     let result = TunnelObfuscatorRuntime::new_lwo(
@@ -86,6 +102,7 @@ pub unsafe extern "C" fn start_lwo_obfuscator_proxy(
     )
     .run();
 
+    // SAFETY: `proxy_handle` must be a valid pointer to enough memory for a `ProxyHandle` struct
     unsafe { start(proxy_handle, result) }
 }
 


### PR DESCRIPTION
Documenting all uses of `unsafe` so that the GotaTun PR can be green.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10716)
<!-- Reviewable:end -->
