### PR TITLE
Fix LPE in macOS uninstall script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ Line wrap the file at 100 chars.                                              Th
 #### Linux
 - Plug hole in Custom DNS firewall rules for LAN resolvers.
 
+#### macOS
+- Fix local privilege escalation attack in the uninstall script. This could be used by admin users
+  to obtain root privileges during uninstall.
+
 
 ## [2026.3] - 2026-06-15
 This release is identical to 2026.3-beta3.

--- a/dist-assets/uninstall_macos.sh
+++ b/dist-assets/uninstall_macos.sh
@@ -3,10 +3,12 @@
 set -ue
 
 ASSUMEYES="n"
+FROMDAEMON="n"
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --yes) ASSUMEYES="y";;
+        --from-daemon) FROMDAEMON="y";;
         *)
             echo "Unknown parameter: $1"
             exit 1
@@ -31,9 +33,12 @@ DAEMON_PLIST_PATH="/Library/LaunchDaemons/net.mullvad.daemon.plist"
 sudo launchctl unload -w "$DAEMON_PLIST_PATH"
 sudo rm -f "$DAEMON_PLIST_PATH"
 
-echo "Resetting firewall"
-sudo /Applications/Mullvad\ VPN.app/Contents/Resources/mullvad-setup reset-firewall || echo "Failed to reset firewall"
-sudo /Applications/Mullvad\ VPN.app/Contents/Resources/mullvad-setup remove-device || echo "Failed to remove device from account"
+if [[ $FROMDAEMON == "n" ]]; then
+    echo "Resetting firewall"
+    sudo /Applications/Mullvad\ VPN.app/Contents/Resources/mullvad-setup reset-firewall || echo "Failed to reset firewall"
+    echo "Removing device from account"
+    sudo /Applications/Mullvad\ VPN.app/Contents/Resources/mullvad-setup remove-device || echo "Failed to remove device from account"
+fi
 
 echo "Removing zsh shell completion symlink ..."
 sudo rm -f /usr/local/share/zsh/site-functions/_mullvad

--- a/mullvad-daemon/src/macos.rs
+++ b/mullvad-daemon/src/macos.rs
@@ -154,6 +154,12 @@ pub async fn handle_app_bundle_removal(
         .arg(UNINSTALL_SCRIPT_PATH)
         // Don't prompt for confirmation.
         .arg("--yes")
+        // Skip device/firewall cleanup.
+        //
+        // It is important that we do not invoke mullvad-setup or anything else in
+        // /Applications/Mullvad VPN.app, as admin users can use that for privilege escalation to
+        // root.
+        .arg("--from-daemon")
         // Spawn as its own process group.
         // This prevents the command from being killed when the daemon is killed.
         .process_group(0)


### PR DESCRIPTION
I believe this requires replacing `mullvad-setup` as the app is removed. macOS does not seem to allow admins to move or remove root-owned directories in `/Applications` (at least not anymore).

Fix DES-3142.
Fix DES-2955.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10781)
<!-- Reviewable:end -->
