### PR TITLE
Improve systemd services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Line wrap the file at 100 chars.                                              Th
   the git commit being built instead of the time of the build. Required for reproducible builds.
 - Set the `BUILDHOST` header of `.rpm` packages to a fixed value instead of the hostname of the
   build machine. Required for reproducible builds.
+- De-couple `mullvad-daemon.service` "After=" dependencies from systemd.resolved and NetworkManager.
 
 #### Windows
 - Update `wireguard-nt` to version 1.1. This retires the Mullvad fork at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Line wrap the file at 100 chars.                                              Th
 - Set the `BUILDHOST` header of `.rpm` packages to a fixed value instead of the hostname of the
   build machine. Required for reproducible builds.
 - De-couple `mullvad-daemon.service` "After=" dependencies from systemd.resolved and NetworkManager.
+- Start `mullvad-early-boot-blocking.service` before `network-pre.target` instead of `basic.target`.
 
 #### Windows
 - Update `wireguard-nt` to version 1.1. This retires the Mullvad fork at

--- a/dist-assets/linux/mullvad-daemon.service
+++ b/dist-assets/linux/mullvad-daemon.service
@@ -1,10 +1,9 @@
 # Systemd service unit file for the Mullvad VPN daemon
-# testing if new changes are added
 
 [Unit]
 Description=Mullvad VPN daemon
 Before=network-online.target
-After=mullvad-early-boot-blocking.service NetworkManager.service systemd-resolved.service
+After=mullvad-early-boot-blocking.service network.target
 
 StartLimitBurst=5
 StartLimitIntervalSec=20

--- a/dist-assets/linux/mullvad-early-boot-blocking.service
+++ b/dist-assets/linux/mullvad-early-boot-blocking.service
@@ -6,7 +6,8 @@
 [Unit]
 Description=Mullvad early boot network blocker
 DefaultDependencies=no
-Before=basic.target mullvad-daemon.service
+# systemd docs: "network-pre.target is used to order services before any network interfaces start to be configured. Its primary purpose is for usage with firewall services that want to establish a firewall before any network interface is up."
+Before=network-pre.target mullvad-daemon.service
 # Mount local filesystems (/var) before starting the early-boot service,
 # else persisting logs will fail.
 After=local-fs.target


### PR DESCRIPTION
- mullvad-daemon.service: De-couple service from specific network manager implementations.
- mullvad-early-boot-blocking.service: Start service before network stack is up. Don't care about unrelated dependencies encapsulated by [basic.target](https://www.man7.org/linux/man-pages/man7/systemd.special.7.html).

Closes https://github.com/mullvad/mullvadvpn-app/issues/7743.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10769)
<!-- Reviewable:end -->
