### PR TITLE
Use releases.mullvad.net directly in mullvad-release

### DIFF
--- a/installer-downloader/src/controller.rs
+++ b/installer-downloader/src/controller.rs
@@ -73,7 +73,7 @@ pub fn initialize_controller<T: AppDelegate + 'static>(delegate: &mut T, environ
     type DirProvider = crate::temp::TempDirProvider;
 
     let platform = MetaRepositoryPlatform::current().expect("current platform must be supported");
-    let version_provider = HttpVersionInfoProvider::from(platform);
+    let version_provider = HttpVersionInfoProvider::api(platform);
 
     type CacheDir = cfg_select! {
         target_os = "windows" => { mullvad_update::local::AppCacheDir }

--- a/mullvad-update/mullvad-release/src/platform.rs
+++ b/mullvad-update/mullvad-release/src/platform.rs
@@ -113,16 +113,15 @@ impl Platform {
 
     /// Pull latest metadata from repository and store it in `signed/`
     pub async fn pull(&self, assume_yes: bool) -> anyhow::Result<()> {
-        let platform = MetaRepositoryPlatform::from(*self);
+        // Use 'releases.mullvad.net' instead of the API to make it less likely that the data is stale.
+        let info_provider = HttpVersionInfoProvider::releases(MetaRepositoryPlatform::from(*self));
 
-        println!("Pulling {self} metadata from {}...", platform.url());
+        println!("Pulling {self} metadata from {}...", info_provider.url());
 
-        let response = HttpVersionInfoProvider::get_versions_for_platform(
-            platform,
-            mullvad_update::version::MIN_VERIFY_METADATA_VERSION,
-        )
-        .await
-        .context("Failed to retrieve versions")?;
+        let response = info_provider
+            .get_versions(mullvad_update::version::MIN_VERIFY_METADATA_VERSION)
+            .await
+            .context("Failed to retrieve versions")?;
 
         let json = serde_json::to_string_pretty(&response)
             .context("Failed to serialize updated metadata")?;

--- a/mullvad-update/src/client/api.rs
+++ b/mullvad-update/src/client/api.rs
@@ -35,11 +35,6 @@ impl MetaRepositoryPlatform {
         }
     }
 
-    /// Return complete URL used for the metadata
-    pub fn url(&self) -> String {
-        format!("{}/{}", defaults::RELEASES_URL, self.filename())
-    }
-
     fn filename(&self) -> &str {
         match self {
             MetaRepositoryPlatform::Windows => "windows.json",
@@ -72,42 +67,52 @@ impl VersionInfoProvider for HttpVersionInfoProvider {
     }
 }
 
-impl From<MetaRepositoryPlatform> for HttpVersionInfoProvider {
-    /// Construct an [HttpVersionInfoProvider] for the given platform using reasonable defaults.
+impl HttpVersionInfoProvider {
+    /// Maximum size of the GET response, in bytes
+    const SIZE_LIMIT: usize = 1024 * 1024;
+
+    /// Create a repository using the base URL [defaults::RELEASES_URL].
     ///
-    /// By default, `pinned_certificate` will be set to the LE root certificate.
-    fn from(platform: MetaRepositoryPlatform) -> Self {
+    /// This will fetch the metadata from `api.mullvad.net`, and reject anything except the LE root
+    /// certificate. This assumes the domain name resolves to [`API_IP_DEFAULT`] instead of using
+    /// DNS.
+    pub fn api(platform: MetaRepositoryPlatform) -> Self {
+        Self::new(defaults::RELEASES_URL, platform)
+    }
+
+    /// Create a repository using the base URL [defaults::METADATA_URL].
+    ///
+    /// This will fetch the metadata from `releases.mullvad.net`. It does not pin the TLS
+    /// certificate, and resolves the domain name using DNS. This may be useful as the data is less
+    /// likely to be stale.
+    ///
+    /// You most likely want to use [Self::api] instead.
+    pub fn releases(platform: MetaRepositoryPlatform) -> Self {
+        Self::new(defaults::METADATA_URL, platform)
+    }
+
+    /// Return repository based on the `base_url`.
+    fn new(base_url: &str, platform: MetaRepositoryPlatform) -> Self {
         HttpVersionInfoProvider {
-            url: platform.url(),
+            url: format!("{}/{}", base_url, platform.filename()),
             resolve: Some((API_HOST_DEFAULT, API_IP_DEFAULT)),
             pinned_certificate: Some(defaults::PINNED_CERTIFICATE.clone()),
             dump_to_path: None,
         }
     }
-}
 
-impl HttpVersionInfoProvider {
-    /// Maximum size of the GET response, in bytes
-    const SIZE_LIMIT: usize = 1024 * 1024;
-
-    /// Retrieve version metadata for the given platform using reasonable defaults.
-    ///
-    /// By default, `pinned_certificate` will be set to the LE root certificate, and
-    /// `verifying_keys` will be set to the keys in `trusted-metadata-signing-keys`.
-    pub async fn get_versions_for_platform(
-        platform: MetaRepositoryPlatform,
-        lowest_metadata_version: usize,
-    ) -> anyhow::Result<SignedResponse> {
-        HttpVersionInfoProvider::from(platform)
-            .get_versions(lowest_metadata_version)
-            .await
+    /// Return complete URL used for the metadata
+    pub fn url(&self) -> &str {
+        &self.url
     }
 
-    /// Download and verify signed data with sane defaults
+    /// Download and verify signed data with sane defaults.
     ///
-    /// By default, `pinned_certificate` will be set to the LE root certificate, and
-    /// and the keys in `trusted-metadata-signing-keys` will be used for verification.
-    async fn get_versions(&self, lowest_metadata_version: usize) -> anyhow::Result<SignedResponse> {
+    /// By default, the keys in `trusted-metadata-signing-keys` are used for verification.
+    pub async fn get_versions(
+        &self,
+        lowest_metadata_version: usize,
+    ) -> anyhow::Result<SignedResponse> {
         self.get_versions_inner(|raw_json| {
             SignedResponse::deserialize_and_verify(raw_json, lowest_metadata_version)
         })


### PR DESCRIPTION
Previously, I've run into the issue where I run `mullvad-release pull` and it replaces the metadata just uploaded with stale metadata. This PR attempts to ameliorate that by not fetching the metadata via the API.

This does not 100% prevent the issue as the CDN servers may also be out of sync, but syncing those should only take seconds.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10758)
<!-- Reviewable:end -->
