### PR TITLE
Reproducible builds: No timestamps or absolute PDB paths in Windows PE binaries

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,21 +1,26 @@
-# The /Brepro link arg below replaces the PE TimeDateStamp (normally the link time)
-# with a hash of the linker inputs. Required for reproducible builds.
+# The /Brepro and /PDBALTPATH link args below make the linked PE files reproducible:
+# /Brepro replaces the PE TimeDateStamp (normally the link time) with a hash of the
+# inputs, and /PDBALTPATH:%_PDB% embeds only the PDB file name, not its absolute path,
+# in the PE debug directory. Both are required for reproducible builds.
 [target.x86_64-pc-windows-msvc]
 rustflags = [
   "-Ctarget-feature=+crt-static",
   "-Clink-arg=/Brepro",
+  "-Clink-arg=/PDBALTPATH:%_PDB%",
 ]
 
 [target.i686-pc-windows-msvc]
 rustflags = [
   "-Ctarget-feature=+crt-static",
   "-Clink-arg=/Brepro",
+  "-Clink-arg=/PDBALTPATH:%_PDB%",
 ]
 
 [target.aarch64-pc-windows-msvc]
 rustflags = [
   "-Ctarget-feature=+crt-static",
   "-Clink-arg=/Brepro",
+  "-Clink-arg=/PDBALTPATH:%_PDB%",
 ]
 
 [target.x86_64-unknown-linux-gnu.mnl]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,11 +1,22 @@
+# The /Brepro link arg below replaces the PE TimeDateStamp (normally the link time)
+# with a hash of the linker inputs. Required for reproducible builds.
 [target.x86_64-pc-windows-msvc]
-rustflags = ["-Ctarget-feature=+crt-static"]
+rustflags = [
+  "-Ctarget-feature=+crt-static",
+  "-Clink-arg=/Brepro",
+]
 
 [target.i686-pc-windows-msvc]
-rustflags = ["-Ctarget-feature=+crt-static"]
+rustflags = [
+  "-Ctarget-feature=+crt-static",
+  "-Clink-arg=/Brepro",
+]
 
 [target.aarch64-pc-windows-msvc]
-rustflags = ["-Ctarget-feature=+crt-static"]
+rustflags = [
+  "-Ctarget-feature=+crt-static",
+  "-Clink-arg=/Brepro",
+]
 
 [target.x86_64-unknown-linux-gnu.mnl]
 rustc-link-lib = ["mnl"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Line wrap the file at 100 chars.                                              Th
 - Update `wireguard-nt` to version 1.1. This retires the Mullvad fork at
   <https://github.com/mullvad/wireguard-nt>.
 - Switch winreg out for windows_registry.
+- Make the timestamps embedded in the Rust Windows binaries + winfw.dll deterministic.
+  Required for reproducible builds.
 
 #### macOS
 - Use arch-specific installers to deliver updates. This makes updates around 50% smaller.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ Line wrap the file at 100 chars.                                              Th
 - Switch winreg out for windows_registry.
 - Make the timestamps embedded in the Rust Windows binaries + winfw.dll deterministic.
   Required for reproducible builds.
+- Stop embedding absolute build machine PDB paths in the Rust Windows binaries + winfw.dll.
+  Required for reproducible builds.
 
 #### macOS
 - Use arch-specific installers to deliver updates. This makes updates around 50% smaller.

--- a/windows/winfw/src/winfw/winfw.vcxproj
+++ b/windows/winfw/src/winfw/winfw.vcxproj
@@ -219,9 +219,10 @@
       <AdditionalDependencies>libwfp.lib;libcommon.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)/bin/$(Platform)-$(Configuration)</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>winfw.def</ModuleDefinitionFile>
-      <!-- /Brepro gives a hash-based PE TimeDateStamp instead of the link time.
-           Required for reproducible builds. -->
-      <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
+      <!-- /Brepro gives a hash-based PE TimeDateStamp instead of the link time;
+           /PDBALTPATH:%_PDB% embeds only the PDB file name, not its absolute path.
+           Required for reproducible builds. A literal % is written as %25 in MSBuild. -->
+      <AdditionalOptions>/Brepro /PDBALTPATH:%25_PDB%25 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PreBuildEvent>
       <Command>cargo run -q --bin mullvad-version version.h &gt; $(ProjectDir)..\..\..\version.h
@@ -246,9 +247,10 @@ cargo run -q -p talpid-types --bin generate-cpp-lannetworks &gt; $(ProjectDir)la
       <AdditionalDependencies>libwfp.lib;libcommon.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)/bin/$(Platform)-$(Configuration)</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>winfw.def</ModuleDefinitionFile>
-      <!-- /Brepro gives a hash-based PE TimeDateStamp instead of the link time.
-           Required for reproducible builds. -->
-      <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
+      <!-- /Brepro gives a hash-based PE TimeDateStamp instead of the link time;
+           /PDBALTPATH:%_PDB% embeds only the PDB file name, not its absolute path.
+           Required for reproducible builds. A literal % is written as %25 in MSBuild. -->
+      <AdditionalOptions>/Brepro /PDBALTPATH:%25_PDB%25 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PreBuildEvent>
       <Command>cargo run -q --bin mullvad-version version.h &gt; $(ProjectDir)..\..\..\version.h
@@ -273,9 +275,10 @@ cargo run -q -p talpid-types --bin generate-cpp-lannetworks &gt; $(ProjectDir)la
       <AdditionalDependencies>libwfp.lib;libcommon.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)/bin/$(Platform)-$(Configuration)</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>winfw.def</ModuleDefinitionFile>
-      <!-- /Brepro gives a hash-based PE TimeDateStamp instead of the link time.
-           Required for reproducible builds. -->
-      <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
+      <!-- /Brepro gives a hash-based PE TimeDateStamp instead of the link time;
+           /PDBALTPATH:%_PDB% embeds only the PDB file name, not its absolute path.
+           Required for reproducible builds. A literal % is written as %25 in MSBuild. -->
+      <AdditionalOptions>/Brepro /PDBALTPATH:%25_PDB%25 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PreBuildEvent>
       <Command>cargo run -q --bin mullvad-version version.h &gt; $(ProjectDir)..\..\..\version.h
@@ -305,9 +308,10 @@ cargo run -q -p talpid-types --bin generate-cpp-lannetworks &gt; $(ProjectDir)la
       <AdditionalDependencies>libwfp.lib;libcommon.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)/bin/$(Platform)-$(Configuration)</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>winfw.def</ModuleDefinitionFile>
-      <!-- /Brepro gives a hash-based PE TimeDateStamp instead of the link time.
-           Required for reproducible builds. -->
-      <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
+      <!-- /Brepro gives a hash-based PE TimeDateStamp instead of the link time;
+           /PDBALTPATH:%_PDB% embeds only the PDB file name, not its absolute path.
+           Required for reproducible builds. A literal % is written as %25 in MSBuild. -->
+      <AdditionalOptions>/Brepro /PDBALTPATH:%25_PDB%25 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PreBuildEvent>
       <Command>cargo run -q --bin mullvad-version version.h &gt; $(ProjectDir)..\..\..\version.h
@@ -337,9 +341,10 @@ cargo run -q -p talpid-types --bin generate-cpp-lannetworks &gt; $(ProjectDir)la
       <AdditionalDependencies>libwfp.lib;libcommon.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)/bin/$(Platform)-$(Configuration)</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>winfw.def</ModuleDefinitionFile>
-      <!-- /Brepro gives a hash-based PE TimeDateStamp instead of the link time.
-           Required for reproducible builds. -->
-      <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
+      <!-- /Brepro gives a hash-based PE TimeDateStamp instead of the link time;
+           /PDBALTPATH:%_PDB% embeds only the PDB file name, not its absolute path.
+           Required for reproducible builds. A literal % is written as %25 in MSBuild. -->
+      <AdditionalOptions>/Brepro /PDBALTPATH:%25_PDB%25 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PreBuildEvent>
       <Command>cargo run -q --bin mullvad-version version.h &gt; $(ProjectDir)..\..\..\version.h
@@ -369,9 +374,10 @@ cargo run -q -p talpid-types --bin generate-cpp-lannetworks &gt; $(ProjectDir)la
       <AdditionalDependencies>libwfp.lib;libcommon.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)/bin/$(Platform)-$(Configuration)</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>winfw.def</ModuleDefinitionFile>
-      <!-- /Brepro gives a hash-based PE TimeDateStamp instead of the link time.
-           Required for reproducible builds. -->
-      <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
+      <!-- /Brepro gives a hash-based PE TimeDateStamp instead of the link time;
+           /PDBALTPATH:%_PDB% embeds only the PDB file name, not its absolute path.
+           Required for reproducible builds. A literal % is written as %25 in MSBuild. -->
+      <AdditionalOptions>/Brepro /PDBALTPATH:%25_PDB%25 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PreBuildEvent>
       <Command>cargo run -q --bin mullvad-version version.h &gt; $(ProjectDir)..\..\..\version.h

--- a/windows/winfw/src/winfw/winfw.vcxproj
+++ b/windows/winfw/src/winfw/winfw.vcxproj
@@ -219,6 +219,9 @@
       <AdditionalDependencies>libwfp.lib;libcommon.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)/bin/$(Platform)-$(Configuration)</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>winfw.def</ModuleDefinitionFile>
+      <!-- /Brepro gives a hash-based PE TimeDateStamp instead of the link time.
+           Required for reproducible builds. -->
+      <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PreBuildEvent>
       <Command>cargo run -q --bin mullvad-version version.h &gt; $(ProjectDir)..\..\..\version.h
@@ -243,6 +246,9 @@ cargo run -q -p talpid-types --bin generate-cpp-lannetworks &gt; $(ProjectDir)la
       <AdditionalDependencies>libwfp.lib;libcommon.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)/bin/$(Platform)-$(Configuration)</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>winfw.def</ModuleDefinitionFile>
+      <!-- /Brepro gives a hash-based PE TimeDateStamp instead of the link time.
+           Required for reproducible builds. -->
+      <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PreBuildEvent>
       <Command>cargo run -q --bin mullvad-version version.h &gt; $(ProjectDir)..\..\..\version.h
@@ -267,6 +273,9 @@ cargo run -q -p talpid-types --bin generate-cpp-lannetworks &gt; $(ProjectDir)la
       <AdditionalDependencies>libwfp.lib;libcommon.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)/bin/$(Platform)-$(Configuration)</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>winfw.def</ModuleDefinitionFile>
+      <!-- /Brepro gives a hash-based PE TimeDateStamp instead of the link time.
+           Required for reproducible builds. -->
+      <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PreBuildEvent>
       <Command>cargo run -q --bin mullvad-version version.h &gt; $(ProjectDir)..\..\..\version.h
@@ -296,6 +305,9 @@ cargo run -q -p talpid-types --bin generate-cpp-lannetworks &gt; $(ProjectDir)la
       <AdditionalDependencies>libwfp.lib;libcommon.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)/bin/$(Platform)-$(Configuration)</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>winfw.def</ModuleDefinitionFile>
+      <!-- /Brepro gives a hash-based PE TimeDateStamp instead of the link time.
+           Required for reproducible builds. -->
+      <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PreBuildEvent>
       <Command>cargo run -q --bin mullvad-version version.h &gt; $(ProjectDir)..\..\..\version.h
@@ -325,6 +337,9 @@ cargo run -q -p talpid-types --bin generate-cpp-lannetworks &gt; $(ProjectDir)la
       <AdditionalDependencies>libwfp.lib;libcommon.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)/bin/$(Platform)-$(Configuration)</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>winfw.def</ModuleDefinitionFile>
+      <!-- /Brepro gives a hash-based PE TimeDateStamp instead of the link time.
+           Required for reproducible builds. -->
+      <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PreBuildEvent>
       <Command>cargo run -q --bin mullvad-version version.h &gt; $(ProjectDir)..\..\..\version.h
@@ -354,6 +369,9 @@ cargo run -q -p talpid-types --bin generate-cpp-lannetworks &gt; $(ProjectDir)la
       <AdditionalDependencies>libwfp.lib;libcommon.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)/bin/$(Platform)-$(Configuration)</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>winfw.def</ModuleDefinitionFile>
+      <!-- /Brepro gives a hash-based PE TimeDateStamp instead of the link time.
+           Required for reproducible builds. -->
+      <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PreBuildEvent>
       <Command>cargo run -q --bin mullvad-version version.h &gt; $(ProjectDir)..\..\..\version.h


### PR DESCRIPTION
This PR is a bit similar to #10765, but for Windows. We add linker flags that remove things from the binaries that easily vary per build (time and absolute paths).

Add the MSVC linker flag `/Brepro` to Rust and C++ linkers. It writes a hash of the linker inputs into the PE TimeDateStamp fields instead of the wall-clock link time, and emits an IMAGE_DEBUG_TYPE_REPRO debug directory entry.

Add the MSVC linker flag `/PDBALTPATH:%_PDB%` to linking of Rust and C++ programs. It embeds only the PDB file name in the PE debug directory instead of its absolute path on the build machine.

Together with #10783 this makes the Windows Rust and C++ binaries reproducible for me. When both these PRs are applied and I do `./build.sh [--optimize]` I end up with bit identical binaries in `target/` and `windows/winfw/bin/`. The binaries will of course diverge once signatures are attached etc. But that's a separate problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10787)
<!-- Reviewable:end -->
