### PR TITLE
Resolve settings migration issue

### DIFF
--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -742,16 +742,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
                     settingsResolver.resolve(store: self.settingsManager.store) { [self] result in
                         switch result {
-                        case let .migrated(old, new):
+                        case let .migrated(old, new, changes):
                             // Tell the tunnel to re-read tunnel configuration after migration.
                             logger.debug("Successful resolving deprecated settings from UI Process")
                             appPreferences.migratedSettingsState = MigratedSettingsState(
                                 preMigrationSettings: old,
                                 lastInstalledVersion: Bundle.main.productVersion,
                                 lastMigratedVersion: MigratedVersion.current.rawValue,
-                                hasCompletedMigrationWizard: false,
-                                shouldShowMigratedSettingsMenuItem: true)
-                            migratedSettingsListener.onMigratedSettingsHandler?(.migrated)
+                                hasCompletedMigrationWizard: changes.isEmpty,
+                                shouldShowMigratedSettingsMenuItem: !changes.isEmpty)
+                            migratedSettingsListener.onMigratedSettingsHandler?(
+                                changes.isEmpty ? .noChanges : .migrated)
                             tunnelManager.updateSettings([.all(new)])
                             finish(nil)
 
@@ -760,11 +761,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                                 "Attempted resolving deprecated settings from UI Process, but It's already up to date, so nothing to do"
                             )
                             migratedSettingsListener.onMigratedSettingsHandler?(.noChanges)
-                            finish(nil)
-                        case .noChanges:
-                            logger.debug(
-                                "Successful resolving deprecated settings from UI Process, No changes were required")
-                            resetVisibility()
                             finish(nil)
                         case let .failure(error):
                             logger.error("Failed resolving deprecated settings from UI Process: \(error)")

--- a/ios/MullvadVPN/Coordinators/Settings/SettingsMigrationWizard/DeprecatedSettingsResolver.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/SettingsMigrationWizard/DeprecatedSettingsResolver.swift
@@ -10,16 +10,13 @@ import MullvadREST
 import MullvadSettings
 import MullvadTypes
 
-public enum DeprecatedSettingsResolverResult: Sendable {
+enum DeprecatedSettingsResolverResult: Sendable {
 
     // Nothing to migrate
     case nothing
 
-    // Migration completed successfully, but no changes were required.
-    case noChanges
-
     /// Successfully performed migration.
-    case migrated(from: LatestTunnelSettings, to: LatestTunnelSettings)
+    case migrated(from: LatestTunnelSettings, to: LatestTunnelSettings, changes: [Change])
 
     /// Failure when migrating store.
     case failure(Error)
@@ -81,8 +78,7 @@ struct DeprecatedSettingsResolver: Sendable {
             let currentSettings = try parser.parsePayload(as: LatestTunnelSettings.self, from: settingsData)
             var copy = currentSettings
             let migrationOutput = try MultihopMigrationTrackerFactory.make(relaySelector).run(input: &copy)
-            migrationCompleted(
-                migrationOutput.changes.isEmpty ? .noChanges : .migrated(from: currentSettings, to: copy))
+            migrationCompleted(.migrated(from: currentSettings, to: copy, changes: migrationOutput.changes))
         } catch {
             migrationCompleted(.failure(error))
         }

--- a/ios/MullvadVPN/Coordinators/Settings/SettingsMigrationWizard/MultihopMigrationTrackerFactory.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/SettingsMigrationWizard/MultihopMigrationTrackerFactory.swift
@@ -21,7 +21,7 @@ enum MultihopMigrationTrackerFactory {
     > {
 
         let scenario1A = SettingsRule<MultihopStateV2, MultihopSuggestedAction>(
-            name: "Scenario1 A"
+            name: "Scenario 1A"
         ) { input in
             input.tunnelMultihopState == .never && !input.daita.isEnabled
                 && input.relayConstraints.exitFilter == .any
@@ -36,7 +36,7 @@ enum MultihopMigrationTrackerFactory {
         }
 
         let scenario1B = SettingsRule<MultihopStateV2, MultihopSuggestedAction>(
-            name: "Scenario1 B"
+            name: "Scenario 1B"
         ) { input in
             input.tunnelMultihopState == .never && !input.daita.isEnabled
                 && input.relayConstraints.exitFilter != .any
@@ -58,7 +58,7 @@ enum MultihopMigrationTrackerFactory {
         }
 
         let scenario2 = SettingsRule<MultihopStateV2, MultihopSuggestedAction>(
-            name: "Scenario2"
+            name: "Scenario 2"
         ) { input in
             input.tunnelMultihopState == .never && input.daita.isEnabled && !input.daita.directOnlyState.isEnabled
                 && input.relayConstraints.exitFilter == .any


### PR DESCRIPTION
This PR updates the default configuration so that the multihop state is set to `.whenNeeded` by default.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10728)
<!-- Reviewable:end -->
