### PR TITLE
Fix blurry windows installer UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Line wrap the file at 100 chars.                                              Th
 - Preserve the app's own theme colors when Windows high contrast (forced-colors) mode is
   enabled in order to prevent toggle switches and other custom-styled controls from becoming
   invisible.
+- Fix the installer UI from looking blurry by making the installer DPI-aware.
 
 ### Security
 - Linux and macOS: Fix management interface socket being created with less restrictive permissions

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -11,6 +11,12 @@
 # The default also includes Windows 7, 8.1, and 8.
 ManifestSupportedOS "{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"
 
+# Declare that the installer is DPI-aware.
+# A DPI-aware application is not scaled by the DWM (DPI virtualization) so the text is never blurry.
+# - https://nsis.sourceforge.io/Reference/ManifestDPIAware
+# - https://github.com/electron-userland/electron-builder/issues/5329
+ManifestDPIAware true
+
 #
 # NOTES
 #


### PR DESCRIPTION
Fixes https://github.com/mullvad/mullvadvpn-app/issues/7781 - a long standing issue with the Windows installer looking blurry. See attachments.

# Before
<img width="998" height="776" alt="not-dpi-aware-1" src="https://github.com/user-attachments/assets/8bd03e10-b173-4f7c-9fae-943fae8c10a4" />
e
<img width="998" height="776" alt="not-dpi-aware-2" src="https://github.com/user-attachments/assets/c7f83d97-496b-4ede-9eca-cd14f8cb0281" />

# After
<img width="998" height="744" alt="dpi-aware-1" src="https://github.com/user-attachments/assets/841b1773-d9e8-4b2e-b8a9-58e61d98cd91" />
<img width="998" height="744" alt="dpi-aware-2" src="https://github.com/user-attachments/assets/53c8ad44-da09-4690-9729-5fcb0f38eaec" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10763)
<!-- Reviewable:end -->
