### PR TITLE
Always route socks 5 proxy ip addresses

### DIFF
--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -26,6 +26,10 @@ Line wrap the file at 100 chars.                                              Th
 - Make the globe interactive, with supports for pan, pinch-to-zoom, and fling. This to discover
   where servers are located as well as displaying your connection path.
 
+### Changed
+- Route 10.124.0.0/23 inside the tunnel when Local network sharing is turned on. This is to enable
+  the use SOCKS5 proxies on other relays together with Local network sharing.
+
 
 ## [android/2026.8] - 2026-07-15
 ### Fixed

--- a/talpid-tunnel/src/tun_provider/android/mod.rs
+++ b/talpid-tunnel/src/tun_provider/android/mod.rs
@@ -2,7 +2,7 @@ mod ipnetwork_sub;
 
 use self::ipnetwork_sub::IpNetworkSub;
 use super::TunConfig;
-use ipnetwork::IpNetwork;
+use ipnetwork::{IpNetwork, Ipv4Network};
 use jnix::{
     FromJava, IntoJava, JnixEnv,
     jni::{
@@ -11,6 +11,7 @@ use jnix::{
         signature::{JavaType, Primitive},
     },
 };
+use std::net::Ipv4Addr;
 use std::{
     net::IpAddr,
     os::{
@@ -22,6 +23,11 @@ use std::{
 use talpid_routing::Route;
 use talpid_types::net::{ALLOWED_LAN_MULTICAST_NETS, ALLOWED_LAN_NETS};
 use talpid_types::{ErrorExt, android::AndroidContext, android::InetNetwork};
+
+/// Socks5 proxies on Mullvad relays can be connected on the range 10.124.0.0/23 if already
+/// connected to another Mullvad relay.
+const SOCKS_PROXIES: IpNetwork =
+    IpNetwork::V4(Ipv4Network::new_checked(Ipv4Addr::new(10, 124, 0, 0), 23).unwrap());
 
 /// Errors that occur while setting up VpnService tunnel.
 #[derive(Debug, thiserror::Error)]
@@ -317,8 +323,11 @@ impl VpnServiceConfig {
             .collect()
     }
 
-    /// Potentially subtract LAN nets from the VPN service routes, excepting gateways.
-    /// This prevents LAN traffic from going in the tunnel.
+    /// Returns a vector representing all networks from the routes in the given config,
+    /// minus ALLOWED_LAN_NETS and ALLOWED_LAN_MULTICAST_NETS from the routes if allow lan
+    /// is true. This will prevent LAN traffic going in the tunnel. The gateway addresses are always
+    /// kept in the vector as well as SOCKS_PROXIES, the latter to support using SOCKS proxies
+    /// on Mullvad relays.
     fn resolve_routes(config: &TunConfig) -> Vec<InetNetwork> {
         if !config.allow_lan {
             return config
@@ -329,7 +338,11 @@ impl VpnServiceConfig {
                 .collect();
         }
 
-        let required_ipv4_routes = vec![IpNetwork::from(IpAddr::from(config.ipv4_gateway))];
+        let required_ipv4_routes = vec![
+            IpNetwork::from(IpAddr::from(config.ipv4_gateway)),
+            // We want to keep the socks proxies subnet so that users can use those to multihop when lan sharing is active
+            SOCKS_PROXIES,
+        ];
         let required_ipv6_routes = config
             .ipv6_gateway
             .map(|addr| IpNetwork::from(IpAddr::from(addr)))


### PR DESCRIPTION
## What
Removes the range `10.124.0.0/23` from the range of addresses that are routed outside the tunnel when LAN sharing is turned on.

## Why
[User requested feature](https://github.com/mullvad/mullvadvpn-app/discussions/8942)
Currently it is not possible to use a socks 5 proxy on a different relay than the one that the app is currently connected. This allows a user to connect to one relay and then use a sock 5 proxy on a different relay. All socks 5 proxies on mullvad relays uses an IP address on the `10.124.0.0/23` range.

## Test
This was tested by using an extension on Firefox Android. The socks 5 proxy was set up with the host `de-dus-wg-socks5-001.relays.mullvad.net` and the port 1080. Then mullvad.net/check was used to confirm that the proxy was used.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10764)
<!-- Reviewable:end -->
