### PR TITLE
Replace `winres` with `winresource` to get deterministic resource ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2561,7 +2561,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "windows-sys 0.61.2",
- "winres",
+ "winresource",
 ]
 
 [[package]]
@@ -3234,7 +3234,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "windows-sys 0.61.2",
- "winres",
+ "winresource",
 ]
 
 [[package]]
@@ -3294,7 +3294,7 @@ dependencies = [
  "winapi",
  "windows-service",
  "windows-sys 0.61.2",
- "winres",
+ "winresource",
 ]
 
 [[package]]
@@ -3518,7 +3518,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "windows-sys 0.61.2",
- "winres",
+ "winresource",
 ]
 
 [[package]]
@@ -5427,6 +5427,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6414,23 +6423,29 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -6459,7 +6474,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
@@ -6491,6 +6506,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tonic"
@@ -7363,7 +7384,7 @@ dependencies = [
  "talpid-platform-metadata",
  "tempfile",
  "windows-sys 0.52.0",
- "winres",
+ "winresource",
 ]
 
 [[package]]
@@ -7746,12 +7767,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "winres"
-version = "0.1.12"
+name = "winresource"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
+checksum = "0986a8b1d586b7d3e4fe3d9ea39fb451ae22869dcea4aa109d287a374d866087"
 dependencies = [
- "toml 0.5.11",
+ "toml 1.1.3+spec-1.1.0",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,6 +145,7 @@ windows = "0.62.2"
 windows-registry = "0.6.1"
 windows-result = "0.4.1"
 windows-sys = "0.61.2"
+winresource = "0.1.31"
 wmi = "0.18.1"
 # We cannot use zerocopy "0.8.32" or above due to https://github.com/google/zerocopy/issues/2880
 # TODO: Update the version when the issue is resolved

--- a/installer-downloader/Cargo.toml
+++ b/installer-downloader/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
-[package.metadata.winres]
+[package.metadata.winresource]
 LegalCopyright = "(c) 2026 Mullvad VPN AB"
 
 [build-dependencies]
@@ -18,7 +18,7 @@ windows-sys = { workspace = true, features = [
   "Win32_System_LibraryLoader",
   "Win32_System_SystemServices"
 ] }
-winres = "0.1"
+winresource.workspace = true
 
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
 anyhow = { workspace = true }

--- a/installer-downloader/build.rs
+++ b/installer-downloader/build.rs
@@ -12,7 +12,7 @@ fn main() -> anyhow::Result<()> {
 fn win_main() -> anyhow::Result<()> {
     use anyhow::Context;
 
-    let mut res = winres::WindowsResource::new();
+    let mut res = winresource::WindowsResource::new();
 
     res.set_language(make_lang_id(
         windows_sys::Win32::System::SystemServices::LANG_ENGLISH as u16,

--- a/installer-downloader/src/winapi_impl/ui.rs
+++ b/installer-downloader/src/winapi_impl/ui.rs
@@ -147,7 +147,7 @@ impl AppWindow {
         nwg::EmbedResource::builder().build(&mut self.window_icon_res)?;
 
         // Load icon embedded using the build script. This has a default id of 1.
-        // See `winres::WindowsResource::set_icon`.
+        // See `winresource::WindowsResource::set_icon`.
         self.window_icon = self.window_icon_res.icon(1, None);
 
         nwg::Window::builder()

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -6,7 +6,7 @@ description = "Manage the Mullvad VPN daemon via a convenient CLI"
 repository.workspace = true
 license.workspace = true
 
-[package.metadata.winres]
+[package.metadata.winresource]
 ProductName = "Mullvad VPN"
 CompanyName = "Mullvad VPN AB"
 LegalCopyright = "(c) 2026 Mullvad VPN AB"
@@ -39,7 +39,7 @@ nix = { workspace = true, features = ["signal"] }
 
 [target.'cfg(windows)'.build-dependencies]
 mullvad-version = { path = "../mullvad-version" }
-winres = "0.1"
+winresource.workspace = true
 
 [target.'cfg(windows)'.build-dependencies.windows-sys]
 workspace = true

--- a/mullvad-cli/build.rs
+++ b/mullvad-cli/build.rs
@@ -6,7 +6,7 @@ fn make_lang_id(p: u16, s: u16) -> u16 {
 fn main() {
     #[cfg(windows)]
     {
-        let mut res = winres::WindowsResource::new();
+        let mut res = winresource::WindowsResource::new();
         res.set("ProductVersion", mullvad_version::VERSION);
         res.set_icon("../dist-assets/icon.ico");
         res.set_language(make_lang_id(

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -6,7 +6,7 @@ description = "Mullvad VPN daemon. Runs and controls the VPN tunnels"
 repository.workspace = true
 license.workspace = true
 
-[package.metadata.winres]
+[package.metadata.winresource]
 ProductName = "Mullvad VPN"
 CompanyName = "Mullvad VPN AB"
 LegalCopyright = "(c) 2026 Mullvad VPN AB"
@@ -170,7 +170,7 @@ features = [
 
 [target."cfg(windows)".build-dependencies]
 mullvad-version = { path = "../mullvad-version" }
-winres = "0.1"
+winresource.workspace = true
 
 [target."cfg(windows)".build-dependencies.windows-sys]
 workspace = true

--- a/mullvad-daemon/build.rs
+++ b/mullvad-daemon/build.rs
@@ -11,7 +11,7 @@ fn main() {
 
     #[cfg(windows)]
     {
-        let mut res = winres::WindowsResource::new();
+        let mut res = winresource::WindowsResource::new();
         res.set("ProductVersion", mullvad_version::VERSION);
         res.set_icon("../dist-assets/icon.ico");
         res.set_language(make_lang_id(

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -6,7 +6,7 @@ description = "Collect Mullvad VPN logs into a report and send it to support"
 repository.workspace = true
 license.workspace = true
 
-[package.metadata.winres]
+[package.metadata.winresource]
 ProductName = "Mullvad VPN"
 CompanyName = "Mullvad VPN AB"
 LegalCopyright = "(c) 2026 Mullvad VPN AB"
@@ -32,7 +32,7 @@ tracing-subscriber = { workspace = true }
 
 [target.'cfg(windows)'.build-dependencies]
 mullvad-version = { path = "../mullvad-version" }
-winres = "0.1"
+winresource.workspace = true
 
 [target.'cfg(windows)'.build-dependencies.windows-sys]
 workspace = true

--- a/mullvad-problem-report/build.rs
+++ b/mullvad-problem-report/build.rs
@@ -6,7 +6,7 @@ fn make_lang_id(p: u16, s: u16) -> u16 {
 fn main() {
     #[cfg(windows)]
     {
-        let mut res = winres::WindowsResource::new();
+        let mut res = winresource::WindowsResource::new();
         res.set("ProductVersion", mullvad_version::VERSION);
         res.set_icon("../dist-assets/icon.ico");
         res.set_language(make_lang_id(

--- a/windows-installer/Cargo.toml
+++ b/windows-installer/Cargo.toml
@@ -6,7 +6,7 @@ description = "Pack the Mullvad VPN installer for several platforms into a one e
 repository.workspace = true
 license.workspace = true
 
-[package.metadata.winres]
+[package.metadata.winresource]
 ProductName = "Mullvad VPN"
 CompanyName = "Mullvad VPN AB"
 LegalCopyright = "(c) 2026 Mullvad VPN AB"
@@ -21,7 +21,7 @@ windows-sys = { version = "0.52.0", features = [
   "Win32_System_LibraryLoader",
   "Win32_System_SystemServices"
 ] }
-winres = "0.1"
+winresource.workspace = true
 
 [target.'cfg(all(target_os = "windows", target_arch = "x86_64"))'.dependencies]
 anyhow.workspace = true

--- a/windows-installer/build.rs
+++ b/windows-installer/build.rs
@@ -26,7 +26,7 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     };
 
-    let mut res = winres::WindowsResource::new();
+    let mut res = winresource::WindowsResource::new();
     res.append_rc_content(&format!(
         r#"
 #define IDB_X64EXE {IDB_X64EXE}


### PR DESCRIPTION
winres is an abandoned crate. It also stores the version info string properties in a HashMap and writes the StringFileInfo block by iterating it directly. This results in every unique build having these resources embedded in the resulting binary in a random order. winresource is the maintained fork of winres. [It stores the properties in a BTreeMap](https://github.com/BenjaminRi/winresource/pull/39), so the block is emitted in sorted key order.

This is further progress towards reproducible builds, on Windows.

If we wanted to get rid of the new `toml` dependency, we can disable default features on `winresource` and instead set the fields we want in code. Either we put all the fields in the five different `build.rs` files, or we focus on reducing duplication by moving it to a shared place and calling into that from all the various `build.rs` files. But I did not want to spend that time before discussing it with anyone.

I have actually succeeded in producing bit-identical Rust binaries on Windows with this fix plus another fix that I'll post in a separate PR later.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10783)
<!-- Reviewable:end -->
