### PR TITLE
Fix invisible switches in Windows high contrast mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Windows
 - Fix misleading "split tunneling" error when offline.
+- Preserve the app's own theme colors when Windows high contrast (forced-colors) mode is
+  enabled in order to prevent toggle switches and other custom-styled controls from becoming
+  invisible.
 
 ### Security
 - Linux and macOS: Fix management interface socket being created with less restrictive permissions

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/theme/Theme.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/theme/Theme.tsx
@@ -25,6 +25,10 @@ const GlobalStyle = createGlobalStyle`
       ...fontWeights,
       ...lineHeights,
     }).reduce((styleString, [key, value]) => ({ ...styleString, [key]: value }), {})}
+
+    // Keep the app's own theme under Windows forced-colors (high contrast) mode, since it
+    // otherwise strips colors from custom-styled controls like the switch, making them invisible.
+    forced-color-adjust: none;
   }
 
   body {


### PR DESCRIPTION
## what

Set `forced-color-adjust: none` on the app root so it keeps its own theme colors when Windows forced-colors (high contrast) mode is active, instead of letting Chromium override them.

<img width="265" height="441" alt="image" src="https://github.com/user-attachments/assets/a9484fc6-4284-40f4-b548-32f88716aa68" /> 
<img width="255" height="432" alt="image" src="https://github.com/user-attachments/assets/2636145e-0697-4a7a-bba0-959e991415ad" />

## why

The app's toggle switches (`SwitchInput`) are `<input type="checkbox">` elements styled with `appearance: none` and fully custom colors (border, background, `::before` thumb). Under Windows forced-colors mode, Chromium strips author colors from native form controls it recognizes, which collapses the switch's custom background/border, making it blend into the background or disappear — along with other custom-styled controls. Since the app already ships its own dark theme designed to meet contrast requirements, opting out of the forced-colors override (rather than attempting to redesign every control for the OS palette) keeps the UI legible and consistent with the rest of the app.

Fixes #3533

## testing

Built the desktop app locally and compared the Settings page (toggle switches, nav, buttons) with a Windows contrast theme enabled, before and after the fix. Before: switches were invisible, matching the issue's screenshots. After: switches and other controls render with the app's normal branded colors, fully legible, while the OS-drawn window frame still reflects the active contrast theme (outside the app's control).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10731)
<!-- Reviewable:end -->
