### PR TITLE
Reproducible builds: stable build timestamps and BUILDHOST on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ Line wrap the file at 100 chars.                                              Th
 - Old `mullvad log set-level` command has been renamed to `mullvad log set-rust-log`.
 - Update `gotatun` to 0.8.1.
 
+#### Linux
+- Make all timestamps embedded in `.deb` and `.rpm` packages deterministic by deriving them from
+  the git commit being built instead of the time of the build. Required for reproducible builds.
+
 #### Windows
 - Update `wireguard-nt` to version 1.1. This retires the Mullvad fork at
   <https://github.com/mullvad/wireguard-nt>.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Line wrap the file at 100 chars.                                              Th
 #### Linux
 - Make all timestamps embedded in `.deb` and `.rpm` packages deterministic by deriving them from
   the git commit being built instead of the time of the build. Required for reproducible builds.
+- Set the `BUILDHOST` header of `.rpm` packages to a fixed value instead of the hostname of the
+  build machine. Required for reproducible builds.
 
 #### Windows
 - Update `wireguard-nt` to version 1.1. This retires the Mullvad fork at

--- a/build.sh
+++ b/build.sh
@@ -68,6 +68,11 @@ fi
 # Configure build
 ################################################################################
 
+# Timestamp embedded in build artifacts (https://reproducible-builds.org/docs/source-date-epoch/).
+# Set to the commit time of HEAD, so everyone building the same commit embeds the same timestamps.
+# Required for the .deb and .rpm output to be reproducible.
+export SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-$(git log -1 --pretty=%ct)}
+
 CARGO_ARGS=()
 NPM_PACK_ARGS=()
 

--- a/desktop/packages/mullvad-vpn/tasks/distribution.cjs
+++ b/desktop/packages/mullvad-vpn/tasks/distribution.cjs
@@ -224,6 +224,11 @@ function newConfig() {
         // same across all electron-builder applications, which causes package
         // conflicts
         '--rpm-rpmbuild-define=_build_id_links none',
+        // Required for reproducible rpm output. Unlike fpm's deb output, which is
+        // deterministic when SOURCE_DATE_EPOCH is set (exported by build.sh), rpmbuild must
+        // be explicitly told to clamp payload file mtimes and the BUILDTIME header to it.
+        '--rpm-rpmbuild-define=clamp_mtime_to_source_date_epoch 1',
+        '--rpm-rpmbuild-define=use_source_date_epoch_as_buildtime 1',
         '--directories=/opt/Mullvad VPN/',
         '--before-install',
         distAssets('linux/before-install.sh'),

--- a/desktop/packages/mullvad-vpn/tasks/distribution.cjs
+++ b/desktop/packages/mullvad-vpn/tasks/distribution.cjs
@@ -229,6 +229,8 @@ function newConfig() {
         // be explicitly told to clamp payload file mtimes and the BUILDTIME header to it.
         '--rpm-rpmbuild-define=clamp_mtime_to_source_date_epoch 1',
         '--rpm-rpmbuild-define=use_source_date_epoch_as_buildtime 1',
+        // Set the BUILDHOST header to a fixed value instead of the build machine's hostname
+        '--rpm-rpmbuild-define=_buildhost reproducible',
         '--directories=/opt/Mullvad VPN/',
         '--before-install',
         distAssets('linux/before-install.sh'),


### PR DESCRIPTION
When looking into how realistic it would be to make our Electron app produce [reproducible builds](https://reproducible-builds.org/), I found that there were some low hanging fruits. Even if we don't commit to make the app fully reproducible, these things do not hurt to have, and they move us in a good direction IMHO.

This makes the timestamps embedded in the Linux `.deb` and `.rpm` packages deterministic (derived from the commit being built instead of the build time) thanks to `SOURCE_DATE_EPOCH`, and pins the rpm `BUILDHOST` header to a fixed value instead of the build machine's hostname.

With this change, two builds from the same commit in the same build container produce bit-for-bit identical `.deb` and `.rpm` files.

This was inspired by Signal's work on making their Linux app reproducible: https://github.com/signalapp/Signal-Desktop/pull/6945

## How to test

```bash
./building/containerized-build.sh linux   # run twice, save dist/*.{deb,rpm} after each run
sha256sum run1/* run2/*
```

Hashes should be equal with this change. Without it they differ. You can inspect the difference in more detail with:
```
diffoscope --exclude-directory-metadata=recursive run1/x.deb run2/x.deb and
rpm -qp --qf '%{BUILDTIME} %{BUILDHOST}\n' x.rpm.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10765)
<!-- Reviewable:end -->
