### PR TITLE
Make (naively) AddressCacheUpdateScheduler an actor, removing NSLock

### DIFF
--- a/ios/MullvadVPN/AddressCacheUpdateScheduler/AddressCacheUpdateScheduler.swift
+++ b/ios/MullvadVPN/AddressCacheUpdateScheduler/AddressCacheUpdateScheduler.swift
@@ -13,7 +13,7 @@ import MullvadTypes
 import Operations
 import UIKit
 
-final class AddressCacheUpdateScheduler: @unchecked Sendable {
+final actor AddressCacheUpdateScheduler: @unchecked Sendable {
     /// Update interval.
     private static let updateInterval: Duration = .days(1)
 
@@ -42,9 +42,6 @@ final class AddressCacheUpdateScheduler: @unchecked Sendable {
     /// Operation queue.
     private let operationQueue = AsyncOperationQueue.makeSerial()
 
-    /// Lock used for synchronizing member access.
-    private let nslock = NSLock()
-
     private let apiContext: MullvadApiContext
 
     /// Designated initializer
@@ -55,9 +52,6 @@ final class AddressCacheUpdateScheduler: @unchecked Sendable {
     }
 
     func startPeriodicUpdates() {
-        nslock.lock()
-        defer { nslock.unlock() }
-
         guard !isPeriodicUpdatesEnabled else {
             return
         }
@@ -74,9 +68,6 @@ final class AddressCacheUpdateScheduler: @unchecked Sendable {
     }
 
     func stopPeriodicUpdates() {
-        nslock.lock()
-        defer { nslock.unlock() }
-
         guard isPeriodicUpdatesEnabled else { return }
 
         logger.debug("Stop periodic address cache updates.")
@@ -91,18 +82,26 @@ final class AddressCacheUpdateScheduler: @unchecked Sendable {
         mullvad_api_update_address_cache(apiContext.context)
         recordUpdateRequestTime()
     }
+    
+    func updateEndpoints() async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
+            self.updateEndpoints { result in
+                continuation.resume(with: result)
+            
+            }
+        }
+    }
 
     func nextScheduleDate() -> Date {
-        nslock.lock()
-        defer { nslock.unlock() }
-
         return _nextScheduleDate()
     }
 
     private func scheduleEndpointsUpdate(startTime: DispatchWallTime) {
         let newTimer = DispatchSource.makeTimerSource()
         newTimer.setEventHandler { [weak self] in
-            self?.handleTimer()
+            Task { [self] in
+                await self?.handleTimer()
+            }
         }
 
         newTimer.schedule(wallDeadline: startTime)
@@ -114,9 +113,6 @@ final class AddressCacheUpdateScheduler: @unchecked Sendable {
 
     private func handleTimer() {
         updateEndpoints { _ in
-            self.nslock.lock()
-            defer { self.nslock.unlock() }
-
             guard self.isPeriodicUpdatesEnabled else { return }
 
             let scheduleDate = self._nextScheduleDate()
@@ -137,8 +133,6 @@ final class AddressCacheUpdateScheduler: @unchecked Sendable {
     }
 
     private func recordUpdateRequestTime() {
-        nslock.lock()
-        defer { nslock.unlock() }
         lastUpdateRequestDate = Date()
     }
 }

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -296,12 +296,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     @objc private func didBecomeActive(_ notification: Notification) {
         tunnelManager.startPeriodicPrivateKeyRotation()
         relayCacheTracker.startPeriodicUpdates()
-        addressCacheUpdateScheduler.startPeriodicUpdates()
+        Task {
+            await addressCacheUpdateScheduler.startPeriodicUpdates()
+        }
     }
 
     @objc private func willResignActive(_ notification: Notification) {
         tunnelManager.stopPeriodicPrivateKeyRotation()
-        relayCacheTracker.stopPeriodicUpdates()
+        Task {
+            await relayCacheTracker.stopPeriodicUpdates()
+        }
         addressCacheUpdateScheduler.stopPeriodicUpdates()
     }
 
@@ -367,9 +371,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             forTaskWithIdentifier: BackgroundTask.addressCacheUpdate.identifier,
             using: .main
         ) { [self] task in
-            addressCacheUpdateScheduler.updateEndpoints { [self] result in
+            Task { [self]
+                do {
+                    try await addressCacheUpdateScheduler.updateEndpoints() // { [self] result in
+                    task.setTaskCompleted(success: true)
+                } catch {
+                    task.setTaskCompleted(success: false)
+
+                }
                 scheduleAddressCacheUpdateTask()
-                task.setTaskCompleted(success: result.isSuccess)
             }
         }
 
@@ -420,18 +430,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
 
     private func scheduleAddressCacheUpdateTask() {
-        do {
-            let date = addressCacheUpdateScheduler.nextScheduleDate()
-
-            let request = BGProcessingTaskRequest(identifier: BackgroundTask.addressCacheUpdate.identifier)
-            request.requiresNetworkConnectivity = true
-            request.earliestBeginDate = date
-
-            logger.debug("Schedule address cache update task at \(date.logFormatted).")
-
-            try BGTaskScheduler.shared.submit(request)
-        } catch {
-            logger.error(error: error, message: "Could not schedule address cache update task.")
+        Task {
+            do {
+                let date = await addressCacheUpdateScheduler.nextScheduleDate()
+                
+                let request = BGProcessingTaskRequest(identifier: BackgroundTask.addressCacheUpdate.identifier)
+                request.requiresNetworkConnectivity = true
+                request.earliestBeginDate = date
+                
+                logger.debug("Schedule address cache update task at \(date.logFormatted).")
+                
+                try BGTaskScheduler.shared.submit(request)
+            } catch {
+                logger.error(error: error, message: "Could not schedule address cache update task.")
+            }
         }
     }
 


### PR DESCRIPTION
This is a very quick and naive sketch of converting a small `NSLock()`-protected class, `AddressCacheUpdateScheduler`, to modern actor isolation.

I have not yet addressed other issues, such as its use of the iOS 8-era `Dispatch` framework for concurrency, just slapped an actor isolation wall around it and removed the `NSLock` mechanism. Further refactoring will need to follow.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10730)
<!-- Reviewable:end -->
