### PR TITLE
Remove `flock` from FileCache

### DIFF
--- a/ios/MullvadTypes/FileCache.swift
+++ b/ios/MullvadTypes/FileCache.swift
@@ -105,6 +105,58 @@ public final class FileCache<Content: Codable>: FileCacheProtocol, @unchecked Se
     }
 }
 
+/// One-shot maintenance for directories containing `FileCache`-backed files, meant to be run once
+/// on app launch.
+///
+/// This code can be removed in 2027.1: by then every install has run a version that no longer
+/// creates `.lock` and `.tmp` files, and orphaned `.tmp-<UUID>` files accumulate slowly enough
+/// (one small file per process death mid-write) that a year of sweeps is plenty.
+public enum FileCacheMaintenance {
+    /// Deletes auxiliary files that `FileCache` instances leave behind in `directory`:
+    /// `.lock` and `.tmp` files created by versions up to 2026.3, and uniquely named
+    /// `.tmp-<UUID>` files orphaned when a process died mid-write. The UUID-named files are
+    /// only deleted when older than a day, so that another process's in-flight write is never
+    /// swept away.
+    ///
+    /// Returns the number of deleted orphaned `.tmp-<UUID>` files. Unlike the expected legacy
+    /// leftovers, each of those marks a process death mid-write, so callers should log them.
+    @discardableResult
+    public static func removeStaleCacheFiles(
+        in directory: URL,
+        olderThan staleAge: TimeInterval = 24 * 60 * 60
+    ) -> Int {
+        let fileManager = FileManager.default
+
+        guard
+            let files = try? fileManager.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.contentModificationDateKey]
+            )
+        else { return 0 }
+
+        let staleCutoff = Date(timeIntervalSinceNow: -staleAge)
+        var removedOrphanCount = 0
+
+        for url in files {
+            let name = url.lastPathComponent
+
+            if name.hasSuffix(".lock") || name.hasSuffix(".tmp") {
+                try? fileManager.removeItem(at: url)
+            } else if let uuidRange = name.range(of: ".tmp-", options: .backwards),
+                UUID(uuidString: String(name[uuidRange.upperBound...])) != nil
+            {
+                let modified = (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?
+                    .contentModificationDate
+                if let modified, modified < staleCutoff, (try? fileManager.removeItem(at: url)) != nil {
+                    removedOrphanCount += 1
+                }
+            }
+        }
+
+        return removedOrphanCount
+    }
+}
+
 /// Errors specific to `FileCache` operations.
 public enum FileCacheError: LocalizedError {
     /// Atomic rename of temporary file failed.

--- a/ios/MullvadTypes/FileCache.swift
+++ b/ios/MullvadTypes/FileCache.swift
@@ -19,58 +19,45 @@ public protocol FileCacheProtocol<Content> {
 
 /// File cache implementation that can read and write any `Codable` content.
 ///
-/// Uses `flock()` for cross-process synchronization (shared locks for reads, exclusive locks for writes)
-/// and an in-memory cache keyed by file modification time to skip I/O when the file hasn't changed.
+/// Cross-process coordination relies on atomic whole-file replacement instead of file locks:
+/// writes go to a uniquely named temporary file that is then `rename(2)`d into place. A reader
+/// always observes either the previous or the new complete file, never a partial write, and the
+/// in-memory cache keyed by file modification time guarantees that content replaced by another
+/// process is picked up on the next read.
 ///
-/// Writes are crash-safe: data is written to a temporary file first, then atomically renamed into place
-/// while holding the exclusive lock. If a process crashes mid-write, the original file remains intact
-/// and the lock is automatically released by the kernel when the file descriptor is closed.
-///
-/// A separate lock file (`.lock` extension) is used as the locking point so that atomic renames
-/// don't invalidate held locks.
-///
-/// Multiple `FileCache` instances backed by the same file are safe — they all coordinate through the
-/// same lock file.
+/// Multiple `FileCache` instances backed by the same file are safe — writes are atomic and each
+/// instance detects external changes through the file modification time. But we should use a shared
+/// instance instead. There is no reason for a single file to be backed by multiple file caches in the same process.
 public final class FileCache<Content: Codable>: FileCacheProtocol, @unchecked Sendable {
     public let fileURL: URL
-    private let lockFileURL: URL
 
-    /// Lock protecting `cachedContent` and `cachedMtime` against data races.
+    /// Lock protecting `cachedContent` and `contentModified` against data races.
     private let cacheLock = NSLock()
     private var cachedContent: Content?
     private var contentModified: Date?
 
     public init(fileURL: URL) {
         self.fileURL = fileURL
-        self.lockFileURL = fileURL.appendingPathExtension("lock")
     }
 
     public func read() throws -> Content {
         cacheLock.lock()
         defer { cacheLock.unlock() }
 
-        // Fast path: if the file modification time hasn't changed, return the cached content.
-        let currentModificationTime = fileModificationTime()
-        if let cachedContent, let contentModified, contentModified == currentModificationTime,
-            currentModificationTime != nil
+        // Stat before reading, so that a concurrent replacement between the stat and the read can
+        // only mark the cache as stale and cause an extra re-read, never serve stale content.
+        let modificationTime = fileModificationTime(at: fileURL)
+        if let cachedContent, let contentModified, modificationTime != nil,
+            contentModified == modificationTime
         {
             return cachedContent
         }
-
-        // Slow path: acquire a shared lock and read from disk.
-        let lockFd = try openLockFile()
-        defer { close(lockFd) }
-
-        guard flock(lockFd, LOCK_SH) == 0 else {
-            throw FileCacheError.lockFailed(errno)
-        }
-        defer { flock(lockFd, LOCK_UN) }
 
         let data = try Data(contentsOf: fileURL)
         let content = try JSONDecoder().decode(Content.self, from: data)
 
         cachedContent = content
-        contentModified = fileModificationTime()
+        contentModified = modificationTime
 
         return content
     }
@@ -79,20 +66,18 @@ public final class FileCache<Content: Codable>: FileCacheProtocol, @unchecked Se
         cacheLock.lock()
         defer { cacheLock.unlock() }
 
-        // Encode before acquiring the lock to minimize exclusive lock hold time.
         let data = try JSONEncoder().encode(content)
 
-        let lockFd = try openLockFile()
-        defer { close(lockFd) }
-
-        guard flock(lockFd, LOCK_EX) == 0 else {
-            throw FileCacheError.lockFailed(errno)
-        }
-        defer { flock(lockFd, LOCK_UN) }
-
-        // Write to a temporary file then atomically rename, both under the exclusive lock.
-        let tempURL = fileURL.appendingPathExtension("tmp")
+        // Write to a uniquely named temporary file, then atomically rename into place. The unique
+        // name prevents concurrent writers in this or another process from clobbering each other's
+        // in-progress writes.
+        let tempURL = fileURL.appendingPathExtension("tmp-\(UUID().uuidString)")
         try data.write(to: tempURL)
+
+        // Capture the modification time before the rename, which preserves it. If another process
+        // replaces the file afterwards, the stored time no longer matches and the next read
+        // re-reads from disk.
+        let writtenModificationTime = fileModificationTime(at: tempURL)
 
         if rename(tempURL.path, fileURL.path) != 0 {
             try? FileManager.default.removeItem(at: tempURL)
@@ -100,20 +85,12 @@ public final class FileCache<Content: Codable>: FileCacheProtocol, @unchecked Se
         }
 
         cachedContent = content
-        contentModified = fileModificationTime()
+        contentModified = writtenModificationTime
     }
 
     public func clear() throws {
         cacheLock.lock()
         defer { cacheLock.unlock() }
-
-        let lockFd = try openLockFile()
-        defer { close(lockFd) }
-
-        guard flock(lockFd, LOCK_EX) == 0 else {
-            throw FileCacheError.lockFailed(errno)
-        }
-        defer { flock(lockFd, LOCK_UN) }
 
         try FileManager.default.removeItem(at: fileURL)
 
@@ -123,35 +100,18 @@ public final class FileCache<Content: Codable>: FileCacheProtocol, @unchecked Se
 
     // MARK: - Private
 
-    private func openLockFile() throws -> Int32 {
-        // Open a file path that is to be used with `flock` to synchronize access to the actual caching file.
-        let fd = open(lockFileURL.path, O_RDWR | O_CREAT, 0o644)
-        guard fd >= 0 else {
-            throw FileCacheError.openFailed(errno)
-        }
-        return fd
-    }
-
-    private func fileModificationTime() -> Date? {
-        (try? FileManager.default.attributesOfItem(atPath: fileURL.path))?[.modificationDate] as? Date
+    private func fileModificationTime(at url: URL) -> Date? {
+        (try? FileManager.default.attributesOfItem(atPath: url.path))?[.modificationDate] as? Date
     }
 }
 
 /// Errors specific to `FileCache` operations.
 public enum FileCacheError: LocalizedError {
-    /// `flock()` failed with the given `errno`.
-    case lockFailed(Int32)
-    /// Could not open or create the lock file.
-    case openFailed(Int32)
     /// Atomic rename of temporary file failed.
     case renameFailed(Int32)
 
     public var errorDescription: String? {
         switch self {
-        case let .lockFailed(code):
-            return "Failed to acquire file lock: \(String(cString: strerror(code)))"
-        case let .openFailed(code):
-            return "Failed to open lock file: \(String(cString: strerror(code)))"
         case let .renameFailed(code):
             return "Failed to rename temporary file: \(String(cString: strerror(code)))"
         }

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -79,6 +79,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         migrationManager = MigrationManager(cacheDirectory: containerURL, settingsManager: settingsManager)
         configureLogging()
 
+        // Can be removed in 2027.1, see `FileCacheMaintenance`.
+        Task.detached(priority: .utility) { [containerURL, logger] in
+            let removedOrphanCount = FileCacheMaintenance.removeStaleCacheFiles(in: containerURL)
+            if removedOrphanCount > 0 {
+                logger?.warning("Removed \(removedOrphanCount) orphaned file cache temporary file(s).")
+            }
+        }
+
         let ipOverrideWrapper = IPOverrideWrapper(
             relayCache: RelayCache(cacheDirectory: containerURL),
             ipOverrideRepository: ipOverrideRepository

--- a/ios/MullvadVPNTests/MullvadTypes/FileCacheTests.swift
+++ b/ios/MullvadVPNTests/MullvadTypes/FileCacheTests.swift
@@ -12,17 +12,18 @@ import XCTest
 @testable import MullvadTypes
 
 class FileCacheTests: XCTestCase {
+    var testDirectoryURL: URL!
     var testFileURL: URL!
 
-    override func setUp() {
-        testFileURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("FileCacheTest-\(UUID().uuidString)", isDirectory: false)
+    override func setUpWithError() throws {
+        testDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FileCacheTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: testDirectoryURL, withIntermediateDirectories: false)
+        testFileURL = testDirectoryURL.appendingPathComponent("cache.json", isDirectory: false)
     }
 
-    override func tearDown() {
-        try? FileManager.default.removeItem(at: testFileURL)
-        try? FileManager.default.removeItem(at: testFileURL.appendingPathExtension("lock"))
-        try? FileManager.default.removeItem(at: testFileURL.appendingPathExtension("tmp"))
+    override func tearDownWithError() throws {
+        try FileManager.default.removeItem(at: testDirectoryURL)
     }
 
     func testRead() throws {
@@ -123,6 +124,59 @@ class FileCacheTests: XCTestCase {
         XCTAssertEqual(try freshCache.read(), "original")
 
         try? FileManager.default.removeItem(at: tempURL)
+    }
+
+    // MARK: - Stale sibling cleanup
+
+    func testCleanupRemovesLegacyLockAndTempFiles() throws {
+        let lockURL = testFileURL.appendingPathExtension("lock")
+        let tempURL = testFileURL.appendingPathExtension("tmp")
+        try Data().write(to: lockURL)
+        try Data().write(to: tempURL)
+
+        let removedOrphanCount = FileCacheMaintenance.removeStaleCacheFiles(in: testDirectoryURL)
+
+        XCTAssertEqual(removedOrphanCount, 0, "Legacy files are not orphaned temporary files")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: lockURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tempURL.path))
+    }
+
+    func testCleanupRemovesOnlyStaleUUIDTempFiles() throws {
+        let staleURL = testFileURL.appendingPathExtension("tmp-\(UUID().uuidString)")
+        let freshURL = testFileURL.appendingPathExtension("tmp-\(UUID().uuidString)")
+        try Data().write(to: staleURL)
+        try Data().write(to: freshURL)
+
+        // Backdate the stale file past the one-day threshold.
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSinceNow: -25 * 60 * 60)],
+            ofItemAtPath: staleURL.path
+        )
+
+        let removedOrphanCount = FileCacheMaintenance.removeStaleCacheFiles(in: testDirectoryURL)
+
+        XCTAssertEqual(removedOrphanCount, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: staleURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: freshURL.path))
+    }
+
+    func testCleanupLeavesUnrelatedFilesAlone() throws {
+        let cacheData = try JSONEncoder().encode("content")
+        try cacheData.write(to: testFileURL)
+
+        // Non-UUID suffix after "tmp-" must not be treated as an orphaned temporary file.
+        let nonUUIDURL = testFileURL.appendingPathExtension("tmp-not-a-uuid")
+        try Data().write(to: nonUUIDURL)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSinceNow: -25 * 60 * 60)],
+            ofItemAtPath: nonUUIDURL.path
+        )
+
+        let removedOrphanCount = FileCacheMaintenance.removeStaleCacheFiles(in: testDirectoryURL)
+
+        XCTAssertEqual(removedOrphanCount, 0)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: testFileURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: nonUUIDURL.path))
     }
 
     // MARK: - Thundering herd


### PR DESCRIPTION
After spending too much time not looking at the crash address which would tell me that the crashes we're seeing are due to iOS killing our app, I've come to the conclusion that using `flock` to synchronize the `FileCache` between the packet tunnel and app doesn't work. As such, I'm reverting that change to a lighter weight synchronization mechanism. Now, reads will not block during writes, but they will not be smeared. For the shadowsocks config, this might be an issue - but I do not believe this will be too big of an issue - as when the packet tunnel is up the app should reasonably only reach the API via the packet tunnel anyway. For the relay list, it is only the app that updates the relay list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10720)
<!-- Reviewable:end -->
