### PR TITLE
Handle unavailable IPv6 in GotaTun UDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - Clicking on the tray icon will toggle the window instead of just showing it
 - Old `mullvad log set-level` command has been renamed to `mullvad log set-rust-log`.
+- Update `gotatun` to 0.8.1.
 
 #### Windows
 - Update `wireguard-nt` to version 1.1. This retires the Mullvad fork at
@@ -46,6 +47,10 @@ Line wrap the file at 100 chars.                                              Th
 - Reject invalid DAITA fraction limits in tunnel config responses before starting the tunnel.
 - Ignore DAITA tunnel config responses unless DAITA was requested.
 - Fix infinite loop of account checks when account ran out of time.
+
+#### Linux
+- Fix issue where `gotatun` would fail to start on Linux systems where the
+  IPv6 stack had been disabled.
 
 #### Windows
 - Fix misleading "split tunneling" error when offline.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1888,9 +1888,9 @@ dependencies = [
 
 [[package]]
 name = "gotatun"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08e81edfb0f5289200018c31d9aeaa1090ae7575fdb499073dd1b24ea8874c60"
+checksum = "87942cf21be131088380c8b3cb3dc9a8528a7f840a8230bed0e79b2e202d0629"
 dependencies = [
  "aead",
  "base64",
@@ -1909,7 +1909,6 @@ dependencies = [
  "ip_network_table",
  "ipnetwork",
  "libc",
- "log",
  "maybenot",
  "nix 0.31.3",
  "parking_lot",
@@ -1922,6 +1921,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-util 0.7.18",
+ "tracing",
  "tun 0.8.11",
  "typed-builder 0.21.2",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ ctrlc = "3.5"
 dirs = "6.0.0"
 either = "1.15.0"
 futures = "0.3.15"
-gotatun = { version = "0.7.1", default-features = false, features = ["ring"] }
+gotatun = { version = "0.8.1", default-features = false, features = ["ring"] }
 hickory-proto = "0.26.1"
 hickory-resolver = { version = "0.26.1", default-features = false, features = [
   "tokio"

--- a/talpid-wireguard/src/gotatun/mod.rs
+++ b/talpid-wireguard/src/gotatun/mod.rs
@@ -215,8 +215,9 @@ impl UdpTransportFactory for AndroidUdpSocketFactory {
     ) -> std::io::Result<((Self::SendV4, Self::RecvV4), (Self::SendV6, Self::RecvV6))> {
         let ((udp_v4_tx, udp_v4_rx), (udp_v6_tx, udp_v6_rx)) = self.udp.bind(params).await?;
 
-        self.tun.bypass(&udp_v4_tx).unwrap();
-        self.tun.bypass(&udp_v6_tx).unwrap();
+        use std::os::fd::AsFd;
+        self.tun.bypass(&udp_v4_tx.socket()?.as_fd()).unwrap();
+        self.tun.bypass(&udp_v6_tx.socket()?.as_fd()).unwrap();
 
         Ok(((udp_v4_tx, udp_v4_rx), (udp_v6_tx, udp_v6_rx)))
     }

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -107,7 +107,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -118,7 +118,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -783,7 +783,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -953,7 +953,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1235,9 +1235,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gotatun"
-version = "0.6.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee896ae91b1a90a10642d58ced8721560dc399ceeaba66d9cab14ad1db846936"
+checksum = "87942cf21be131088380c8b3cb3dc9a8528a7f840a8230bed0e79b2e202d0629"
 dependencies = [
  "aead",
  "aws-lc-rs",
@@ -1257,7 +1257,6 @@ dependencies = [
  "ip_network_table",
  "ipnetwork 0.21.1",
  "libc",
- "log",
  "nix 0.31.3",
  "parking_lot",
  "rand 0.9.4",
@@ -1267,9 +1266,10 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",
+ "tracing",
  "tun",
  "typed-builder",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
  "x25519-dalek",
  "zerocopy",
 ]
@@ -1535,7 +1535,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2599,7 +2599,7 @@ checksum = "044b1fa4f259f4df9ad5078e587b208f5d288a25407575fcddb9face30c7c692"
 dependencies = [
  "rand 0.8.6",
  "socket2 0.6.3",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2881,7 +2881,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2918,7 +2918,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3171,7 +3171,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3277,7 +3277,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3465,7 +3465,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.3.14",
+ "errno 0.2.8",
  "libc",
 ]
 
@@ -3523,7 +3523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3756,7 +3756,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4649,7 +4649,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -24,7 +24,7 @@ colored = "2.0.0"
 dirs = "6.0.0"
 env_logger = "0.11.7"
 futures = "0.3"
-gotatun = { version = "0.6", default-features = false, features = ["aws-lc-rs"] }
+gotatun = { version = "0.8", default-features = false, features = ["aws-lc-rs"] }
 http-body-util = "0.1.2"
 hyper = { version = "1.4.1", default-features = false }
 hyper-rustls = { version = "0.27.3", default-features = false }


### PR DESCRIPTION
## what

Allows the Linux GotaTun UDP transport to keep starting with IPv4-only sockets when IPv6 socket binding fails because IPv6 is unavailable

## why

GotaTun currently binds both IPv4 and IPv6 UDP sockets during startup. On Linux systems without IPv6, the IPv6 bind fails before the tunnel can start, even for IPv4 relay paths. This matches #10654

fixes #10654

## how

The Linux app-side factory still uses the normal gotatun `UdpSocketFactory` first. If that bind fails with `EAFNOSUPPORT` or `EADDRNOTAVAIL`, it binds a real IPv4 socket and provides a disabled IPv6 transport. The disabled IPv6 receiver parks instead of returning an immediate error, and `set_fwmark` / `enable_udp_gro` stay no-ops so normal device setup can finish

## testing

- `cargo fmt --check`
- `git diff --check`
- `PKG_CONFIG=/usr/bin/pkg-config cargo check -p talpid-wireguard --all-targets`
- `PKG_CONFIG=/usr/bin/pkg-config cargo test -p talpid-wireguard gotatun::udp --lib`
- `PKG_CONFIG=/usr/bin/pkg-config cargo test -p talpid-wireguard --lib`
- `PKG_CONFIG=/usr/bin/pkg-config ci/cargo-ci.sh check -p talpid-wireguard`
- `PKG_CONFIG=/usr/bin/pkg-config ci/cargo-ci.sh test -p talpid-wireguard --lib`
- `PKG_CONFIG=/usr/bin/pkg-config ci/cargo-ci.sh clippy -p talpid-wireguard --all-targets`
- `ci/verify-locked-down-signatures.sh --whitelist origin/main`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10722)
<!-- Reviewable:end -->
