### PR TITLE
Remove unnecessary brew update call in screenshot tests setup

### DIFF
--- a/.github/workflows/ios-screenshots-tests.yml
+++ b/.github/workflows/ios-screenshots-tests.yml
@@ -44,7 +44,6 @@ jobs:
 
       - name: Install zip
         run: |
-          brew update
           brew install zip
 
       - name: Run screenshot tests


### PR DESCRIPTION
This PR removes an unnecesary call to `brew update` when running the screenshot tests yaml setup.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10778)
<!-- Reviewable:end -->
