### PR TITLE
Allow 0BSD license dependencies

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -61,6 +61,7 @@ allow = [
   "ISC",
   "BSD-3-Clause",
   "BSD-2-Clause",
+  "0BSD",
   "CC0-1.0",
   "Unicode-DFS-2016",
   "Zlib",


### PR DESCRIPTION
0BSD is compatible with GPLv3 and more permissive than other BSD licenses we already support.

https://www.gnu.org/licenses/license-list.en.html#Zero-BSD

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10739)
<!-- Reviewable:end -->
