### PR TITLE
Fix account out-of-time loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Line wrap the file at 100 chars.                                              Th
   existing, invalid access method is removed with a settings migration.
 - Reject invalid DAITA fraction limits in tunnel config responses before starting the tunnel.
 - Ignore DAITA tunnel config responses unless DAITA was requested.
+- Fix infinite loop of account checks when account ran out of time.
 
 #### Windows
 - Fix misleading "split tunneling" error when offline.

--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -1332,8 +1332,10 @@ impl TunnelStateChangeHandler {
     /// Handle state transitions and optionally check the device/account validity. This should be
     /// called during every tunnel state transition.
     pub fn handle_state_transition(&mut self, new_state: &TunnelStateTransition) {
-        self.wg_retry_attempt = Self::update_retry_counter(new_state, self.wg_retry_attempt);
-        Self::update_retry_bool(new_state, self.can_retry.clone());
+        if let Some(attempt) = Self::update_retry_counter(new_state, self.wg_retry_attempt) {
+            self.wg_retry_attempt = attempt;
+            Self::update_retry_bool(new_state, self.can_retry.clone());
+        }
         // Check if a device-check should be triggered
         if Self::should_check_device_validity(self.wg_retry_attempt, self.can_retry.clone()) {
             let handle = self.manager.clone();
@@ -1380,14 +1382,17 @@ impl TunnelStateChangeHandler {
     /// attempt, otherwise `retry_attempt` is returned.
     ///
     /// Reset to the counter to `0` when we manage to successfully connect to a Wireguard relay.
-    fn update_retry_counter(new_state: &TunnelStateTransition, retry_attempt: usize) -> usize {
+    fn update_retry_counter(
+        new_state: &TunnelStateTransition,
+        retry_attempt: usize,
+    ) -> Option<usize> {
         match new_state {
             // Increment the counter if this is another connection attempt
-            TunnelStateTransition::Connecting(_) => retry_attempt.wrapping_add(1),
+            TunnelStateTransition::Connecting(_) => Some(retry_attempt.wrapping_add(1)),
             // Reset the counter when successfully connected
-            TunnelStateTransition::Connected(_) => 0,
+            TunnelStateTransition::Connected(_) => Some(0),
             // Any other state transition doesn't affect the counter
-            _ => retry_attempt,
+            _ => None,
         }
     }
 

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1719,10 +1719,16 @@ impl Daemon {
                         self.connect_tunnel();
                     }
                 } else {
-                    log::debug!("Entering blocking state since the account is out of time");
-                    self.send_tunnel_command(TunnelCommand::Block(ErrorStateCause::AuthFailed(
-                        Some(AuthFailed::ExpiredAccount.as_str().to_string()),
-                    )))
+                    let already_blocked = matches!(
+                        &self.tunnel_state,
+                        TunnelState::Error(state) if matches!(state.cause(), ErrorStateCause::AuthFailed(_))
+                    );
+                    if !already_blocked {
+                        log::debug!("Entering blocking state since the account is out of time");
+                        self.send_tunnel_command(TunnelCommand::Block(ErrorStateCause::AuthFailed(
+                            Some(AuthFailed::ExpiredAccount.as_str().to_string()),
+                        )))
+                    }
                 }
             }
             _ => (),


### PR DESCRIPTION
`Error` to `error` tunnel state transitions can cause the daemon to check if the account is out of time, and checking if the account is out of time itself causes a transition to `error`. So the daemon can get stuck in an infinite loop of checking if the account is invalid/expired.

```
[2026-06-08 18:00:43.597] DEBUG mullvad_daemon: New tunnel state: Error(ErrorState { cause: AuthFailed(Some("[EXPIRED_ACCOUNT]")), block_failure: None })
[2026-06-08 18:00:43.597]  INFO mullvad_daemon: Blocking all network connections, reason: Authentication with remote server failed: [EXPIRED_ACCOUNT]
[2026-06-08 18:00:43.702] DEBUG mullvad_daemon::device: Account has no time left
[2026-06-08 18:00:43.702] DEBUG mullvad_daemon: Entering blocking state since the account is out of time
[2026-06-08 18:00:43.702]  INFO talpid_core::firewall: Applying firewall policy: Blocked. Blocking LAN. Allowing endpoint: [REDACTED]:443/TCP for mullvad-problem-report.exe mullvad-daemon.exe
[2026-06-08 18:00:43.720] DEBUG mullvad_daemon: New tunnel state: Error(ErrorState { cause: AuthFailed(Some("[EXPIRED_ACCOUNT]")), block_failure: None })
[2026-06-08 18:00:43.720]  INFO mullvad_daemon: Blocking all network connections, reason: Authentication with remote server failed: [EXPIRED_ACCOUNT]
[2026-06-08 18:00:43.815] DEBUG mullvad_daemon::device: Account has no time left
[2026-06-08 18:00:43.815] DEBUG mullvad_daemon: Entering blocking state since the account is out of time
[2026-06-08 18:00:43.816]  INFO talpid_core::firewall: Applying firewall policy: Blocked. Blocking LAN. Allowing endpoint: [REDACTED]:443/TCP for mullvad-problem-report.exe mullvad-daemon.exe
```

Fix DES-3095.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10747)
<!-- Reviewable:end -->
