### PR TITLE
Prevent item duplication in recents when removing custom lists

### DIFF
--- a/ios/MullvadVPN/Coordinators/CustomLists/CustomListInteractor.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/CustomListInteractor.swift
@@ -9,6 +9,7 @@
 import MullvadSettings
 import MullvadTypes
 
+@MainActor
 protocol CustomListInteractorProtocol {
     func fetch(by id: UUID) -> CustomList?
     func fetchAll() -> [CustomList]

--- a/ios/MullvadVPN/Coordinators/CustomLists/EditCustomListCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/EditCustomListCoordinator.swift
@@ -11,6 +11,12 @@ import MullvadSettings
 import Routing
 import UIKit
 
+enum CustomListAction {
+    case didSave(CustomList)
+    case didDelete(CustomList)
+    case noAction
+}
+
 class EditCustomListCoordinator: Coordinator, Presentable, Presenting {
     let navigationController: UINavigationController
     let customListInteractor: CustomListInteractorProtocol
@@ -25,14 +31,14 @@ class EditCustomListCoordinator: Coordinator, Presentable, Presenting {
         navigationController
     }
 
-    var didFinish: ((EditCustomListCoordinator, CustomList) -> Void)?
-    var didCancel: ((EditCustomListCoordinator) -> Void)?
+    var didFinish: ((EditCustomListCoordinator, CustomListAction) -> Void)?
+    var didCancel: ((EditCustomListCoordinator, CustomListAction) -> Void)?
 
     init(
         navigationController: UINavigationController,
         customListInteractor: CustomListInteractorProtocol,
         customList: CustomList,
-        nodes: [LocationNode]
+        nodes: [LocationNode],
     ) {
         self.navigationController = navigationController
         self.customListInteractor = customListInteractor
@@ -102,7 +108,7 @@ class EditCustomListCoordinator: Coordinator, Presentable, Presenting {
                     title: NSLocalizedString("Discard changes", comment: ""),
                     style: .destructive,
                     handler: {
-                        self.didCancel?(self)
+                        self.didCancel?(self, .noAction)
                     }
                 ),
                 AlertAction(
@@ -118,11 +124,11 @@ class EditCustomListCoordinator: Coordinator, Presentable, Presenting {
 
 extension EditCustomListCoordinator: @preconcurrency CustomListViewControllerDelegate {
     func customListDidSave(_ list: CustomList) {
-        didFinish?(self, list)
+        didFinish?(self, .didSave(list))
     }
 
     func customListDidDelete(_ list: CustomList) {
-        didFinish?(self, list)
+        didFinish?(self, .didDelete(list))
     }
 
     func showLocations(_ list: CustomList) {

--- a/ios/MullvadVPN/Coordinators/CustomLists/EditCustomListCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/EditCustomListCoordinator.swift
@@ -32,7 +32,7 @@ class EditCustomListCoordinator: Coordinator, Presentable, Presenting {
     }
 
     var didFinish: ((EditCustomListCoordinator, CustomListAction) -> Void)?
-    var didCancel: ((EditCustomListCoordinator, CustomListAction) -> Void)?
+    var didCancel: ((EditCustomListCoordinator) -> Void)?
 
     init(
         navigationController: UINavigationController,
@@ -108,7 +108,7 @@ class EditCustomListCoordinator: Coordinator, Presentable, Presenting {
                     title: NSLocalizedString("Discard changes", comment: ""),
                     style: .destructive,
                     handler: {
-                        self.didCancel?(self, .noAction)
+                        self.didCancel?(self)
                     }
                 ),
                 AlertAction(

--- a/ios/MullvadVPN/Coordinators/CustomLists/ListCustomListCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/ListCustomListCoordinator.swift
@@ -65,9 +65,9 @@ class ListCustomListCoordinator: Coordinator, Presentable, Presenting {
             editCustomListCoordinator.removeFromParent()
         }
 
-        coordinator.didCancel = { [weak self] editCustomListCoordinator, action in
+        coordinator.didCancel = { [weak self] editCustomListCoordinator in
             guard let self else { return }
-            popToList(action)
+            popToList(.noAction)
             editCustomListCoordinator.removeFromParent()
         }
 

--- a/ios/MullvadVPN/Coordinators/CustomLists/ListCustomListCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/ListCustomListCoordinator.swift
@@ -22,7 +22,7 @@ class ListCustomListCoordinator: Coordinator, Presentable, Presenting {
         navigationController
     }
 
-    var didFinish: ((ListCustomListCoordinator) -> Void)?
+    var didFinish: ((ListCustomListCoordinator, CustomListAction) -> Void)?
 
     init(
         navigationController: UINavigationController,
@@ -39,9 +39,9 @@ class ListCustomListCoordinator: Coordinator, Presentable, Presenting {
     }
 
     func start() {
-        listViewController.didFinish = { [weak self] in
+        listViewController.didFinish = { [weak self] action in
             guard let self else { return }
-            didFinish?(self)
+            didFinish?(self, action)
         }
         listViewController.didSelectItem = { [weak self] in
             self?.edit(list: $0)
@@ -58,16 +58,16 @@ class ListCustomListCoordinator: Coordinator, Presentable, Presenting {
             nodes: nodes
         )
 
-        coordinator.didFinish = { [weak self] editCustomListCoordinator, list in
+        coordinator.didFinish = { [weak self] editCustomListCoordinator, action in
             guard let self else { return }
 
-            popToList()
+            popToList(action)
             editCustomListCoordinator.removeFromParent()
         }
 
-        coordinator.didCancel = { [weak self] editCustomListCoordinator in
+        coordinator.didCancel = { [weak self] editCustomListCoordinator, action in
             guard let self else { return }
-            popToList()
+            popToList(action)
             editCustomListCoordinator.removeFromParent()
         }
 
@@ -75,10 +75,10 @@ class ListCustomListCoordinator: Coordinator, Presentable, Presenting {
         addChild(coordinator)
     }
 
-    private func popToList() {
+    private func popToList(_ action: CustomListAction) {
         if interactor.fetchAll().isEmpty {
             navigationController.dismiss(animated: true)
-            didFinish?(self)
+            didFinish?(self, action)
         } else if let listController = navigationController.viewControllers
             .first(where: { $0 is ListCustomListViewController })
         {

--- a/ios/MullvadVPN/Coordinators/CustomLists/ListCustomListViewController.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/ListCustomListViewController.swift
@@ -35,7 +35,7 @@ class ListCustomListViewController: UIViewController {
     private var fetchedItems: [CustomList] = []
     private var tableView = UITableView(frame: .zero, style: .plain)
     var didSelectItem: ((CustomList) -> Void)?
-    var didFinish: (() -> Void)?
+    var didFinish: ((CustomListAction) -> Void)?
 
     init(interactor: CustomListInteractorProtocol) {
         self.interactor = interactor
@@ -97,7 +97,7 @@ class ListCustomListViewController: UIViewController {
         navigationItem.rightBarButtonItem = UIBarButtonItem(
             systemItem: .done,
             primaryAction: UIAction(handler: { [weak self] _ in
-                self?.didFinish?()
+                self?.didFinish?(.noAction)
             })
         )
 

--- a/ios/MullvadVPN/Coordinators/LocationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/LocationCoordinator.swift
@@ -106,10 +106,7 @@ class LocationCoordinator: Coordinator, Presentable, Presenting {
     private func showAddCustomList(nodes: [LocationNode]) {
         let coordinator = AddCustomListCoordinator(
             navigationController: CustomNavigationController(),
-            interactor: CustomListInteractor(
-                tunnelManager: tunnelManager,
-                repository: customListRepository
-            ),
+            interactor: selectLocationViewModel,
             nodes: nodes
         )
 
@@ -125,17 +122,23 @@ class LocationCoordinator: Coordinator, Presentable, Presenting {
     private func showEditCustomLists(nodes: [LocationNode]) {
         let coordinator = ListCustomListCoordinator(
             navigationController: InterceptibleNavigationController(),
-            interactor: CustomListInteractor(
-                tunnelManager: tunnelManager,
-                repository: customListRepository
-            ),
+            interactor: selectLocationViewModel,
             tunnelManager: tunnelManager,
-            nodes: nodes
+            nodes: nodes,
         )
 
-        coordinator.didFinish = { [weak self] listCustomListCoordinator in
+        coordinator.didFinish = { [weak self] listCustomListCoordinator, action in
+            guard let self else { return }
             listCustomListCoordinator.dismiss(animated: true)
-            self?.selectLocationViewModel?.customListsChanged()
+
+            switch action {
+            case .didDelete(let list):
+                self.selectLocationViewModel.delete(customList: list)
+            case .didSave(let list):
+                try? self.selectLocationViewModel.save(list: list)
+            case .noAction:
+                self.selectLocationViewModel.customListsChanged()
+            }
         }
 
         coordinator.start()
@@ -147,10 +150,7 @@ class LocationCoordinator: Coordinator, Presentable, Presenting {
     private func showEditCustomList(list: CustomList, nodes: [LocationNode]) {
         let coordinator = EditCustomListCoordinator(
             navigationController: InterceptibleNavigationController(),
-            customListInteractor: CustomListInteractor(
-                tunnelManager: tunnelManager,
-                repository: customListRepository
-            ),
+            customListInteractor: selectLocationViewModel,
             customList: list,
             nodes: nodes
         )

--- a/ios/MullvadVPN/Coordinators/LocationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/LocationCoordinator.swift
@@ -155,7 +155,7 @@ class LocationCoordinator: Coordinator, Presentable, Presenting {
             nodes: nodes
         )
 
-        coordinator.didFinish = { [weak self] editCustomListCoordinator, list in
+        coordinator.didFinish = { [weak self] editCustomListCoordinator, _ in
             editCustomListCoordinator.dismiss(animated: true)
             self?.selectLocationViewModel?.customListsChanged()
         }

--- a/ios/MullvadVPN/View controllers/SelectLocation/MockSelectLocationViewModel.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/MockSelectLocationViewModel.swift
@@ -181,6 +181,18 @@ class MockSelectLocationViewModel: SelectLocationViewModel {
         customListName: String
     ) {}
 
+    func fetch(by id: UUID) -> CustomList? { nil }
+
+    func fetchAll() -> [CustomList] { [] }
+
+    func save(list: CustomList) throws {}
+
+    func delete(customList: CustomList) {}
+
+    func addLocationToCustomList(relayLocations: [RelayLocation], customListName: String) throws {}
+
+    func removeLocationFromCustomList(relayLocations: [RelayLocation], customListName: String) throws {}
+
     func deleteCustomList(name: String) {}
 
     func showEditCustomList(name: String) {}

--- a/ios/MullvadVPN/View controllers/SelectLocation/SelectLocationViewModel.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/SelectLocationViewModel.swift
@@ -20,7 +20,6 @@ protocol SelectLocationViewModel: ObservableObject, CustomListInteractorProtocol
     func customListsChanged()
     func addLocationToCustomList(location: LocationNode, customListName: String)
     func removeLocationFromCustomList(location: LocationNode, customListName: String)
-    func deleteCustomList(name: String)
     func showEditCustomList(name: String)
     func didFinish()
     func showDaitaSettings()
@@ -278,15 +277,6 @@ class SelectLocationViewModelImpl: SelectLocationViewModel {
         customListInteractor.fetchAll()
     }
 
-    func deleteCustomList(name: String) {
-        guard let customList = customListInteractor.fetchAll().first(where: { $0.name == name }) else {
-            return
-        }
-        customListInteractor.delete(customList: customList)
-        recentsInteractor.cleanup(customList.id)
-        customListsChanged()
-    }
-
     func showEditCustomList(name: String) {
         guard let customList = customListInteractor.fetchAll().first(where: { $0.name == name }) else {
             return
@@ -322,6 +312,7 @@ class SelectLocationViewModelImpl: SelectLocationViewModel {
         customListsChanged()
     }
 
+    // MARK: - CustomListInteractorProtocol
     func fetch(by id: UUID) -> CustomList? {
         customListInteractor.fetch(by: id)
     }
@@ -337,6 +328,7 @@ class SelectLocationViewModelImpl: SelectLocationViewModel {
 
     func delete(customList: CustomList) {
         customListInteractor.delete(customList: customList)
+        recentsInteractor.cleanup(customList.id)
         customListsChanged()
     }
 
@@ -351,6 +343,7 @@ class SelectLocationViewModelImpl: SelectLocationViewModel {
         customListsChanged()
     }
 
+    //MARK: -
     func customListsChanged() {
         refreshCustomLists()
         refreshRecents()

--- a/ios/MullvadVPN/View controllers/SelectLocation/SelectLocationViewModel.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/SelectLocationViewModel.swift
@@ -5,7 +5,7 @@ import MullvadTypes
 import SwiftUI
 
 @MainActor
-protocol SelectLocationViewModel: ObservableObject {
+protocol SelectLocationViewModel: ObservableObject, CustomListInteractorProtocol {
     var exitContext: LocationContext { get set }
     var entryContext: LocationContext { get set }
     var multihopContext: MultihopContext { get set }
@@ -274,6 +274,10 @@ class SelectLocationViewModelImpl: SelectLocationViewModel {
         }
     }
 
+    func fetchAllCustomLists() -> [CustomList] {
+        customListInteractor.fetchAll()
+    }
+
     func deleteCustomList(name: String) {
         guard let customList = customListInteractor.fetchAll().first(where: { $0.name == name }) else {
             return
@@ -315,6 +319,35 @@ class SelectLocationViewModelImpl: SelectLocationViewModel {
                 relayLocations: location.locations,
                 customListName: customListName
             )
+        customListsChanged()
+    }
+
+    func fetch(by id: UUID) -> CustomList? {
+        customListInteractor.fetch(by: id)
+    }
+
+    func fetchAll() -> [CustomList] {
+        customListInteractor.fetchAll()
+    }
+
+    func save(list: CustomList) throws {
+        try customListInteractor.save(list: list)
+        customListsChanged()
+    }
+
+    func delete(customList: CustomList) {
+        customListInteractor.delete(customList: customList)
+        customListsChanged()
+    }
+
+    func addLocationToCustomList(relayLocations: [RelayLocation], customListName: String) throws {
+        try customListInteractor.addLocationToCustomList(relayLocations: relayLocations, customListName: customListName)
+        customListsChanged()
+    }
+
+    func removeLocationFromCustomList(relayLocations: [RelayLocation], customListName: String) throws {
+        try customListInteractor.removeLocationFromCustomList(
+            relayLocations: relayLocations, customListName: customListName)
         customListsChanged()
     }
 

--- a/ios/MullvadVPN/View controllers/SelectLocation/Views/LocationContextMenu.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/Views/LocationContextMenu.swift
@@ -28,7 +28,7 @@ extension ExitLocationView {
                                     type: .danger,
                                     title: "Delete list",
                                     handler: {
-                                        viewModel.deleteCustomList(name: location.name)
+                                        viewModel.delete(customList: location.customList)
                                         alert = nil
                                     }
                                 ),

--- a/ios/MullvadVPNTests/MullvadVPN/Interactors/CustomListInteractorTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/Interactors/CustomListInteractorTests.swift
@@ -6,6 +6,7 @@ import Testing
 @testable import MullvadSettings
 @testable import MullvadTypes
 
+@MainActor
 struct CustomListInteractorTests {
     let store = InMemorySettingsStore<SettingNotFound>()
 

--- a/ios/MullvadVPNUITests/CustomListsTests.swift
+++ b/ios/MullvadVPNUITests/CustomListsTests.swift
@@ -170,10 +170,15 @@ class CustomListsTests: LoggedInWithTimeUITestCase {
         // MARK: 5) Verify that there is only 1 instance of the selected relay in the recents list
         ///
         /// `app.buttons[.recentListItem(BaseUITestCase.testsDefaultMullvadOwnedRelayName)]`
-        /// cannot be used here as there are likely multiple invisible instances of such button.
-        /// Hence the test resorts to count the number of list items for lack of better ways.
+        /// cannot be used here as there are seemingly multiple invisible instances of such button.
+        /// Hence the test uses a predicate to find the exact instance of the accessibilityIdentifier matching the recent
+
         XCTAssertTrue(
-            app.buttons.matching(NSPredicate(format: "identifier BEGINSWITH %@", "recentListItem")).count == 1)
+            app.buttons.matching(
+                NSPredicate(
+                    format: "identifier LIKE %@",
+                    "recentListItem(\"\(BaseUITestCase.testsDefaultMullvadOwnedRelayName)\")")
+            ).count == 1)
 
         SelectLocationPage(app)
             .tapDoneButton()

--- a/ios/MullvadVPNUITests/CustomListsTests.swift
+++ b/ios/MullvadVPNUITests/CustomListsTests.swift
@@ -11,7 +11,7 @@ import XCTest
 class CustomListsTests: LoggedInWithTimeUITestCase {
 
     override class var settingsResetPolicy: UITestSettingsResetPolicy {
-        .only([.customRelayLists])
+        .only([.customRelayLists, .recentConnections])
     }
 
     func testCreateCustomListPersistAfterAppRestarts() throws {
@@ -111,6 +111,75 @@ class CustomListsTests: LoggedInWithTimeUITestCase {
             .cellWithIdentifier(identifier: .locationListItem(BaseUITestCase.testsDefaultRelayName))
 
         XCTAssertTrue(customListLocation.exists)
+    }
+
+    func testDeletingCustomListWithSingleEntryDoesNotCreateDuplicateInRecents() throws {
+        TunnelControlPage(app)
+            .tapSelectLocationButton()
+
+        // MARK: 1) Create a custom list for setting up the test
+        let customListName = createCustomListName()
+        createCustomList(named: customListName)
+
+        startEditingCustomList(named: customListName)
+
+        EditCustomListLocationsPage(app)
+            .scrollToLocationWith(identifier: BaseUITestCase.testsDefaultCountryName)
+            .unfoldLocationwith(identifier: BaseUITestCase.testsDefaultCountryName)
+            .unfoldLocationwith(identifier: BaseUITestCase.testsDefaultMullvadOwnedCityName)
+            .toggleLocationCheckmarkWith(identifier: BaseUITestCase.testsDefaultMullvadOwnedRelayName)
+            .tapBackButton()
+
+        CustomListPage(app)
+            .tapSaveListButton()
+
+        ListCustomListsPage(app)
+            .tapDoneButton()
+
+        // MARK: 2) Connect to a relay that has the same item as in the custom list
+
+        /// Guarantee that the "search" button doesn't eat input by scrolling to the bottom of the page
+        /// Repeat the scroll every time a section is unfolded for the same reasons
+        app.swipeUp(velocity: .fast)
+        SelectLocationPage(app)
+            .tapLocationCellExpandButton(withName: BaseUITestCase.testsDefaultCountryName)
+        app.swipeUp(velocity: .fast)
+        SelectLocationPage(app)
+            .tapLocationCellExpandButton(withName: BaseUITestCase.testsDefaultMullvadOwnedCityName)
+        app.swipeUp(velocity: .fast)
+        SelectLocationPage(app)
+            .tapLocationCell(withName: BaseUITestCase.testsDefaultMullvadOwnedRelayName)
+
+        allowAddVPNConfigurationsIfAsked()
+
+        TunnelControlPage(app)
+            .waitForConnectedLabel()
+            .tapSelectLocationButton()
+
+        // MARK: 3) Connect to the custom list
+        SelectLocationPage(app)
+            .tapLocationCell(withName: customListName)
+
+        TunnelControlPage(app)
+            .waitForConnectedLabel()
+            .tapSelectLocationButton()
+
+        // MARK: 4) Delete the custom list
+        deleteCustomList(named: customListName)
+
+        // MARK: 5) Verify that there is only 1 instance of the selected relay in the recents list
+        ///
+        /// `app.buttons[.recentListItem(BaseUITestCase.testsDefaultMullvadOwnedRelayName)]`
+        /// cannot be used here as there are likely multiple invisible instances of such button.
+        /// Hence the test resorts to count the number of list items for lack of better ways.
+        XCTAssertTrue(
+            app.buttons.matching(NSPredicate(format: "identifier BEGINSWITH %@", "recentListItem")).count == 1)
+
+        SelectLocationPage(app)
+            .tapDoneButton()
+
+        TunnelControlPage(app)
+            .tapCancelOrDisconnectButton()
     }
 
     func createCustomList(named name: String) {


### PR DESCRIPTION
This PR prevents a recent item from appearing twice when deleting a custom list that contained an item already in recents without using quick actions.
A UI test has been added to verify the behaviour is correct as no Unit Tests were fit for that verification effort.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10756)
<!-- Reviewable:end -->
