### PR TITLE
Update `spin` from yanked version (0.10.0 -> 0.10.1) in test workspace

### DIFF
--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -3539,9 +3539,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 dependencies = [
  "lock_api",
 ]


### PR DESCRIPTION
Follow up to https://github.com/mullvad/mullvadvpn-app/pull/10750 which missed to bump `spin` in the test workspace.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10755)
<!-- Reviewable:end -->
