### PR TITLE
Accept any valid metadata signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Line wrap the file at 100 chars.                                              Th
   existing, invalid access method is removed with a settings migration.
 - Reject invalid DAITA fraction limits in tunnel config responses before starting the tunnel.
 - Ignore DAITA tunnel config responses unless DAITA was requested.
+- Accept version metadata when any signature from a trusted key is valid.
 
 #### Windows
 - Fix misleading "split tunneling" error when offline.

--- a/mullvad-update/src/format/deserializer.rs
+++ b/mullvad-update/src/format/deserializer.rs
@@ -101,26 +101,34 @@ pub(super) fn deserialize_and_verify(
 
     let valid_keys: Vec<_> = keys.into_iter().map(|k| k.0).collect();
 
-    // Check if one of the keys matches
-    let Some((key, sig)) = partial_data.signatures.iter().find_map(|sig| match sig {
-        // Check if ed25519 key matches
-        ResponseSignature::Ed25519 { keyid, sig } if valid_keys.contains(&keyid.0) => {
-            Some((keyid, sig))
-        }
-        // Ignore all non-matching key
-        _ => None,
-    }) else {
-        anyhow::bail!("Unrecognized key");
-    };
-
     // Serialize to canonical json format
     let canon_data = json_canon::to_vec(&partial_data.signed)
         .context("Failed to serialize to canonical JSON")?;
 
-    // Check if the data is signed by our key
-    key.0
-        .verify_strict(&canon_data, &sig.0)
-        .context("Signature verification failed")?;
+    let mut signature_error = None;
+    let valid_signature = partial_data.signatures.iter().any(|signature| {
+        let ResponseSignature::Ed25519 { keyid, sig } = signature else {
+            return false;
+        };
+        if !valid_keys.contains(&keyid.0) {
+            return false;
+        }
+
+        match keyid.0.verify_strict(&canon_data, &sig.0) {
+            Ok(()) => true,
+            Err(error) => {
+                signature_error = Some(error);
+                false
+            }
+        }
+    });
+
+    if !valid_signature {
+        let Some(error) = signature_error else {
+            anyhow::bail!("Unrecognized key");
+        };
+        return Err(error).context("Signature verification failed");
+    }
 
     Ok(PartialSignedResponse {
         signatures: partial_data.signatures,

--- a/mullvad-update/src/format/serializer.rs
+++ b/mullvad-update/src/format/serializer.rs
@@ -154,4 +154,33 @@ mod test {
 
         Ok(())
     }
+
+    #[test]
+    fn test_sign_multiple_accepts_later_valid_signature() -> anyhow::Result<()> {
+        let key = SecretKey::generate();
+        let pubkey = key.pubkey();
+        let key2 = SecretKey::generate();
+        let pubkey2 = key2.pubkey();
+
+        let data = json!({
+            "stuff": "I can prove that I wrote this"
+        });
+        let other_data = json!({
+            "stuff": "This is not the signed data"
+        });
+
+        let mut partial = sign(&key, &other_data).context("Signing failed")?;
+        let valid_partial = sign(&key2, &data).context("Signing failed")?;
+        partial.signed = valid_partial.signed;
+        partial.signatures.extend(valid_partial.signatures);
+
+        let bytes = serde_json::to_vec(&partial)?;
+
+        let error = deserialize_and_verify(&vec1![pubkey.clone()], &bytes).unwrap_err();
+        assert_eq!(error.to_string(), "Signature verification failed");
+        deserialize_and_verify(&vec1![pubkey2.clone()], &bytes)?;
+        deserialize_and_verify(&vec1![pubkey, pubkey2], &bytes)?;
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
## What

Version metadata supports multiple signatures and trusted keys, but verification stopped after the first signature from a trusted key

If that signature was invalid, a later valid signature was never checked

This tries every signature from a trusted key and accepts the metadata once one verifies, while preserving the existing errors when no key is recognized or every trusted signature is invalid

## Why

This makes verification match the existing one-of-multiple-keys behavior and removes the dependency on signature ordering

## Testing

- `ci/cargo-ci.sh test --workspace`
- `ci/cargo-ci.sh clippy -p mullvad-update --all-targets --all-features`
- `cargo fmt --all -- --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10743)
<!-- Reviewable:end -->
