### PR TITLE
Replace Linus' github account with the company one as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,40 +7,40 @@
 # `/code-owners.json` and `/.github/workflows/code-owner-approval.yml`.
 
 # Container images used for building the app are owned by respective team leads and tech lead
-/building/android-container-image.txt @faern @albin-mullvad @rawa
-/building/linux-container-image.txt @faern @raksooo @tobias-jarvelov
+/building/android-container-image.txt @linus-mullvad @albin-mullvad @rawa
+/building/linux-container-image.txt @linus-mullvad @raksooo @tobias-jarvelov
 
 # Developer signing keys must be approved by team/tech leads
-/ci/keys/ @faern @raksooo @pinkisemils @rawa
-/mullvad-update/trusted-metadata-signing-pubkeys @faern @raksooo @pinkisemils @rawa
+/ci/keys/ @linus-mullvad @raksooo @pinkisemils @rawa
+/mullvad-update/trusted-metadata-signing-pubkeys @linus-mullvad @raksooo @pinkisemils @rawa
 
 # Desktop build server files owned by desktop leads
-/ci/buildserver* @faern @raksooo @tobias-jarvelov
-/ci/linux-repository-builder/ @faern @raksooo @tobias-jarvelov
+/ci/buildserver* @linus-mullvad @raksooo @tobias-jarvelov
+/ci/linux-repository-builder/ @linus-mullvad @raksooo @tobias-jarvelov
 
 # Android build server files owned by android
-/ci/android/** @faern @rawa @albin-mullvad
+/ci/android/** @linus-mullvad @rawa @albin-mullvad
 
 # Desktop release config specifying code signing key fingerprint
 /desktop/scripts/release/release-config.sh
 
 # Cargo deny config must be approved by tech lead or desktop team lead
-**/deny.toml @faern @raksooo @tobias-jarvelov
+**/deny.toml @linus-mullvad @raksooo @tobias-jarvelov
 
 # Changes to what CVEs are ignored must be approved by leads
-**/osv-scanner.toml @faern @raksooo @pinkisemils @albin-mullvad @rawa @tobias-jarvelov
-/.github/workflows/osv-scanner*.yml @faern @raksooo @pinkisemils @rawa @tobias-jarvelov
+**/osv-scanner.toml @linus-mullvad @raksooo @pinkisemils @albin-mullvad @rawa @tobias-jarvelov
+/.github/workflows/osv-scanner*.yml @linus-mullvad @raksooo @pinkisemils @rawa @tobias-jarvelov
 
 # Security related github action workflow changes must be approved by leads
-/.github/workflows/verify-locked-down-signatures.yml @faern @raksooo @pinkisemils @rawa
-/ci/verify-locked-down-signatures.sh @faern @raksooo @pinkisemils @rawa
-/.github/workflows/unicop.yml @faern @raksooo @pinkisemils @rawa
+/.github/workflows/verify-locked-down-signatures.yml @linus-mullvad @raksooo @pinkisemils @rawa
+/ci/verify-locked-down-signatures.sh @linus-mullvad @raksooo @pinkisemils @rawa
+/.github/workflows/unicop.yml @linus-mullvad @raksooo @pinkisemils @rawa
 
 # Our own code ownership mapping and automation must be approved by leads
-/.github/workflows/code-owner-approval.yml @faern @raksooo @pinkisemils @rawa @tobias-jarvelov
-/code-owners.json @faern @raksooo @pinkisemils @rawa @tobias-jarvelov
+/.github/workflows/code-owner-approval.yml @linus-mullvad @raksooo @pinkisemils @rawa @tobias-jarvelov
+/code-owners.json @linus-mullvad @raksooo @pinkisemils @rawa @tobias-jarvelov
 
 # The CODEOWNERS itself must be protected from unauthorized changes,
 # otherwise the protection becomes quite moot.
 # Keep this entry last, so it is sure to override any existing previous wildcard match
-/.github/CODEOWNERS @faern @raksooo @pinkisemils @rawa
+/.github/CODEOWNERS @linus-mullvad @raksooo @pinkisemils @rawa


### PR DESCRIPTION
Replace my private github account with my new company specific account as code owner. I could not find any other place in the repo where my private account was mentioned.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10751)
<!-- Reviewable:end -->
