### PR TITLE
Filter quic and shadowsocks entry relays by IP version

### DIFF
--- a/ios/MullvadMockData/MullvadREST/ServerRelaysResponse+Stubs.swift
+++ b/ios/MullvadMockData/MullvadREST/ServerRelaysResponse+Stubs.swift
@@ -218,6 +218,25 @@ public enum ServerRelaysResponseStubs {
                     )
                 ),
                 REST.ServerRelay(
+                    hostname: "se3-wireguard",
+                    active: true,
+                    owned: true,
+                    location: "se-got",
+                    provider: "100TB",
+                    weight: 10,
+                    ipv4AddrIn: .loopback,
+                    ipv6AddrIn: .loopback,
+                    publicKey: WireGuard.PrivateKey().publicKey.rawValue,
+                    includeInCountry: true,
+                    daita: false,
+                    shadowsocksExtraAddrIn: ["::1"],
+                    features: .init(
+                        daita: nil,
+                        quic: .init(addrIn: ["::1"], domain: "quic.domain", token: ""),
+                        lwo: nil
+                    )
+                ),
+                REST.ServerRelay(
                     hostname: "se2-wireguard",
                     active: true,
                     owned: true,

--- a/ios/MullvadREST/ApiHandlers/ServerRelaysResponse.swift
+++ b/ios/MullvadREST/ApiHandlers/ServerRelaysResponse.swift
@@ -105,9 +105,19 @@ extension REST {
             shadowsocksExtraAddrIn?.contains(where: { IPv6Address($0) != nil }) ?? false
         }
 
+        /// Returns true if the relay has IPv4 addresses in shadowsocksExtraAddrIn
+        public var hasShadowsocksIpv4: Bool {
+            shadowsocksExtraAddrIn?.contains(where: { IPv4Address($0) != nil }) ?? false
+        }
+
         /// Returns true if the relay has IPv6 addresses in QUIC addrIn
         public var hasQuicIpv6: Bool {
             features?.quic?.addrIn.contains(where: { IPv6Address($0) != nil }) ?? false
+        }
+
+        /// Returns true if the relay has IPv4 addresses in QUIC addrIn
+        public var hasQuicIpv4: Bool {
+            features?.quic?.addrIn.contains(where: { IPv4Address($0) != nil }) ?? false
         }
 
         public func override(ipv4AddrIn: IPv4Address?, ipv6AddrIn: IPv6Address?) -> Self {

--- a/ios/MullvadREST/Relay/Obfuscation/QuicObfuscator.swift
+++ b/ios/MullvadREST/Relay/Obfuscation/QuicObfuscator.swift
@@ -28,6 +28,8 @@ struct QuicObfuscator: RelayObfuscating {
         // Regular entry IPv6 addresses don't work with QUIC
         if tunnelSettings.ipVersion.isIPv6 {
             filteredRelays = filteredRelays.filter { $0.hasQuicIpv6 }
+        } else {
+            filteredRelays = filteredRelays.filter { $0.hasQuicIpv4 }
         }
 
         return REST.ServerRelaysResponse(

--- a/ios/MullvadREST/Relay/Obfuscation/ShadowsocksObfuscator.swift
+++ b/ios/MullvadREST/Relay/Obfuscation/ShadowsocksObfuscator.swift
@@ -48,7 +48,7 @@ struct ShadowsocksObfuscator: RelayObfuscating {
         if tunnelSettings.ipVersion.isIPv6 {
             filteredRelays = relays.wireguard.relays.filter { $0.hasShadowsocksIpv6 }
         } else {
-            filteredRelays = relays.wireguard.relays.filter { $0.shadowsocksExtraAddrIn != nil }
+            filteredRelays = relays.wireguard.relays.filter { $0.hasShadowsocksIpv4 }
         }
 
         return REST.ServerRelaysResponse(

--- a/ios/MullvadVPNTests/MullvadREST/Relay/RelayObfuscatorTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/RelayObfuscatorTests.swift
@@ -168,6 +168,7 @@ final class RelayObfuscatorTests: XCTestCase {
             state: .shadowsocks,
             shadowsocksPort: .custom(port)
         )
+        tunnelSettings.ipVersion = .ipv4
 
         let obfuscationResult = try RelayObfuscator(
             relays: sampleRelays,
@@ -177,7 +178,7 @@ final class RelayObfuscatorTests: XCTestCase {
         ).obfuscate()
 
         let relaysWithExtraAddresses = sampleRelays.wireguard.relays.filter { relay in
-            !relay.shadowsocksExtraAddrIn.isNil
+            relay.hasShadowsocksIpv4
         }
 
         XCTAssertEqual(obfuscationResult.relays.wireguard.relays.count, relaysWithExtraAddresses.count)
@@ -202,6 +203,72 @@ final class RelayObfuscatorTests: XCTestCase {
         XCTAssertEqual(obfuscationResult.relays.wireguard.relays.count, sampleRelays.wireguard.relays.count)
     }
 
+    func testObfuscateShadowsocksFiltersExitRelaysForIpv4AndAutomatic() throws {
+        let allPorts: Range<UInt16> = 1..<65000
+        let defaultPortRanges = RelaySelector.parseRawPortRanges(sampleRelays.wireguard.shadowsocksPortRanges)
+
+        let portsOutsideDefaultRange = allPorts.filter { port in
+            !defaultPortRanges.contains { range in
+                range.contains(port)
+            }
+        }
+
+        let port = try XCTUnwrap(portsOutsideDefaultRange.randomElement())
+
+        tunnelSettings.wireGuardObfuscation = WireGuardObfuscationSettings(
+            state: .shadowsocks,
+            shadowsocksPort: .custom(port)
+        )
+        tunnelSettings.relayConstraints = RelayConstraints(
+            exitLocations: .only(UserSelectedRelays(locations: [.hostname("se", "got", "se3-wireguard")])))
+        tunnelSettings.ipVersion = .automatic
+
+        let obfuscationResult = try RelayObfuscator(
+            relays: sampleRelays,
+            tunnelSettings: tunnelSettings,
+            connectionAttemptCount: 0,
+            obfuscationBypass: IdentityObfuscationProvider()
+        ).obfuscate()
+
+        XCTAssertGreaterThan(
+            obfuscationResult.relays.wireguard.relays.filter { $0.hasShadowsocksIpv4 }.count,
+            0
+        )
+    }
+
+    func testObfuscateShadowsocksFiltersExitRelaysForIpv6() throws {
+        let allPorts: Range<UInt16> = 1..<65000
+        let defaultPortRanges = RelaySelector.parseRawPortRanges(sampleRelays.wireguard.shadowsocksPortRanges)
+
+        let portsOutsideDefaultRange = allPorts.filter { port in
+            !defaultPortRanges.contains { range in
+                range.contains(port)
+            }
+        }
+
+        let port = try XCTUnwrap(portsOutsideDefaultRange.randomElement())
+
+        tunnelSettings.wireGuardObfuscation = WireGuardObfuscationSettings(
+            state: .shadowsocks,
+            shadowsocksPort: .custom(port)
+        )
+        tunnelSettings.relayConstraints = RelayConstraints(
+            exitLocations: .only(UserSelectedRelays(locations: [.hostname("se", "got", "se3-wireguard")])))
+        tunnelSettings.ipVersion = .ipv6
+
+        let obfuscationResult = try RelayObfuscator(
+            relays: sampleRelays,
+            tunnelSettings: tunnelSettings,
+            connectionAttemptCount: 0,
+            obfuscationBypass: IdentityObfuscationProvider()
+        ).obfuscate()
+
+        XCTAssertGreaterThan(
+            obfuscationResult.relays.wireguard.relays.filter { $0.hasShadowsocksIpv6 }.count,
+            0
+        )
+    }
+
     // MARK: QUIC
 
     func testObfuscateQuicOverPort443() throws {
@@ -217,6 +284,49 @@ final class RelayObfuscatorTests: XCTestCase {
         ).obfuscate()
 
         XCTAssertEqual(obfuscationResult.port, defaultQuicPort)
+    }
+
+    func testQuicObfuscationFiltersExitRelaysForIpv4AndAutomatic() throws {
+        tunnelSettings.wireGuardObfuscation = WireGuardObfuscationSettings(
+            state: .quic
+        )
+        tunnelSettings.relayConstraints = RelayConstraints(
+            exitLocations: .only(UserSelectedRelays(locations: [.hostname("se", "got", "se3-wireguard")])))
+        tunnelSettings.ipVersion = .automatic
+
+        let obfuscationResult = try RelayObfuscator(
+            relays: sampleRelays,
+            tunnelSettings: tunnelSettings,
+            connectionAttemptCount: 0,
+            obfuscationBypass: IdentityObfuscationProvider()
+        ).obfuscate()
+
+        XCTAssertEqual(obfuscationResult.port, defaultQuicPort)
+        XCTAssertEqual(
+            obfuscationResult.relays.wireguard.relays.filter { $0.hasQuicIpv6 }.count,
+            0
+        )
+    }
+
+    func testQuicObfuscationFiltersExitRelaysForIpv6() throws {
+        tunnelSettings.wireGuardObfuscation = WireGuardObfuscationSettings(
+            state: .quic
+        )
+        tunnelSettings.relayConstraints = RelayConstraints(
+            exitLocations: .only(UserSelectedRelays(locations: [.hostname("se", "got", "se3-wireguard")])))
+        tunnelSettings.ipVersion = .ipv6
+
+        let obfuscationResult = try RelayObfuscator(
+            relays: sampleRelays,
+            tunnelSettings: tunnelSettings,
+            connectionAttemptCount: 0,
+            obfuscationBypass: IdentityObfuscationProvider()
+        ).obfuscate()
+
+        XCTAssertEqual(obfuscationResult.port, defaultQuicPort)
+        XCTAssertEqual(
+            obfuscationResult.relays.wireguard.relays.filter { $0.hasQuicIpv6 }.count,
+            obfuscationResult.relays.wireguard.relays.count)
     }
 
     // MARK: LWO

--- a/ios/MullvadVPNTests/MullvadREST/Relay/RelayPickingTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/RelayPickingTests.swift
@@ -274,4 +274,125 @@ class RelayPickingTests: XCTestCase {
 
         XCTAssertNoThrow(try picker.pick())
     }
+
+    // QUIC enabled, multihop enabled when needed.
+    // The selected exit relay is incompatible with the effective IP version,
+    // so the picker should require multihop rather than use it as a single-hop exit.
+    func testUsesMultihopWhenQuicExitRelayIsIncompatibleWithIpVersion() throws {
+        let constraints = RelayConstraints(
+            exitLocations: .only(UserSelectedRelays(locations: [.hostname("se", "got", "se3-wireguard")]))
+        )
+
+        var settings = LatestTunnelSettings()
+        settings.relayConstraints = constraints
+        settings.wireGuardObfuscation = .init(state: .quic)
+        settings.ipVersion = .automatic
+        settings.tunnelMultihopState = .whenNeeded
+
+        let picker = SinglehopPicker(
+            relays: sampleRelays,
+            tunnelSettings: settings,
+            connectionAttemptCount: 0
+        )
+
+        let selectedRelays = try picker.pick()
+
+        XCTAssertNotNil(selectedRelays.entry)
+        XCTAssertEqual(selectedRelays.exit.hostname, "se3-wireguard")
+    }
+
+    // QUIC enabled, multihop enabled when needed.
+    // The selected exit relay supports QUIC for the requested IPv6 connection,
+    // so single-hop selection should succeed.
+    func testDoesNotUseMultihopWhenQuicExitRelaySupportsIpv6() throws {
+        let constraints = RelayConstraints(
+            entryLocations: .any,
+            exitLocations: .only(UserSelectedRelays(locations: [.hostname("se", "got", "se3-wireguard")]))
+        )
+
+        var settings = LatestTunnelSettings()
+        settings.relayConstraints = constraints
+        settings.wireGuardObfuscation = .init(state: .quic)
+        settings.ipVersion = .ipv6
+        settings.tunnelMultihopState = .whenNeeded
+
+        let picker = SinglehopPicker(
+            relays: sampleRelays,
+            tunnelSettings: settings,
+            connectionAttemptCount: 0
+        )
+        XCTAssertNoThrow(try picker.pick())
+    }
+
+    // Shadowsocks enabled with a custom port outside the default ranges.
+    // The selected exit relay is incompatible with the effective IP version,
+    // so the picker should select a compatible entry relay and use multihop.
+    func testUsesMultihopWhenShadowsocksExitRelayIsIncompatibleWithIpVersion() throws {
+        let allPorts: Range<UInt16> = 1..<65000
+        let defaultPortRanges = RelaySelector.parseRawPortRanges(sampleRelays.wireguard.shadowsocksPortRanges)
+
+        let portsOutsideDefaultRange = allPorts.filter { port in
+            !defaultPortRanges.contains { range in
+                range.contains(port)
+            }
+        }
+        let port = try XCTUnwrap(portsOutsideDefaultRange.randomElement())
+
+        let constraints = RelayConstraints(
+            entryLocations: .any,
+            exitLocations: .only(UserSelectedRelays(locations: [.hostname("se", "got", "se3-wireguard")]))
+        )
+
+        var settings = LatestTunnelSettings()
+        settings.relayConstraints = constraints
+        settings.wireGuardObfuscation = .init(state: .shadowsocks, shadowsocksPort: .custom(port))
+        settings.ipVersion = .automatic
+        settings.tunnelMultihopState = .whenNeeded
+
+        let picker = MultihopPicker(
+            relays: sampleRelays,
+            tunnelSettings: settings,
+            connectionAttemptCount: 0
+        )
+
+        let selectedRelays = try picker.pick()
+
+        XCTAssertEqual(selectedRelays.entry?.location.countryCode, "se")
+        XCTAssertEqual(selectedRelays.exit.hostname, "se3-wireguard")
+    }
+
+    // Shadowsocks enabled with a custom port outside the default ranges.
+    // The selected exit relay supports the requested IPv6 connection,
+    // so multihop is not required and single-hop selection should succeed.
+    func testDoesNotUseMultihopWhenShadowsocksExitRelaySupportsIpv6() throws {
+        let allPorts: Range<UInt16> = 1..<65000
+        let defaultPortRanges = RelaySelector.parseRawPortRanges(sampleRelays.wireguard.shadowsocksPortRanges)
+
+        let portsOutsideDefaultRange = allPorts.filter { port in
+            !defaultPortRanges.contains { range in
+                range.contains(port)
+            }
+        }
+        let port = try XCTUnwrap(portsOutsideDefaultRange.randomElement())
+
+        let constraints = RelayConstraints(
+            exitLocations: .only(UserSelectedRelays(locations: [.hostname("se", "got", "se3-wireguard")])),
+        )
+
+        var settings = LatestTunnelSettings()
+        settings.relayConstraints = constraints
+        settings.wireGuardObfuscation = .init(state: .shadowsocks, shadowsocksPort: .custom(port))
+        settings.ipVersion = .ipv6
+        settings.tunnelMultihopState = .whenNeeded
+
+        let picker = SinglehopPicker(
+            relays: sampleRelays,
+            tunnelSettings: settings,
+            connectionAttemptCount: 0
+        )
+
+        let selectedRelays = try picker.pick()
+        XCTAssertNil(selectedRelays.entry)
+        XCTAssertEqual(selectedRelays.exit.hostname, "se3-wireguard")
+    }
 }

--- a/ios/MullvadVPNTests/MullvadREST/Relay/RelaySelectorTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/RelaySelectorTests.swift
@@ -35,7 +35,8 @@ class RelaySelectorTests: XCTestCase {
         )
 
         let result = try pickRelay(by: constraints, in: sampleRelays, failedAttemptCount: 0)
-        XCTAssertEqual(result.relay.hostname, "se10-wireguard")
+        XCTAssertEqual(result.location.cityCode, "got")
+        XCTAssertEqual(result.location.countryCode, "se")
     }
 
     func testHostnameConstraint() throws {


### PR DESCRIPTION
Relay selection did not consider the configured IP version when selecting QUIC and Shadowsocks relays, which could result in incompatible relays being selected. This PR makes a fix for it by  filtering QUIC and Shadowsocks relays based on the configured IP version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10788)
<!-- Reviewable:end -->
