### PR TITLE
Finish remaining tarnsaction before running UITest

### DIFF
--- a/ios/MullvadVPN/SceneDelegate.swift
+++ b/ios/MullvadVPN/SceneDelegate.swift
@@ -47,7 +47,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, @preconcurrency Setting
     private func addTunnelObserver() {
         let tunnelObserver = TunnelBlockObserver(
             didLoadConfiguration: { [weak self] _ in
-                self?.configureScene()
+                guard let self, appDelegate.launchArguments.target != .uiTests else { return }
+                configureScene()
             },
             didUpdateDeviceState: { [weak self] _, deviceState, _ in
                 self?.deviceStateDidChange(deviceState)
@@ -186,15 +187,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, @preconcurrency Setting
         let launchViewController = LaunchViewController(
             launchArguments: appDelegate.launchArguments,
             tunnelManager: tunnelManager,
-            accessMethodRepository: accessMethodRepository,
             settingsManager: settingsManager)
 
         launchViewController.onAppReady = { [weak self] in
             guard let self = self else { return }
-            if tunnelManager.isConfigurationLoaded {
-                isSceneConfigured = false
-                configureScene()
-            }
+            configureScene()
         }
 
         window = UIWindow(windowScene: windowScene)

--- a/ios/MullvadVPN/StorePaymentManager/StorePaymentManager.swift
+++ b/ios/MullvadVPN/StorePaymentManager/StorePaymentManager.swift
@@ -141,35 +141,26 @@ final actor StorePaymentManager: @unchecked Sendable {
         }
     }
 
-    static func finishOutstandingSandboxAndOldAPITransactions() async {
+    static func cleanupUnfinishedTransactions() async {
         let logger = Logger(label: "StorePaymentManager")
 
-        logger.debug("Finishing outstanding sandbox and old transactions")
+        logger.debug("About to iterate Transaction.unfinished")
 
         for await verification in Transaction.unfinished {
-            guard let payload = try? verification.payloadValue else {
-                logger.debug("Verification is missing a valid payload")
-                continue
-            }
+            switch verification {
+            case .verified(let transaction):
+                logger.debug("Verified unfinished transaction: \(transaction.id)")
+                await transaction.finish()
 
-            logger.debug("Unfinished transaction environment is \(payload.environment)")
-
-            let isStagingEnvironment = payload.environment != .production
-            let isOldAPI = !StoreSubscription.allCases
-                .map { $0.rawValue }
-                .contains(payload.productID)
-
-            if isStagingEnvironment || isOldAPI {
-                logger.debug(
-                    "Finishing transaction. isStagingEnvironment: \(isStagingEnvironment), isOldAPI: \(isOldAPI)"
+            case .unverified(let transaction, let error):
+                logger.warning(
+                    "Unverified unfinished transaction \(transaction.id): \(error)"
                 )
-                await payload.finish()
-            } else {
-                logger.debug(
-                    "Skipping transaction. isStagingEnvironment: \(isStagingEnvironment), isOldAPI: \(isOldAPI)"
-                )
+                await transaction.finish()
             }
         }
+
+        logger.debug("Completed Transaction.unfinished iteration")
     }
 
     // MARK: - Private methods

--- a/ios/MullvadVPN/View controllers/Account/AccountViewController.swift
+++ b/ios/MullvadVPN/View controllers/Account/AccountViewController.swift
@@ -267,11 +267,11 @@ class AccountViewController: UIViewController, @unchecked Sendable {
 
         sheetController.addAction(
             UIAlertAction(
-                title: "Finish unfinished sandbox purchases",
+                title: "Finish unfinished purchases",
                 style: .default,
                 handler: { _ in
                     Task {
-                        await StorePaymentManager.finishOutstandingSandboxAndOldAPITransactions()
+                        await StorePaymentManager.cleanupUnfinishedTransactions()
                     }
                 }
             )

--- a/ios/MullvadVPN/View controllers/Launch/LaunchViewController.swift
+++ b/ios/MullvadVPN/View controllers/Launch/LaunchViewController.swift
@@ -15,12 +15,14 @@ class LaunchViewController: UIViewController {
     var onAppReady: (() -> Void)?
 
     init(
-        launchArguments: LaunchArguments, tunnelManager: TunnelManager,
-        accessMethodRepository: any AccessMethodRepositoryProtocol,
+        launchArguments: LaunchArguments,
+        tunnelManager: TunnelManager,
         settingsManager: SettingsManager
     ) {
         self.appResetManager = AppResetManager(
-            launchArguments: launchArguments, tunnelManager: tunnelManager, settingsManager: settingsManager)
+            launchArguments: launchArguments,
+            tunnelManager: tunnelManager,
+            settingsManager: settingsManager)
         super.init(nibName: nil, bundle: nil)
         setupLaunchScreen()
         self.appResetManager.onAppReady = { [weak self] in
@@ -34,6 +36,11 @@ class LaunchViewController: UIViewController {
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
         .lightContent
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        appResetManager.start()
     }
 
     private func setupLaunchScreen() {

--- a/ios/MullvadVPNUITests/Pages/PaymentPage.swift
+++ b/ios/MullvadVPNUITests/Pages/PaymentPage.swift
@@ -24,13 +24,6 @@ class PaymentPage: Page {
         return self
     }
 
-    @discardableResult func finishUnfinishedSandboxPurchases() -> Self {
-        app.buttons[.debugOptionsButton].tapWhenHittable()
-        app.buttons["Finish unfinished sandbox purchases"].tapWhenHittable()
-
-        return self
-    }
-
     @discardableResult func tapAdd30DaysTimeSheetButton() -> Self {
         // Adding accessibility identifier to the button inside the product sheet would to duplicate
         // button entries, which in turn led to tapping here not working reliably. Using the title
@@ -82,7 +75,7 @@ class PaymentPage: Page {
     // MARK: Springboard functions
 
     @discardableResult func submitSubscribeSheet() -> Self {
-        springboard.buttons["Subscribe"].tapWhenHittable()
+        springboard.buttons["Subscribe"].tapWhenHittable(timeout: .veryLong)
 
         return self
     }
@@ -92,31 +85,39 @@ class PaymentPage: Page {
         password: String
     ) -> Self {
         let usernameTextField = springboard.textFields.firstMatch
+        let passwordTextField = springboard.secureTextFields.firstMatch
         if usernameTextField.existsAfterWait(), usernameTextField.isEnabled {
             usernameTextField.tap()
-            springboard.typeText(username)
+            usernameTextField.typeText(username)
         }
 
-        springboard.secureTextFields.firstMatch.tapWhenHittable()
-        springboard.typeText(password)
+        passwordTextField.tapWhenHittable()
+        passwordTextField.typeText(password)
 
         return self
     }
 
     @discardableResult func submitConfirmAccountSheet() -> Self {
-        springboard.buttons["Confirm"].tapWhenHittable()
-
+        let signInButton = springboard.buttons["Sign In"]
+        let confirmButton = springboard.buttons["Confirm"]
+        if signInButton.exists && signInButton.isHittable {
+            signInButton.tap()
+            return self
+        } else if confirmButton.exists && confirmButton.isHittable {
+            confirmButton.tap()
+            return self
+        }
         return self
     }
 
     @discardableResult func submitRenewSubscriptionSheet() -> Self {
-        springboard.buttons["Buy"].tapWhenHittable(timeout: .long)
+        springboard.buttons["Buy"].tapWhenHittable(timeout: .veryLong)
 
         return self
     }
 
     @discardableResult func submitPurchaseFinishedAlert() -> Self {
-        springboard.buttons["OK"].tapWhenHittable()
+        springboard.buttons["OK"].tapWhenHittable(timeout: .veryLong)
 
         return self
     }

--- a/ios/MullvadVPNUITests/Payment/PaymentTests.swift
+++ b/ios/MullvadVPNUITests/Payment/PaymentTests.swift
@@ -27,7 +27,6 @@ class PaymentTests: LoggedOutUITestCase {
 
         accountPage
             .verifyPaidUntil(accountExpiry)
-            .finishUnfinishedSandboxPurchases()
             .tapAddTimeButton()
             .tapAdd30DaysTimeSheetButton()
 
@@ -50,7 +49,6 @@ class PaymentTests: LoggedOutUITestCase {
             .tapAccountButton()
 
         AccountPage(app)
-            .finishUnfinishedSandboxPurchases()
             .swipeDownToDismissModal()
 
         let welcomePage = WelcomePage(app)
@@ -79,7 +77,6 @@ class PaymentTests: LoggedOutUITestCase {
             .tapAccountButton()
 
         AccountPage(app)
-            .finishUnfinishedSandboxPurchases()
             .swipeDownToDismissModal()
 
         let outOfTimePage = OutOfTimePage(app)
@@ -118,7 +115,6 @@ class PaymentTests: LoggedOutUITestCase {
 
         accountPage
             .verifyPaidUntil(accountExpiry)
-            .finishUnfinishedSandboxPurchases()
             .tapRestorePurchasesButton()
             .dismissAlreadyRestoredPurchasesAlert()
             .verifyPaidUntil(accountExpiry)

--- a/ios/Shared/AppResetManager.swift
+++ b/ios/Shared/AppResetManager.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2026 Mullvad VPN AB. All rights reserved.
 //
 
+import Combine
 import MullvadLogging
 import MullvadSettings
 import NetworkExtension
@@ -17,9 +18,15 @@ final class AppResetManager {
     private let tunnelManager: TunnelManager
     private let settingsManager: SettingsManager
     private var tunnelObserver: TunnelObserver!
+
     let logger = Logger(label: "AppResetManager")
 
     var onAppReady: (@Sendable @MainActor () -> Void)?
+
+    private let isConfigurationLoaded = CurrentValueSubject<Bool, Never>(false)
+    private let isAppReady = CurrentValueSubject<Bool, Never>(false)
+
+    private var cancellables = Set<AnyCancellable>()
 
     init(
         launchArguments: LaunchArguments,
@@ -29,16 +36,37 @@ final class AppResetManager {
         self.launchArguments = launchArguments
         self.tunnelManager = tunnelManager
         self.settingsManager = settingsManager
-
         guard launchArguments.target.isUITest else { return }
+        observeReadiness()
         addObserver()
+    }
+
+    func start() {
         Task {
-            await setup()
+            async let cleanup: () = StorePaymentManager.cleanupUnfinishedTransactions()
+            async let setupTask: () = setup()
+            _ = await (cleanup, setupTask)
         }
+    }
+
+    private func observeReadiness() {
+        Publishers.CombineLatest(isConfigurationLoaded, isAppReady)
+            .filter { configurationLoaded, appReady in
+                configurationLoaded && appReady
+            }
+            .sink { [weak self] _, _ in
+                guard let self else { return }
+                tunnelManager.removeObserver(tunnelObserver)
+                onAppReady?()
+            }
+            .store(in: &cancellables)
     }
 
     private func addObserver() {
         let tunnelObserver = TunnelBlockObserver(
+            didLoadConfiguration: { [weak self] tunnelManager in
+                self?.isConfigurationLoaded.send(true)
+            },
             didUpdateTunnelStatus: { [weak self] tunnelManager, tunnelStatus in
                 guard let self else { return }
                 if tunnelStatus.observedState != .disconnected {
@@ -60,12 +88,11 @@ final class AppResetManager {
             await reset()
         } catch {
             logger.error("Unexpected tunnel error: \(error.localizedDescription)")
-            onAppReady?()
+            isAppReady.send(true)
         }
     }
 
     private func reset() async {
-        defer { tunnelManager.removeObserver(tunnelObserver!) }
         switch tunnelManager.deviceState {
         case .loggedIn:
             await logoutIfNeeded()
@@ -73,7 +100,7 @@ final class AppResetManager {
         default:
             resetUserDefaults()
             resetKeychain()
-            onAppReady?()
+            isAppReady.send(true)
         }
     }
 


### PR DESCRIPTION
This PR marks unfinished payment transactions regardless of the environment when UI tests are launched.

Since the tests interact with the iOS SpringBoard, the button on the credentials screen can sometimes be **"Confirm"** and other times **"Sign In"**. This change handles both cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10766)
<!-- Reviewable:end -->
