### PR TITLE
Draft PR in progress of replacing NSOperation with structured concurrency, one step at a time

### DIFF
--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -208,7 +208,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             tunnelSettingsUpdater: tunnelSettingsUpdater
         )
         addApplicationNotifications(application: application)
-        startInitialization(application: application)
+        Task {
+            await startInitialization(application: application)
+        }
 
         // Pre-warm @Observable infrastructure for LocationNode to avoid first-render lag
         // in SelectLocationView. SwiftUI's observation system has initialization overhead
@@ -514,15 +516,24 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         UNUserNotificationCenter.current().delegate = self
     }
 
-    private func startInitialization(application: UIApplication) {
+    private func startInitialization(application: UIApplication) async {
+        // the new structured code: things here run first, before we run the legacy operations.
+        // in the fullness of time, this section will grow and the latter will shrink to nothing
+        
+        // next: make a TaskGroup containing this and wipeSettings, and await that in one go
+        
+        await doLoadTunnelStore()
+        
+        // legacy concurrency code follows. We comment out the operations that have been converted.
+        
         let defaultLocationOperation = getDefaultLocationOperation()
-        let loadTunnelStoreOperation = getLoadTunnelStoreOperation()
+//        let loadTunnelStoreOperation = getLoadTunnelStoreOperation()
         let initTunnelManagerOperation = getInitTunnelManagerOperation()
         let deprecatedSettingsResolverOperation = getDeprecatedSettingsResolverOperation()
 
         var operations: [Operation] = [
             defaultLocationOperation,
-            loadTunnelStoreOperation,
+//            loadTunnelStoreOperation,
         ]
 
         let wipeSettingsOperation = getWipeSettingsOperation()
@@ -532,7 +543,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         defaultLocationOperation.addDependency(wipeSettingsOperation)
         migrateSettingsOperation.addDependencies([
             wipeSettingsOperation,
-            loadTunnelStoreOperation,
+//            loadTunnelStoreOperation,
         ])
         deprecatedSettingsResolverOperation.addDependency(migrateSettingsOperation)
         initTunnelManagerOperation.addDependency(migrateSettingsOperation)
@@ -560,6 +571,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                     finish(nil)
                 }
             }
+        }
+    }
+    
+    private func doLoadTunnelStore() async {
+        do {
+            try await tunnelStore.loadPersistentTunnels()
+        } catch {
+            logger.error(
+                error: error,
+                message: "Failed to load persistent tunnels."
+            )
         }
     }
 
@@ -635,6 +657,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     /// (`SettingsManager.getShouldWipeSettings()`)
     /// If (1) is `false` and (2) is `true`, we know that the app has been freshly installed/reinstalled and is
     /// compatible, thus triggering a settings wipe.
+    
+    /// CONCURRENCY PORTING NOTE: this does not seem to be asynchronous. It can call `deleteDevice`, but does not await the result. Why is it an AsyncBlockOperation?
     private func getWipeSettingsOperation() -> AsyncBlockOperation {
         AsyncBlockOperation { [settingsManager] in
             let appHasNeverBeenLaunched =

--- a/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProviderManager.swift
+++ b/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProviderManager.swift
@@ -115,6 +115,14 @@
 
             completionHandler(tunnelProviders, nil)
         }
+        
+        static func loadAllFromPreferences() async throws -> [SimulatorTunnelProviderManager] {
+            // locking does not work in async contexts
+            tunnels.map { tunnelInfo in
+                SimulatorTunnelProviderManager(tunnelInfo: tunnelInfo)
+            }
+
+        }
 
         override required init() {
             tunnelInfo = SimulatorTunnelInfo()

--- a/ios/MullvadVPN/TunnelManager/TunnelStore.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelStore.swift
@@ -50,6 +50,29 @@ final class TunnelStore: TunnelStoreProtocol, TunnelStatusObserver, @unchecked S
 
         return persistentTunnels
     }
+    
+    private func setPersistentTunnelsFromManagers(_ managers: [NETunnelProviderManager]) {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+        
+        self.persistentTunnels.forEach { tunnel in
+            tunnel.removeObserver(self)
+        }
+        
+        self.persistentTunnels =
+            managers.map { manager in
+                let tunnel = Tunnel(tunnelProvider: manager, backgroundTaskProvider: self.application)
+                tunnel.addObserver(self)
+
+                self.logger.debug(
+                    "Loaded persistent tunnel: \(tunnel.logFormat()) with status: \(tunnel.status)."
+                )
+
+                return tunnel
+            }
+    }
 
     func loadPersistentTunnels(completion: @escaping @Sendable (Error?) -> Void) {
         TunnelProviderManagerType.loadAllFromPreferences { managers, error in
@@ -61,23 +84,15 @@ final class TunnelStore: TunnelStoreProtocol, TunnelStatusObserver, @unchecked S
             }
 
             guard error == nil else { return }
-
-            self.persistentTunnels.forEach { tunnel in
-                tunnel.removeObserver(self)
-            }
-
-            self.persistentTunnels =
-                managers?.map { manager in
-                    let tunnel = Tunnel(tunnelProvider: manager, backgroundTaskProvider: self.application)
-                    tunnel.addObserver(self)
-
-                    self.logger.debug(
-                        "Loaded persistent tunnel: \(tunnel.logFormat()) with status: \(tunnel.status)."
-                    )
-
-                    return tunnel
-                } ?? []
+            
+            self.setPersistentTunnelsFromManagers(managers ?? [])
         }
+    }
+    
+    // the above function rewritten to be async
+    func loadPersistentTunnels() async throws {
+        let managers = try await TunnelProviderManagerType.loadAllFromPreferences()
+        self.setPersistentTunnelsFromManagers(managers)
     }
 
     func createNewTunnel() -> TunnelType {

--- a/ios/MullvadVPN/TunnelManager/TunnelStore.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelStore.swift
@@ -51,7 +51,7 @@ final class TunnelStore: TunnelStoreProtocol, TunnelStatusObserver, @unchecked S
         return persistentTunnels
     }
     
-    private func setPersistentTunnelsFromManagers(_ managers: [NETunnelProviderManager]) {
+    private func setPersistentTunnelsFromManagers(_ managers: [TunnelProviderManagerType]) {
         self.lock.lock()
         defer {
             self.lock.unlock()


### PR DESCRIPTION
This PR is a work in progress, in which the legacy NSOperation-based system for launching concurrent tasks is being replaced with structured concurrency.  This involves callback-based methods being converted to `async` methods, and these being `await`ed, either individually or in `TaskGroup`s. 

So far, one operation (the loading of the tunnel store) has been moved to structured concurrency. This is an operation that alters background state and can have an error condition, which is intercepted and logged.   This is called and awaited, before the rest of the code continues using the legacy operations.

`loadTunnelStoreOperation` and `wipeSettingsOperation` are two operations on which other operations depend, which will be the first to be converted. `wipeSettingsOperation` does not appear to be highly asynchronous, performing a few quick, synchronous operations, and possibly triggering a device deletion whose result it does not concern itself with. It will be the next to be converted.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10729)
<!-- Reviewable:end -->
