### PR TITLE
Update GotaTun to 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Line wrap the file at 100 chars.                                              Th
   existing, invalid access method is removed with a settings migration.
 - Reject invalid DAITA fraction limits in tunnel config responses before starting the tunnel.
 - Ignore DAITA tunnel config responses unless DAITA was requested.
+- Update GotaTun to 0.7.2, pulling in Linux UDP receive fixes and PSK update handling.
 
 #### Windows
 - Fix misleading "split tunneling" error when offline.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,9 +1745,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gotatun"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08e81edfb0f5289200018c31d9aeaa1090ae7575fdb499073dd1b24ea8874c60"
+checksum = "09e8590454839d406160792e2c5617e463a0d223f7370687528d0dd6560140b9"
 dependencies = [
  "aead",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ ctrlc = "3.5"
 dirs = "6.0.0"
 either = "1.15.0"
 futures = "0.3.15"
-gotatun = { version = "0.7.1", default-features = false, features = ["ring"] }
+gotatun = { version = "0.7.2", default-features = false, features = ["ring"] }
 hickory-proto = "0.26.1"
 hickory-resolver = { version = "0.26.1", default-features = false, features = [
   "tokio"


### PR DESCRIPTION
## what
Updates `gotatun` from 0.7.1 to 0.7.2 and adds the app changelog entry

## why
0.7.2 pulls in upstream fixes that are relevant for the app's GotaTun path, including Linux UDP receive handling for oversized datagrams, PSK update handling, and the transport data counter limit

Upstream changelog: https://github.com/mullvad/gotatun/blob/v0.7.2/CHANGELOG.md

## testing
- `cargo fmt --check`
- `git diff --check`
- `cargo check -p talpid-wireguard -p talpid-tunnel-config-client --all-targets`
- `cargo test -p talpid-tunnel-config-client --lib`
- `cargo test -p talpid-wireguard --lib`
- `cargo test --manifest-path ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/gotatun-0.7.2/Cargo.toml --no-default-features --features ring,daita,device,tun --test udp_oversized_datagram`
- `cargo test --manifest-path ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/gotatun-0.7.2/Cargo.toml --no-default-features --features ring,daita,device,tun --lib`
- `cargo check --locked`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10721)
<!-- Reviewable:end -->
