### PR TITLE
Clean winfw in the `./build-windows-modules.sh clean` subcommand

### DIFF
--- a/build-windows-modules.sh
+++ b/build-windows-modules.sh
@@ -143,6 +143,7 @@ function build_nsis_plugins {
 function clean_all {
     cargo clean -p mullvad-nsis
 
+    clean_solution "./windows/winfw"
     clean_solution "./windows/libshared"
     clean_solution "./windows/windows-libraries"
     clean_solution "./windows/libwfp"


### PR DESCRIPTION
The clean subcommand did not clean `winfw`, leaving built binaries in `windows/winfw/bin/` that I would expect a clean to remove.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10780)
<!-- Reviewable:end -->
