### PR TITLE
Add generic socket bypass/split tunnel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6791,7 +6791,6 @@ dependencies = [
  "futures",
  "log",
  "mullvad-masque-proxy",
- "nix 0.31.3",
  "rand 0.9.4",
  "shadowsocks",
  "talpid-net",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6794,6 +6794,7 @@ dependencies = [
  "nix 0.31.3",
  "rand 0.9.4",
  "shadowsocks",
+ "talpid-net",
  "talpid-types",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6850,7 +6850,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 [[package]]
 name = "udp-over-tcp"
 version = "0.4.0"
-source = "git+https://github.com/mullvad/udp-over-tcp?rev=5c6d8f44a5aa12ed9bb4ae51dd17e5e22e5ec303#5c6d8f44a5aa12ed9bb4ae51dd17e5e22e5ec303"
+source = "git+https://github.com/mullvad/udp-over-tcp?rev=00c8482f303aa23a69cfe9ee10903582cba3eb1e#00c8482f303aa23a69cfe9ee10903582cba3eb1e"
 dependencies = [
  "err-context",
  "futures",

--- a/mullvad-ios/deny.toml
+++ b/mullvad-ios/deny.toml
@@ -35,6 +35,7 @@ exceptions = [
   { crate = "mullvad-update", allow = ["GPL-3.0-or-later"] },
   { crate = "mullvad-version", allow = ["GPL-3.0-or-later"] },
   { crate = "talpid-future", allow = ["GPL-3.0-or-later"] },
+  { crate = "talpid-net", allow = ["GPL-3.0-or-later"] },
   { crate = "talpid-routing", allow = ["GPL-3.0-or-later"] },
   { crate = "talpid-time", allow = ["GPL-3.0-or-later"] },
   { crate = "talpid-tunnel", allow = ["GPL-3.0-or-later"] },

--- a/talpid-net/Cargo.toml
+++ b/talpid-net/Cargo.toml
@@ -6,11 +6,13 @@ description = "Networking helpers"
 repository.workspace = true
 license.workspace = true
 
+[dependencies]
+log = { workspace = true }
+socket2 = { workspace = true, features = ["all"] }
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-log = { workspace = true }
 nix = { workspace = true, features = ["net"] }
-socket2 = { workspace = true, features = ["all"] }
 talpid-types = { path = "../talpid-types" }
 thiserror = { workspace = true }
 

--- a/talpid-net/src/bypass.rs
+++ b/talpid-net/src/bypass.rs
@@ -1,4 +1,10 @@
-use std::{io, sync::Arc};
+use std::{io, ops::Deref, sync::Arc};
+
+#[cfg(unix)]
+use std::os::fd::AsFd as AsSocket;
+
+#[cfg(windows)]
+use std::os::windows::io::AsSocket;
 
 use socket2::SockRef;
 
@@ -34,6 +40,28 @@ impl SocketBypass for NoopBypass {
     }
 }
 
+/// A wrapper for any type of socket and a related [BypassGuard].
+pub struct BypassSocket<S> {
+    pub socket: S,
+    pub guard: BypassGuard,
+}
+
+impl<S: AsSocket> BypassSocket<S> {
+    /// Begin excluding a socket `s` from tunnel traffic.
+    pub fn new(bypass: Arc<dyn SocketBypass>, socket: S) -> io::Result<Self> {
+        let guard = BypassGuard::new(bypass, &socket)?;
+        Ok(Self { socket, guard })
+    }
+}
+
+impl<T> Deref for BypassSocket<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.socket
+    }
+}
+
 /// A guard that, when dropped, allows an excluded socket to no longer be excluded.
 ///
 /// There is no guarantee that dropping this will stop excluding the socket. The contract is
@@ -46,13 +74,11 @@ pub struct BypassGuard {
 
 impl BypassGuard {
     /// Begin excluding a socket `s` from tunnel traffic.
-    pub fn new<'a, S: Into<SockRef<'a>>>(
-        bypass: Arc<dyn SocketBypass>,
-        s: S,
-    ) -> io::Result<BypassGuard> {
-        let socket = s.into().try_clone()?;
+    fn new(bypass: Arc<dyn SocketBypass>, s: impl AsSocket) -> io::Result<BypassGuard> {
+        let ref_ = SockRef::from(&s);
+        let socket = ref_.try_clone()?;
 
-        bypass.bypass_socket(SockRef::from(&socket), &BypassToken(()))?;
+        bypass.bypass_socket(ref_, &BypassToken(()))?;
 
         Ok(BypassGuard { bypass, socket })
     }

--- a/talpid-net/src/bypass.rs
+++ b/talpid-net/src/bypass.rs
@@ -1,0 +1,70 @@
+use std::{io, sync::Arc};
+
+use socket2::SockRef;
+
+/// Guard against using [SocketBypass] without [BypassGuard].
+///
+/// It cannot be constructed outside of this module.
+pub struct BypassToken(());
+
+/// A trait for implementing socket bypass. This lets individual sockets be excluded (leak) from
+/// VPN tunnel traffic.
+pub trait SocketBypass: Send + Sync {
+    /// Begin socket bypass. When called, the socket must be excluded from tunnel traffic until
+    /// [Self::revoke_bypass] has been called and the socket has been destroyed.
+    fn bypass_socket(&self, socket: SockRef<'_>, token: &BypassToken) -> io::Result<()>;
+
+    /// Allow the bypass to cease.
+    ///
+    /// When this has succeeded, there is no longer any guarantee that the socket will be
+    /// excluded. The bypass must not outlast the lifetime of the socket lifetime, but it may cease
+    /// immediately when this is called (depending on the implementation).
+    fn revoke_bypass(&self, socket: SockRef<'_>, token: &BypassToken) -> io::Result<()>;
+}
+
+pub struct NoopBypass;
+
+impl SocketBypass for NoopBypass {
+    fn bypass_socket(&self, _: SockRef<'_>, _: &BypassToken) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn revoke_bypass(&self, _: SockRef<'_>, _: &BypassToken) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// A guard that, when dropped, allows an excluded socket to no longer be excluded.
+///
+/// There is no guarantee that dropping this will stop excluding the socket. The contract is
+/// that when this guard is dropped, there is no longer any guarantee that the socket will be
+/// excluded. Whether it is immediately un-excluded is implementation-dependent.
+pub struct BypassGuard {
+    bypass: Arc<dyn SocketBypass>,
+    socket: socket2::Socket,
+}
+
+impl BypassGuard {
+    /// Begin excluding a socket `s` from tunnel traffic.
+    pub fn new<'a, S: Into<SockRef<'a>>>(
+        bypass: Arc<dyn SocketBypass>,
+        s: S,
+    ) -> io::Result<BypassGuard> {
+        let socket = s.into().try_clone()?;
+
+        bypass.bypass_socket(SockRef::from(&socket), &BypassToken(()))?;
+
+        Ok(BypassGuard { bypass, socket })
+    }
+}
+
+impl Drop for BypassGuard {
+    fn drop(&mut self) {
+        if let Err(err) = self
+            .bypass
+            .revoke_bypass(SockRef::from(&self.socket), &BypassToken(()))
+        {
+            log::error!("Failed to revoke socket bypass: {err}");
+        }
+    }
+}

--- a/talpid-net/src/lib.rs
+++ b/talpid-net/src/lib.rs
@@ -1,2 +1,4 @@
+pub mod bypass;
+
 #[cfg(unix)]
 pub mod unix;

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -19,6 +19,7 @@ parking_lot = "0.12.0"
 rand = { workspace = true }
 socket2 = { workspace = true, features = ["all"] }
 surge-ping = { workspace = true }
+talpid-net = { path = "../talpid-net" }
 talpid-routing = { path = "../talpid-routing" }
 talpid-tunnel = { path = "../talpid-tunnel" }
 talpid-tunnel-config-client = { path = "../talpid-tunnel-config-client" }
@@ -33,9 +34,6 @@ tunnel-obfuscation = { path = "../tunnel-obfuscation" }
 insta = { workspace = true }
 proptest = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
-
-[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
-talpid-net = { path = "../talpid-net" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 netlink-packet-core = { workspace = true }

--- a/talpid-wireguard/src/config.rs
+++ b/talpid-wireguard/src/config.rs
@@ -21,6 +21,7 @@ pub struct Config {
     /// Maximum transmission unit for the tunnel
     pub mtu: u16,
     /// Firewall mark
+    // TODO: Should this be optional? Should it even be configurable?
     #[cfg(target_os = "linux")]
     pub fwmark: Option<u32>,
     /// Enable IPv6 routing rules

--- a/talpid-wireguard/src/obfuscation.rs
+++ b/talpid-wireguard/src/obfuscation.rs
@@ -47,13 +47,7 @@ pub async fn apply_obfuscation_config(
         return Ok(None);
     }
 
-    let settings = settings_from_config(
-        config,
-        obfuscator_config,
-        obfuscation_mtu,
-        #[cfg(target_os = "linux")]
-        config.fwmark,
-    );
+    let settings = settings_from_config(config, obfuscator_config, obfuscation_mtu);
 
     log::trace!("Obfuscation settings: {settings:?}");
 
@@ -116,16 +110,11 @@ fn settings_from_config(
     config: &Config,
     obfuscation_config: &Obfuscators,
     mtu: u16,
-    #[cfg(target_os = "linux")] fwmark: Option<u32>,
 ) -> ObfuscationSettings {
     match obfuscation_config {
-        Obfuscators::Single(obfuscation_config) => settings_from_single_config(
-            config,
-            obfuscation_config,
-            mtu,
-            #[cfg(target_os = "linux")]
-            fwmark,
-        ),
+        Obfuscators::Single(obfuscation_config) => {
+            settings_from_single_config(config, obfuscation_config, mtu)
+        }
         Obfuscators::Multiplexer {
             direct,
             configs: (first_obfs, remaining_obfs),
@@ -135,20 +124,10 @@ fn settings_from_config(
                 transports.push(multiplexer::Transport::Direct(*direct));
             }
             for obfs_config in iter::once(first_obfs).chain(remaining_obfs) {
-                let settings = settings_from_single_config(
-                    config,
-                    obfs_config,
-                    mtu,
-                    #[cfg(target_os = "linux")]
-                    fwmark,
-                );
+                let settings = settings_from_single_config(config, obfs_config, mtu);
                 transports.push(multiplexer::Transport::Obfuscated(settings));
             }
-            ObfuscationSettings::Multiplexer(multiplexer::Settings {
-                transports,
-                #[cfg(target_os = "linux")]
-                fwmark,
-            })
+            ObfuscationSettings::Multiplexer(multiplexer::Settings { transports })
         }
     }
 }
@@ -157,14 +136,11 @@ fn settings_from_single_config(
     config: &Config,
     obfuscation_config: &ObfuscatorConfig,
     mtu: u16,
-    #[cfg(target_os = "linux")] fwmark: Option<u32>,
 ) -> ObfuscationSettings {
     match obfuscation_config {
-        ObfuscatorConfig::Udp2Tcp { endpoint } => ObfuscationSettings::Udp2Tcp(udp2tcp::Settings {
-            peer: *endpoint,
-            #[cfg(target_os = "linux")]
-            fwmark,
-        }),
+        ObfuscatorConfig::Udp2Tcp { endpoint } => {
+            ObfuscationSettings::Udp2Tcp(udp2tcp::Settings { peer: *endpoint })
+        }
         ObfuscatorConfig::Shadowsocks { endpoint } => {
             ObfuscationSettings::Shadowsocks(shadowsocks::Settings {
                 shadowsocks_endpoint: *endpoint,
@@ -173,8 +149,6 @@ fn settings_from_single_config(
                 } else {
                     SocketAddr::from((Ipv6Addr::LOCALHOST, 51820))
                 },
-                #[cfg(target_os = "linux")]
-                fwmark,
             })
         }
         ObfuscatorConfig::Quic {
@@ -190,18 +164,12 @@ fn settings_from_single_config(
                 wireguard_endpoint,
             )
             .mtu(mtu);
-            #[cfg(target_os = "linux")]
-            if let Some(fwmark) = fwmark {
-                return ObfuscationSettings::Quic(settings.fwmark(fwmark));
-            }
             ObfuscationSettings::Quic(settings)
         }
         ObfuscatorConfig::Lwo { endpoint } => ObfuscationSettings::Lwo(lwo::Settings {
             server_addr: *endpoint,
             client_public_key: config.tunnel.private_key.public_key(),
             server_public_key: config.entry_peer.public_key.clone(),
-            #[cfg(target_os = "linux")]
-            fwmark,
         }),
     }
 }

--- a/talpid-wireguard/src/obfuscation.rs
+++ b/talpid-wireguard/src/obfuscation.rs
@@ -3,12 +3,13 @@
 use super::{Error, Result};
 use crate::{CloseMsg, config::Config};
 #[cfg(target_os = "android")]
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use std::{
     iter,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
-    sync::mpsc as sync_mpsc,
+    sync::{Arc, mpsc as sync_mpsc},
 };
+use talpid_net::bypass::{BypassToken, SocketBypass};
 #[cfg(target_os = "android")]
 use talpid_tunnel::tun_provider::TunProvider;
 use talpid_types::{
@@ -17,8 +18,8 @@ use talpid_types::{
 };
 
 use tunnel_obfuscation::{
-    Settings as ObfuscationSettings, create_obfuscator, lwo, multiplexer, quic, shadowsocks,
-    udp2tcp,
+    Settings as ObfuscationSettings, create_obfuscator_with_bypass, lwo, multiplexer, quic,
+    shadowsocks, udp2tcp,
 };
 
 /// Begin running obfuscation machine, if configured. This function will patch `config`'s endpoint
@@ -56,14 +57,22 @@ pub async fn apply_obfuscation_config(
 
     log::trace!("Obfuscation settings: {settings:?}");
 
-    let obfuscator = create_obfuscator(&settings)
+    let bypass = Arc::new(ObfuscatorSocketBypass {
+        #[cfg(target_os = "linux")]
+        fwmark: config.fwmark.unwrap_or_else(|| {
+            log::error!("'fwmark' not set");
+            0
+        }),
+
+        #[cfg(target_os = "android")]
+        tun_provider,
+    });
+
+    let obfuscator = create_obfuscator_with_bypass(bypass, &settings)
         .await
         .map_err(Error::ObfuscationError)?;
 
     let packet_overhead = obfuscator.packet_overhead();
-
-    #[cfg(target_os = "android")]
-    bypass_vpn(tun_provider, obfuscator.remote_socket_fd()).await;
 
     patch_endpoint(config, obfuscator.endpoint());
 
@@ -197,22 +206,6 @@ fn settings_from_single_config(
     }
 }
 
-/// Route socket outside of the VPN on Android
-#[cfg(target_os = "android")]
-async fn bypass_vpn(
-    tun_provider: Arc<Mutex<TunProvider>>,
-    remote_socket_fd: std::os::unix::io::RawFd,
-) {
-    // Exclude remote obfuscation socket or bridge
-    log::debug!("Excluding remote socket fd from the tunnel");
-    let _ = tokio::task::spawn_blocking(move || {
-        if let Err(error) = tun_provider.lock().unwrap().bypass(&remote_socket_fd) {
-            log::error!("Failed to exclude remote socket fd: {error}");
-        }
-    })
-    .await;
-}
-
 /// Simple wrapper that automatically cancels the future which runs an obfuscator.
 pub struct ObfuscatorHandle {
     obfuscation_task: tokio::task::JoinHandle<()>,
@@ -232,5 +225,56 @@ impl ObfuscatorHandle {
 impl Drop for ObfuscatorHandle {
     fn drop(&mut self) {
         self.obfuscation_task.abort();
+    }
+}
+
+struct ObfuscatorSocketBypass {
+    #[cfg(target_os = "linux")]
+    fwmark: u32,
+
+    #[cfg(target_os = "android")]
+    tun_provider: Arc<Mutex<TunProvider>>,
+}
+
+impl SocketBypass for ObfuscatorSocketBypass {
+    #[cfg(target_os = "linux")]
+    fn bypass_socket(
+        &self,
+        socket: socket2::SockRef<'_>,
+        _token: &BypassToken,
+    ) -> std::io::Result<()> {
+        socket.set_mark(self.fwmark)
+    }
+
+    #[cfg(any(windows, target_os = "macos"))]
+    fn bypass_socket(
+        &self,
+        _socket: socket2::SockRef<'_>,
+        _token: &BypassToken,
+    ) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    #[cfg(target_os = "android")]
+    fn bypass_socket(
+        &self,
+        socket: socket2::SockRef<'_>,
+        _token: &BypassToken,
+    ) -> std::io::Result<()> {
+        use std::os::unix::io::AsRawFd;
+
+        self.tun_provider
+            .lock()
+            .unwrap()
+            .bypass(&socket.as_raw_fd())
+            .map_err(std::io::Error::other)
+    }
+
+    fn revoke_bypass(
+        &self,
+        _socket: socket2::SockRef<'_>,
+        _token: &BypassToken,
+    ) -> std::io::Result<()> {
+        Ok(())
     }
 }

--- a/tunnel-obfuscation/Cargo.toml
+++ b/tunnel-obfuscation/Cargo.toml
@@ -21,6 +21,7 @@ log = { workspace = true }
 mullvad-masque-proxy = { path = "../mullvad-masque-proxy" }
 rand = { workspace = true, features = ["small_rng"] }
 shadowsocks = { workspace = true }
+talpid-net = { path = "../talpid-net" }
 talpid-types = { path = "../talpid-types" }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = [

--- a/tunnel-obfuscation/Cargo.toml
+++ b/tunnel-obfuscation/Cargo.toml
@@ -30,7 +30,7 @@ tokio = { workspace = true, features = [
   "rt-multi-thread"
 ] }
 tokio-util = { workspace = true, features = ["rt"] }
-udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "5c6d8f44a5aa12ed9bb4ae51dd17e5e22e5ec303" }
+udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "00c8482f303aa23a69cfe9ee10903582cba3eb1e" }
 
 [dev-dependencies]
 criterion = { version = "0.7.0", features = ["async_tokio", "html_reports"] }

--- a/tunnel-obfuscation/Cargo.toml
+++ b/tunnel-obfuscation/Cargo.toml
@@ -37,8 +37,5 @@ udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "00c8482
 criterion = { version = "0.7.0", features = ["async_tokio", "html_reports"] }
 tokio = { workspace = true, features = ["test-util"] }
 
-[target.'cfg(target_os="linux")'.dependencies]
-nix = { workspace = true, features = ["socket"] }
-
 [lints]
 workspace = true

--- a/tunnel-obfuscation/benches/obfuscation_throughput.rs
+++ b/tunnel-obfuscation/benches/obfuscation_throughput.rs
@@ -98,8 +98,6 @@ fn bench_proxy_lwo(c: &mut Criterion) {
             server_addr: relay.local_addr().unwrap(),
             client_public_key: client_key.clone(),
             server_public_key: server_key.clone(),
-            #[cfg(target_os = "linux")]
-            fwmark: None,
         };
         let lwo = Lwo::new(Arc::new(NoopBypass), &settings).await.unwrap();
         let proxy_addr = lwo.endpoint();

--- a/tunnel-obfuscation/benches/obfuscation_throughput.rs
+++ b/tunnel-obfuscation/benches/obfuscation_throughput.rs
@@ -11,6 +11,8 @@
 
 use core::hint::black_box;
 use criterion::{Criterion, criterion_group, criterion_main};
+use std::sync::Arc;
+use talpid_net::bypass::NoopBypass;
 use talpid_types::net::wireguard::PublicKey;
 use tokio::net::UdpSocket;
 use tunnel_obfuscation::{
@@ -99,7 +101,7 @@ fn bench_proxy_lwo(c: &mut Criterion) {
             #[cfg(target_os = "linux")]
             fwmark: None,
         };
-        let lwo = Lwo::new(&settings).await.unwrap();
+        let lwo = Lwo::new(Arc::new(NoopBypass), &settings).await.unwrap();
         let proxy_addr = lwo.endpoint();
         tokio::spawn((Box::new(lwo) as Box<dyn Obfuscator>).run());
 

--- a/tunnel-obfuscation/src/lib.rs
+++ b/tunnel-obfuscation/src/lib.rs
@@ -44,10 +44,6 @@ pub enum Error {
     #[error("Failed to bypass socket")]
     Bypass(#[source] io::Error),
 
-    #[cfg(target_os = "linux")]
-    #[error("Failed to set fwmark on remote socket")]
-    SetFwmark(#[source] nix::Error),
-
     #[error("Failed to initialize multiplexer")]
     CreateMultiplexerObfuscator(#[source] io::Error),
 

--- a/tunnel-obfuscation/src/lib.rs
+++ b/tunnel-obfuscation/src/lib.rs
@@ -62,10 +62,6 @@ pub trait Obfuscator: Send {
     /// Returns the address of the local socket.
     fn endpoint(&self) -> SocketAddr;
 
-    /// Returns the file descriptor of the outbound socket.
-    #[cfg(target_os = "android")]
-    fn remote_socket_fd(&self) -> std::os::unix::io::RawFd;
-
     /// The overhead (in bytes) of this obfuscation protocol.
     ///
     /// This is used when deciding on MTUs.

--- a/tunnel-obfuscation/src/lib.rs
+++ b/tunnel-obfuscation/src/lib.rs
@@ -7,7 +7,7 @@ pub mod lwo;
 pub mod multiplexer;
 pub mod quic;
 pub mod shadowsocks;
-pub mod socket;
+pub(crate) mod socket;
 pub mod udp2tcp;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/tunnel-obfuscation/src/lib.rs
+++ b/tunnel-obfuscation/src/lib.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
-use std::net::SocketAddr;
+use std::{net::SocketAddr, sync::Arc};
+use talpid_net::bypass::{NoopBypass, SocketBypass};
 use tokio::io;
 
 pub mod lwo;
@@ -40,6 +41,9 @@ pub enum Error {
     #[error("Failed to bind socket")]
     BindRemoteUdp(#[source] io::Error),
 
+    #[error("Failed to bypass socket")]
+    Bypass(#[source] io::Error),
+
     #[cfg(target_os = "linux")]
     #[error("Failed to set fwmark on remote socket")]
     SetFwmark(#[source] nix::Error),
@@ -53,7 +57,6 @@ pub enum Error {
 
 #[async_trait]
 pub trait Obfuscator: Send {
-    /// NOTE(Android): Make sure to call bypass on the obfuscator socket _before_ invoking run.
     async fn run(self: Box<Self>) -> Result<()>;
 
     /// Returns the address of the local socket.
@@ -79,15 +82,23 @@ pub enum Settings {
 }
 
 pub async fn create_obfuscator(settings: &Settings) -> Result<Box<dyn Obfuscator>> {
+    create_obfuscator_with_bypass(Arc::new(NoopBypass), settings).await
+}
+
+pub async fn create_obfuscator_with_bypass(
+    bypass: Arc<dyn SocketBypass>,
+    settings: &Settings,
+) -> Result<Box<dyn Obfuscator>> {
     match settings {
-        Settings::Udp2Tcp(s) => udp2tcp::Udp2Tcp::new(s)
+        Settings::Udp2Tcp(s) => udp2tcp::Udp2Tcp::new(bypass, s).await.map(box_obfuscator),
+        Settings::Shadowsocks(s) => shadowsocks::Shadowsocks::new(bypass, s)
             .await
-            .map(box_obfuscator)
-            .map_err(Error::CreateUdp2TcpObfuscator),
-        Settings::Shadowsocks(s) => shadowsocks::Shadowsocks::new(s).await.map(box_obfuscator),
-        Settings::Quic(s) => quic::Quic::new(s).await.map(box_obfuscator),
-        Settings::Lwo(s) => lwo::Lwo::new(s).await.map(box_obfuscator),
-        Settings::Multiplexer(s) => multiplexer::Multiplexer::new(s).await.map(box_obfuscator),
+            .map(box_obfuscator),
+        Settings::Quic(s) => quic::Quic::new(bypass, s).await.map(box_obfuscator),
+        Settings::Lwo(s) => lwo::Lwo::new(bypass, s).await.map(box_obfuscator),
+        Settings::Multiplexer(s) => multiplexer::Multiplexer::new(bypass, s)
+            .await
+            .map(box_obfuscator),
     }
 }
 

--- a/tunnel-obfuscation/src/lwo.rs
+++ b/tunnel-obfuscation/src/lwo.rs
@@ -7,7 +7,7 @@ use std::{
 
 use async_trait::async_trait;
 use rand::RngCore;
-use talpid_net::bypass::{BypassGuard, SocketBypass};
+use talpid_net::bypass::{BypassSocket, SocketBypass};
 use talpid_types::net::wireguard::PublicKey;
 use tokio::{io, net::UdpSocket, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
@@ -45,13 +45,11 @@ pub struct Settings {
 pub struct Lwo {
     client: Client,
     local_endpoint: SocketAddr,
-    _bypass: BypassGuard,
 }
 
 impl Lwo {
     pub async fn new(bypass: Arc<dyn SocketBypass>, settings: &Settings) -> crate::Result<Self> {
-        let (remote_socket, _bypass) =
-            create_remote_socket(&bypass, settings.server_addr.is_ipv4()).await?;
+        let remote_socket = create_remote_socket(&bypass, settings.server_addr.is_ipv4()).await?;
         let remote_socket = Arc::new(remote_socket);
         let client_socket = Arc::new(
             UdpSocket::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
@@ -75,7 +73,6 @@ impl Lwo {
         Ok(Self {
             local_endpoint,
             client,
-            _bypass,
         })
     }
 
@@ -98,7 +95,7 @@ struct Client {
     rx_key: PublicKey,
     tx_key: PublicKey,
 
-    remote_socket: Arc<UdpSocket>,
+    remote_socket: Arc<BypassSocket<UdpSocket>>,
     client_socket: Arc<UdpSocket>,
 }
 
@@ -149,13 +146,13 @@ impl Client {
         let rx_socket = client_socket.clone();
         let tx_socket = remote_socket.clone();
         let send_task = tokio::spawn(async move {
-            run_obfuscation(true, tx_key, rx_socket, tx_socket).await;
+            run_obfuscation(tx_key, rx_socket, tx_socket).await;
         });
 
         let rx_socket = remote_socket.clone();
         let tx_socket = client_socket.clone();
         let recv_task = tokio::spawn(async move {
-            run_obfuscation(false, rx_key, rx_socket, tx_socket).await;
+            run_deobfuscation(rx_key, rx_socket, tx_socket).await;
         });
 
         Ok(RunningClient {
@@ -166,31 +163,34 @@ impl Client {
 }
 
 async fn run_obfuscation(
-    sending: bool,
     key: PublicKey,
     read_socket: Arc<UdpSocket>,
-    write_socket: Arc<UdpSocket>,
+    write_socket: Arc<BypassSocket<UdpSocket>>,
 ) {
-    if sending {
-        run_obfuscation_inner(
-            move |buf| obfuscate(&mut rand::rng(), buf, key.as_bytes()),
-            read_socket,
-            write_socket,
-        )
-        .await
-    } else {
-        run_obfuscation_inner(
-            move |buf| deobfuscate(buf, key.as_bytes()),
-            read_socket,
-            write_socket,
-        )
-        .await
+    let mut buf = vec![0u8; MAX_UDP_SIZE];
+
+    loop {
+        let read_n = match read_socket.recv(&mut buf).await {
+            Ok(read_n) => read_n,
+            Err(err) => {
+                log::debug!("read_socket.recv failed: {err}");
+                return;
+            }
+        };
+
+        // TODO: recv and send concurrently
+        obfuscate(&mut rand::rng(), &mut buf, key.as_bytes());
+
+        if let Err(err) = write_socket.send(&buf[..read_n]).await {
+            log::debug!("write_socket.send_to failed: {err}");
+            return;
+        }
     }
 }
 
-async fn run_obfuscation_inner(
-    mut action: impl FnMut(&mut [u8]),
-    read_socket: Arc<UdpSocket>,
+async fn run_deobfuscation(
+    key: PublicKey,
+    read_socket: Arc<BypassSocket<UdpSocket>>,
     write_socket: Arc<UdpSocket>,
 ) {
     let mut buf = vec![0u8; MAX_UDP_SIZE];
@@ -205,7 +205,7 @@ async fn run_obfuscation_inner(
         };
 
         // TODO: recv and send concurrently
-        action(&mut buf[..read_n]);
+        deobfuscate(&mut buf, key.as_bytes());
 
         if let Err(err) = write_socket.send(&buf[..read_n]).await {
             log::debug!("write_socket.send_to failed: {err}");

--- a/tunnel-obfuscation/src/lwo.rs
+++ b/tunnel-obfuscation/src/lwo.rs
@@ -7,6 +7,7 @@ use std::{
 
 use async_trait::async_trait;
 use rand::RngCore;
+use talpid_net::bypass::{BypassGuard, SocketBypass};
 use talpid_types::net::wireguard::PublicKey;
 use tokio::{io, net::UdpSocket, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
@@ -49,18 +50,19 @@ pub struct Lwo {
     local_endpoint: SocketAddr,
     #[cfg(target_os = "android")]
     wg_endpoint: Arc<UdpSocket>,
+    _bypass: BypassGuard,
 }
 
 impl Lwo {
-    pub async fn new(settings: &Settings) -> crate::Result<Self> {
-        let remote_socket = Arc::new(
-            create_remote_socket(
-                settings.server_addr.is_ipv4(),
-                #[cfg(target_os = "linux")]
-                settings.fwmark,
-            )
-            .await?,
-        );
+    pub async fn new(bypass: Arc<dyn SocketBypass>, settings: &Settings) -> crate::Result<Self> {
+        let (remote_socket, _bypass) = create_remote_socket(
+            &bypass,
+            settings.server_addr.is_ipv4(),
+            #[cfg(target_os = "linux")]
+            settings.fwmark,
+        )
+        .await?;
+        let remote_socket = Arc::new(remote_socket);
         let client_socket = Arc::new(
             UdpSocket::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
                 .await
@@ -88,6 +90,7 @@ impl Lwo {
             client,
             #[cfg(target_os = "android")]
             wg_endpoint,
+            _bypass,
         })
     }
 
@@ -330,6 +333,8 @@ pub fn obfuscate_thread_local(packet: &mut [u8], key: &[u8; 32]) {
 
 #[cfg(test)]
 mod test {
+    use talpid_net::bypass::NoopBypass;
+
     use super::*;
 
     struct FixedByteRng(u8);
@@ -403,7 +408,7 @@ mod test {
             fwmark: None,
         };
 
-        let lwo = Lwo::new(&settings).await.unwrap();
+        let lwo = Lwo::new(Arc::new(NoopBypass), &settings).await.unwrap();
         let client_socket_addr = lwo.local_endpoint;
 
         tokio::spawn(Box::new(lwo).run());

--- a/tunnel-obfuscation/src/lwo.rs
+++ b/tunnel-obfuscation/src/lwo.rs
@@ -48,8 +48,6 @@ pub struct Settings {
 pub struct Lwo {
     client: Client,
     local_endpoint: SocketAddr,
-    #[cfg(target_os = "android")]
-    wg_endpoint: Arc<UdpSocket>,
     _bypass: BypassGuard,
 }
 
@@ -74,9 +72,6 @@ impl Lwo {
             .map_err(Error::GetUdpLocalAddress)
             .map_err(crate::Error::CreateLwoObfuscator)?;
 
-        #[cfg(target_os = "android")]
-        let wg_endpoint = Arc::clone(&remote_socket);
-
         let client = Client {
             server_addr: settings.server_addr,
             rx_key: settings.client_public_key.clone(),
@@ -88,8 +83,6 @@ impl Lwo {
         Ok(Self {
             local_endpoint,
             client,
-            #[cfg(target_os = "android")]
-            wg_endpoint,
             _bypass,
         })
     }
@@ -314,12 +307,6 @@ impl Obfuscator for Lwo {
 
     fn packet_overhead(&self) -> u16 {
         0
-    }
-
-    #[cfg(target_os = "android")]
-    fn remote_socket_fd(&self) -> std::os::unix::io::RawFd {
-        use std::os::fd::AsRawFd;
-        self.wg_endpoint.as_raw_fd()
     }
 }
 

--- a/tunnel-obfuscation/src/lwo.rs
+++ b/tunnel-obfuscation/src/lwo.rs
@@ -40,9 +40,6 @@ pub struct Settings {
     pub client_public_key: PublicKey,
     /// Public key of the WG server
     pub server_public_key: PublicKey,
-    /// Optional fwmark to set on the remote socket
-    #[cfg(target_os = "linux")]
-    pub fwmark: Option<u32>,
 }
 
 pub struct Lwo {
@@ -53,13 +50,8 @@ pub struct Lwo {
 
 impl Lwo {
     pub async fn new(bypass: Arc<dyn SocketBypass>, settings: &Settings) -> crate::Result<Self> {
-        let (remote_socket, _bypass) = create_remote_socket(
-            &bypass,
-            settings.server_addr.is_ipv4(),
-            #[cfg(target_os = "linux")]
-            settings.fwmark,
-        )
-        .await?;
+        let (remote_socket, _bypass) =
+            create_remote_socket(&bypass, settings.server_addr.is_ipv4()).await?;
         let remote_socket = Arc::new(remote_socket);
         let client_socket = Arc::new(
             UdpSocket::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
@@ -391,8 +383,6 @@ mod test {
             server_addr: endpoint.local_addr().unwrap(),
             client_public_key: client_public_key.clone(),
             server_public_key: server_public_key.clone(),
-            #[cfg(target_os = "linux")]
-            fwmark: None,
         };
 
         let lwo = Lwo::new(Arc::new(NoopBypass), &settings).await.unwrap();

--- a/tunnel-obfuscation/src/main.rs
+++ b/tunnel-obfuscation/src/main.rs
@@ -21,8 +21,6 @@ async fn instantiate_requested(obfuscator_type: &str) -> Box<dyn Obfuscator> {
         "udp2tcp" => {
             let settings = udp2tcp::Settings {
                 peer: SocketAddr::new("127.0.0.1".parse().unwrap(), 3030),
-                #[cfg(target_os = "linux")]
-                fwmark: Some(1337),
             };
 
             create_obfuscator(&Settings::Udp2Tcp(settings))

--- a/tunnel-obfuscation/src/multiplexer.rs
+++ b/tunnel-obfuscation/src/multiplexer.rs
@@ -87,20 +87,8 @@ impl Multiplexer {
             .local_addr()
             .map_err(crate::Error::CreateMultiplexerObfuscator)?;
 
-        let (proxy_socket_v4, _bypass_v4) = create_remote_socket(
-            &bypass,
-            true,
-            #[cfg(target_os = "linux")]
-            settings.fwmark,
-        )
-        .await?;
-        let (proxy_socket_v6, _bypass_v6) = create_remote_socket(
-            &bypass,
-            false,
-            #[cfg(target_os = "linux")]
-            settings.fwmark,
-        )
-        .await?;
+        let (proxy_socket_v4, _bypass_v4) = create_remote_socket(&bypass, true).await?;
+        let (proxy_socket_v6, _bypass_v6) = create_remote_socket(&bypass, false).await?;
 
         Ok(Self {
             client_socket: Arc::new(client_socket),
@@ -369,9 +357,6 @@ pub struct Settings {
     /// Spawn these transports progressively and select
     /// the first one that successfully establishes a connection.
     pub transports: Vec<Transport>,
-    /// Linux-specific firewall mark for outgoing connections
-    #[cfg(target_os = "linux")]
-    pub fwmark: Option<u32>,
 }
 
 /// Represents a transport method that the multiplexer can use.
@@ -423,8 +408,6 @@ mod tests {
                 Transport::Direct(server_addr),
                 Transport::Direct(server_addr2),
             ],
-            #[cfg(target_os = "linux")]
-            fwmark: None,
         };
 
         let multiplexer = Multiplexer::new(Arc::new(NoopBypass), &settings)

--- a/tunnel-obfuscation/src/multiplexer.rs
+++ b/tunnel-obfuscation/src/multiplexer.rs
@@ -400,11 +400,6 @@ impl crate::Obfuscator for Multiplexer {
             .await
             .map_err(crate::Error::RunMultiplexerObfuscator)
     }
-
-    #[cfg(target_os = "android")]
-    fn remote_socket_fd(&self) -> std::os::unix::io::RawFd {
-        unimplemented!("must return the socket fd of every obfuscator here")
-    }
 }
 
 #[cfg(test)]

--- a/tunnel-obfuscation/src/multiplexer.rs
+++ b/tunnel-obfuscation/src/multiplexer.rs
@@ -8,9 +8,11 @@
 //! ## How it works
 //!
 //! 1. **Initial Setup**: The multiplexer creates a local UDP socket that WireGuard connects to
-//! 2. **Transport Spawning**: It progressively spawns different obfuscation transports at timed intervals
+//! 2. **Transport Spawning**: It progressively spawns different obfuscation transports at timed
+//!    intervals
 //! 3. **Traffic Fanout**: All incoming WireGuard packets are fanned out to all active transports
-//! 4. **First Response Wins**: The first transport to receive a response from the server is selected
+//! 4. **First Response Wins**: The first transport to receive a response from the server is
+//!    selected
 //! 5. **Connection Establishment**: Once a transport is selected, the multiplexer switches to a
 //!    direct forwarding mode between WireGuard and the selected transport
 //!
@@ -27,6 +29,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use talpid_net::bypass::{BypassGuard, SocketBypass};
 use tokio::net::UdpSocket;
 use tokio_util::task::AbortOnDropHandle;
 
@@ -62,6 +65,9 @@ pub struct Multiplexer {
     tasks: Vec<AbortOnDropHandle<()>>,
     /// Address of WG endpoint socket
     wg_addr: Option<SocketAddr>,
+    bypass: Arc<dyn SocketBypass>,
+    _bypass_v4: BypassGuard,
+    _bypass_v6: BypassGuard,
 }
 
 impl Multiplexer {
@@ -72,7 +78,7 @@ impl Multiplexer {
     ///
     /// # Returns
     /// A new multiplexer instance ready to start obfuscation discovery
-    pub async fn new(settings: &Settings) -> crate::Result<Self> {
+    pub async fn new(bypass: Arc<dyn SocketBypass>, settings: &Settings) -> crate::Result<Self> {
         let client_socket = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0))
             .await
             .map_err(crate::Error::CreateMultiplexerObfuscator)?;
@@ -81,13 +87,15 @@ impl Multiplexer {
             .local_addr()
             .map_err(crate::Error::CreateMultiplexerObfuscator)?;
 
-        let proxy_socket_v4 = create_remote_socket(
+        let (proxy_socket_v4, _bypass_v4) = create_remote_socket(
+            &bypass,
             true,
             #[cfg(target_os = "linux")]
             settings.fwmark,
         )
         .await?;
-        let proxy_socket_v6 = create_remote_socket(
+        let (proxy_socket_v6, _bypass_v6) = create_remote_socket(
+            &bypass,
             false,
             #[cfg(target_os = "linux")]
             settings.fwmark,
@@ -104,6 +112,9 @@ impl Multiplexer {
             tasks: vec![],
             initial_packets_to_send: vec![],
             wg_addr: None,
+            bypass,
+            _bypass_v4,
+            _bypass_v6,
         })
     }
 
@@ -319,7 +330,11 @@ impl Multiplexer {
                 Ok(addr)
             }
             Transport::Obfuscated(obfuscator_settings) => {
-                let obfuscator = crate::create_obfuscator(&obfuscator_settings).await?;
+                let obfuscator = crate::create_obfuscator_with_bypass(
+                    Arc::clone(&self.bypass),
+                    &obfuscator_settings,
+                )
+                .await?;
                 let endpoint = obfuscator.endpoint();
                 self.running_endpoints
                     .insert(endpoint, Transport::Obfuscated(obfuscator_settings));
@@ -396,6 +411,7 @@ impl crate::Obfuscator for Multiplexer {
 mod tests {
     use super::*;
     use crate::Obfuscator;
+    use talpid_net::bypass::NoopBypass;
 
     /// Test whether the multiplexer works with a direct transports
     #[tokio::test(start_paused = true)]
@@ -416,7 +432,9 @@ mod tests {
             fwmark: None,
         };
 
-        let multiplexer = Multiplexer::new(&settings).await.unwrap();
+        let multiplexer = Multiplexer::new(Arc::new(NoopBypass), &settings)
+            .await
+            .unwrap();
         let multiplexer_endpoint = multiplexer.endpoint();
 
         let client_socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();

--- a/tunnel-obfuscation/src/multiplexer.rs
+++ b/tunnel-obfuscation/src/multiplexer.rs
@@ -29,7 +29,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use talpid_net::bypass::{BypassGuard, SocketBypass};
+use talpid_net::bypass::{BypassSocket, SocketBypass};
 use tokio::net::UdpSocket;
 use tokio_util::task::AbortOnDropHandle;
 
@@ -52,9 +52,9 @@ pub struct Multiplexer {
     /// Address of the client socket that WireGuard should connect to
     client_socket_addr: SocketAddr,
     /// IPv4 socket for communicating with obfuscation proxies
-    proxy_socket_v4: Arc<UdpSocket>,
+    proxy_socket_v4: Arc<BypassSocket<UdpSocket>>,
     /// IPv6 socket for communicating with obfuscation proxies
-    proxy_socket_v6: Arc<UdpSocket>,
+    proxy_socket_v6: Arc<BypassSocket<UdpSocket>>,
     /// Map of currently active transport endpoints and their configurations
     running_endpoints: BTreeMap<SocketAddr, Transport>,
     /// Queue of transports to spawn (in priority order)
@@ -66,8 +66,6 @@ pub struct Multiplexer {
     /// Address of WG endpoint socket
     wg_addr: Option<SocketAddr>,
     bypass: Arc<dyn SocketBypass>,
-    _bypass_v4: BypassGuard,
-    _bypass_v6: BypassGuard,
 }
 
 impl Multiplexer {
@@ -87,8 +85,8 @@ impl Multiplexer {
             .local_addr()
             .map_err(crate::Error::CreateMultiplexerObfuscator)?;
 
-        let (proxy_socket_v4, _bypass_v4) = create_remote_socket(&bypass, true).await?;
-        let (proxy_socket_v6, _bypass_v6) = create_remote_socket(&bypass, false).await?;
+        let proxy_socket_v4 = create_remote_socket(&bypass, true).await?;
+        let proxy_socket_v6 = create_remote_socket(&bypass, false).await?;
 
         Ok(Self {
             client_socket: Arc::new(client_socket),
@@ -101,12 +99,10 @@ impl Multiplexer {
             initial_packets_to_send: vec![],
             wg_addr: None,
             bypass,
-            _bypass_v4,
-            _bypass_v6,
         })
     }
 
-    fn proxy_for_addr(&self, addr: SocketAddr) -> &Arc<UdpSocket> {
+    fn proxy_for_addr(&self, addr: SocketAddr) -> &Arc<BypassSocket<UdpSocket>> {
         if addr.is_ipv4() {
             &self.proxy_socket_v4
         } else {
@@ -133,7 +129,7 @@ impl Multiplexer {
         /// Helper to fan out a packet to all currently running endpoints
         async fn send_to_all<'a>(
             endpoints: &BTreeMap<SocketAddr, Transport>,
-            get_socket: impl Fn(SocketAddr) -> &'a Arc<UdpSocket>,
+            get_socket: impl Fn(SocketAddr) -> &'a Arc<BypassSocket<UdpSocket>>,
             packet: &[u8],
         ) {
             let mut futs = vec![];

--- a/tunnel-obfuscation/src/quic.rs
+++ b/tunnel-obfuscation/src/quic.rs
@@ -218,10 +218,4 @@ impl Obfuscator for Quic {
         // The above would prevent mullvad-masque-proxy-level fragmentation
         0
     }
-
-    #[cfg(target_os = "android")]
-    fn remote_socket_fd(&self) -> std::os::unix::io::RawFd {
-        use std::os::fd::AsRawFd;
-        self.config.quinn_socket.as_raw_fd()
-    }
 }

--- a/tunnel-obfuscation/src/quic.rs
+++ b/tunnel-obfuscation/src/quic.rs
@@ -40,9 +40,6 @@ pub struct Settings {
     /// Authentication token to set for the CONNECT request when establishing a QUIC connection.
     /// Must NOT be prefixed with "Bearer".
     token: AuthToken,
-    /// fwmark to apply to use for the QUIC connection
-    #[cfg(target_os = "linux")]
-    fwmark: Option<u32>,
     /// MTU for the QUIC client. This needs to account for the *additional* headers other than IP
     /// and UDP, but not for those specifically.
     mtu: Option<u16>,
@@ -62,8 +59,6 @@ impl Settings {
             hostname,
             token,
             mtu: None,
-            #[cfg(target_os = "linux")]
-            fwmark: None,
         }
     }
 
@@ -72,13 +67,6 @@ impl Settings {
         debug_assert!(mtu <= 1500, "MTU is too high: {mtu}");
         let mtu = Some(mtu);
         Self { mtu, ..self }
-    }
-
-    /// Set `fwmark` for the Quic obfuscator.
-    #[cfg(target_os = "linux")]
-    pub fn fwmark(self, fwmark: u32) -> Self {
-        let fwmark = Some(fwmark);
-        Self { fwmark, ..self }
     }
 
     /// The masque-proxy server expects the Authentication header to be prefixed with "Bearer ", so
@@ -132,13 +120,8 @@ impl Quic {
         // of the endpoint we're connecting to. The address itself is not important to consumers
         // wanting to obfuscate traffic. It is solely used by the local proxy client to know
         // where the QUIC obfuscator is running.
-        let (quic_socket, _bypass) = create_remote_socket(
-            &bypass,
-            settings.quic_endpoint.is_ipv4(),
-            #[cfg(target_os = "linux")]
-            settings.fwmark,
-        )
-        .await?;
+        let (quic_socket, _bypass) =
+            create_remote_socket(&bypass, settings.quic_endpoint.is_ipv4()).await?;
 
         let config_builder = ClientConfig::builder()
             .client_socket(local_socket)

--- a/tunnel-obfuscation/src/quic.rs
+++ b/tunnel-obfuscation/src/quic.rs
@@ -5,7 +5,9 @@ use mullvad_masque_proxy::client::{Client, ClientConfig};
 use std::{
     io,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
+    sync::Arc,
 };
+use talpid_net::bypass::{BypassGuard, SocketBypass};
 use tokio::net::UdpSocket;
 use tokio_util::sync::CancellationToken;
 
@@ -21,10 +23,10 @@ pub enum Error {
     MasqueProxyError(#[source] mullvad_masque_proxy::client::Error),
 }
 
-#[derive(Debug)]
 pub struct Quic {
     local_endpoint: SocketAddr,
     config: ClientConfig,
+    _bypass: BypassGuard,
 }
 
 #[derive(Debug, Clone)]
@@ -47,7 +49,7 @@ pub struct Settings {
 }
 
 impl Settings {
-    ///See [Settings] for details.
+    /// See [Settings] for details.
     pub fn new(
         quic_server_endpoint: SocketAddr,
         hostname: String,
@@ -118,16 +120,20 @@ impl std::str::FromStr for AuthToken {
 }
 
 impl Quic {
-    pub(crate) async fn new(settings: &Settings) -> crate::Result<Self> {
+    pub(crate) async fn new(
+        bypass: Arc<dyn SocketBypass>,
+        settings: &Settings,
+    ) -> crate::Result<Self> {
         let (local_socket, local_udp_client_addr) =
             Quic::create_local_udp_socket(settings.quic_endpoint.is_ipv4())
                 .await
                 .map_err(crate::Error::CreateQuicObfuscator)?;
         // The address family of the local QUIC client socket has to match the address family
-        // of the endpoint we're connecting to. The address itself is not important to consumers wanting
-        // to obfuscate traffic. It is solely used by the local proxy client to know where the QUIC
-        // obfuscator is running.
-        let quic_socket = create_remote_socket(
+        // of the endpoint we're connecting to. The address itself is not important to consumers
+        // wanting to obfuscate traffic. It is solely used by the local proxy client to know
+        // where the QUIC obfuscator is running.
+        let (quic_socket, _bypass) = create_remote_socket(
+            &bypass,
             settings.quic_endpoint.is_ipv4(),
             #[cfg(target_os = "linux")]
             settings.fwmark,
@@ -148,6 +154,7 @@ impl Quic {
         let quic = Quic {
             local_endpoint: local_udp_client_addr,
             config,
+            _bypass,
         };
 
         Ok(quic)

--- a/tunnel-obfuscation/src/quic.rs
+++ b/tunnel-obfuscation/src/quic.rs
@@ -7,7 +7,7 @@ use std::{
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::Arc,
 };
-use talpid_net::bypass::{BypassGuard, SocketBypass};
+use talpid_net::bypass::{BypassGuard, BypassSocket, SocketBypass};
 use tokio::net::UdpSocket;
 use tokio_util::sync::CancellationToken;
 
@@ -120,8 +120,10 @@ impl Quic {
         // of the endpoint we're connecting to. The address itself is not important to consumers
         // wanting to obfuscate traffic. It is solely used by the local proxy client to know
         // where the QUIC obfuscator is running.
-        let (quic_socket, _bypass) =
-            create_remote_socket(&bypass, settings.quic_endpoint.is_ipv4()).await?;
+        let BypassSocket {
+            socket: quic_socket,
+            guard: _bypass,
+        } = create_remote_socket(&bypass, settings.quic_endpoint.is_ipv4()).await?;
 
         let config_builder = ClientConfig::builder()
             .client_socket(local_socket)

--- a/tunnel-obfuscation/src/shadowsocks.rs
+++ b/tunnel-obfuscation/src/shadowsocks.rs
@@ -21,9 +21,6 @@ use std::{io, net::SocketAddr, sync::Arc};
 use talpid_net::bypass::{BypassGuard, SocketBypass};
 use tokio::{net::UdpSocket, sync::oneshot};
 
-#[cfg(target_os = "android")]
-use std::os::fd::AsRawFd;
-
 const SHADOWSOCKS_CIPHER: CipherKind = CipherKind::AES_256_GCM;
 const SHADOWSOCKS_PASSWORD: &str = "mullvad";
 
@@ -53,8 +50,6 @@ pub struct Shadowsocks {
     server: tokio::task::JoinHandle<Result<()>>,
     // The receiver will implicitly shut down when this is dropped
     _shutdown_tx: oneshot::Sender<()>,
-    #[cfg(target_os = "android")]
-    outbound_fd: i32,
     _bypass: BypassGuard,
 }
 
@@ -88,9 +83,6 @@ impl Shadowsocks {
         )
         .await?;
 
-        #[cfg(target_os = "android")]
-        let outbound_fd = remote_socket.as_raw_fd();
-
         let server = tokio::spawn(run_forwarding(
             settings.shadowsocks_endpoint,
             remote_socket,
@@ -104,8 +96,6 @@ impl Shadowsocks {
             wireguard_endpoint: settings.wireguard_endpoint,
             server,
             _shutdown_tx: shutdown_tx,
-            #[cfg(target_os = "android")]
-            outbound_fd,
             _bypass,
         })
     }
@@ -278,11 +268,6 @@ impl Obfuscator for Shadowsocks {
             Err(_err) if _err.is_cancelled() => Ok(()),
             Err(_err) => panic!("server handle panicked"),
         }
-    }
-
-    #[cfg(target_os = "android")]
-    fn remote_socket_fd(&self) -> std::os::unix::io::RawFd {
-        self.outbound_fd
     }
 
     fn packet_overhead(&self) -> u16 {

--- a/tunnel-obfuscation/src/shadowsocks.rs
+++ b/tunnel-obfuscation/src/shadowsocks.rs
@@ -18,6 +18,7 @@ use shadowsocks::{
     },
 };
 use std::{io, net::SocketAddr, sync::Arc};
+use talpid_net::bypass::{BypassGuard, SocketBypass};
 use tokio::{net::UdpSocket, sync::oneshot};
 
 #[cfg(target_os = "android")]
@@ -54,6 +55,7 @@ pub struct Shadowsocks {
     _shutdown_tx: oneshot::Sender<()>,
     #[cfg(target_os = "android")]
     outbound_fd: i32,
+    _bypass: BypassGuard,
 }
 
 #[derive(Debug, Clone)]
@@ -67,7 +69,10 @@ pub struct Settings {
 }
 
 impl Shadowsocks {
-    pub(crate) async fn new(settings: &Settings) -> crate::Result<Self> {
+    pub(crate) async fn new(
+        bypass: Arc<dyn SocketBypass>,
+        settings: &Settings,
+    ) -> crate::Result<Self> {
         let (local_udp_socket, udp_client_addr) =
             create_local_udp_socket(settings.shadowsocks_endpoint.is_ipv4())
                 .await
@@ -75,7 +80,8 @@ impl Shadowsocks {
 
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
-        let remote_socket = create_remote_socket(
+        let (remote_socket, _bypass) = create_remote_socket(
+            &bypass,
             settings.shadowsocks_endpoint.is_ipv4(),
             #[cfg(target_os = "linux")]
             settings.fwmark,
@@ -100,6 +106,7 @@ impl Shadowsocks {
             _shutdown_tx: shutdown_tx,
             #[cfg(target_os = "android")]
             outbound_fd,
+            _bypass,
         })
     }
 }

--- a/tunnel-obfuscation/src/shadowsocks.rs
+++ b/tunnel-obfuscation/src/shadowsocks.rs
@@ -59,8 +59,6 @@ pub struct Settings {
     pub shadowsocks_endpoint: SocketAddr,
     /// Remote WireGuard endpoint
     pub wireguard_endpoint: SocketAddr,
-    #[cfg(target_os = "linux")]
-    pub fwmark: Option<u32>,
 }
 
 impl Shadowsocks {
@@ -75,13 +73,8 @@ impl Shadowsocks {
 
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
-        let (remote_socket, _bypass) = create_remote_socket(
-            &bypass,
-            settings.shadowsocks_endpoint.is_ipv4(),
-            #[cfg(target_os = "linux")]
-            settings.fwmark,
-        )
-        .await?;
+        let (remote_socket, _bypass) =
+            create_remote_socket(&bypass, settings.shadowsocks_endpoint.is_ipv4()).await?;
 
         let server = tokio::spawn(run_forwarding(
             settings.shadowsocks_endpoint,

--- a/tunnel-obfuscation/src/shadowsocks.rs
+++ b/tunnel-obfuscation/src/shadowsocks.rs
@@ -18,7 +18,7 @@ use shadowsocks::{
     },
 };
 use std::{io, net::SocketAddr, sync::Arc};
-use talpid_net::bypass::{BypassGuard, SocketBypass};
+use talpid_net::bypass::{BypassSocket, SocketBypass};
 use tokio::{net::UdpSocket, sync::oneshot};
 
 const SHADOWSOCKS_CIPHER: CipherKind = CipherKind::AES_256_GCM;
@@ -26,7 +26,7 @@ const SHADOWSOCKS_PASSWORD: &str = "mullvad";
 
 type Result<T> = std::result::Result<T, Error>;
 
-type ShadowSocket = ProxySocket<shadowsocks::net::UdpSocket>;
+type ShadowSocket = BypassSocket<ProxySocket<shadowsocks::net::UdpSocket>>;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -50,7 +50,6 @@ pub struct Shadowsocks {
     server: tokio::task::JoinHandle<Result<()>>,
     // The receiver will implicitly shut down when this is dropped
     _shutdown_tx: oneshot::Sender<()>,
-    _bypass: BypassGuard,
 }
 
 #[derive(Debug, Clone)]
@@ -73,7 +72,7 @@ impl Shadowsocks {
 
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
-        let (remote_socket, _bypass) =
+        let remote_socket =
             create_remote_socket(&bypass, settings.shadowsocks_endpoint.is_ipv4()).await?;
 
         let server = tokio::spawn(run_forwarding(
@@ -89,14 +88,13 @@ impl Shadowsocks {
             wireguard_endpoint: settings.wireguard_endpoint,
             server,
             _shutdown_tx: shutdown_tx,
-            _bypass,
         })
     }
 }
 
 async fn run_forwarding(
     shadowsocks_endpoint: SocketAddr,
-    remote_socket: UdpSocket,
+    remote_socket: BypassSocket<UdpSocket>,
     local_udp_socket: UdpSocket,
     wireguard_endpoint: SocketAddr,
     shutdown_rx: oneshot::Receiver<()>,
@@ -140,7 +138,7 @@ async fn run_forwarding(
 }
 
 fn connect_shadowsocks(
-    remote_socket: UdpSocket,
+    remote_socket: BypassSocket<UdpSocket>,
     shadowsocks_endpoint: SocketAddr,
 ) -> Result<ShadowSocket> {
     let ss_context = Context::new_shared(ServerType::Local);
@@ -149,14 +147,15 @@ fn connect_shadowsocks(
         SHADOWSOCKS_PASSWORD,
         SHADOWSOCKS_CIPHER,
     )?;
+    let guard = remote_socket.guard;
     let socket = ProxySocket::from_socket(
         UdpSocketType::Client,
         ss_context,
         &ss_config,
         // wrap the tokio socket
-        shadowsocks::net::UdpSocket::from(remote_socket),
+        shadowsocks::net::UdpSocket::from(remote_socket.socket),
     );
-    Ok(socket)
+    Ok(BypassSocket { socket, guard })
 }
 
 async fn create_local_udp_socket(ipv4: bool) -> Result<(UdpSocket, SocketAddr)> {

--- a/tunnel-obfuscation/src/socket.rs
+++ b/tunnel-obfuscation/src/socket.rs
@@ -1,18 +1,18 @@
 use std::{net::SocketAddr, sync::Arc};
-use talpid_net::bypass::{BypassGuard, SocketBypass};
+use talpid_net::bypass::{BypassSocket, SocketBypass};
 use tokio::net::UdpSocket;
 
 use crate::Error;
 
 /// Bind a UDP socket for talking to a remote obfuscator, and exclude it from tunnel traffic.
 ///
-/// The returned [BypassGuard] must be kept alive for as long as the socket is in use. Dropping it
-/// revokes the bypass, after which there is no guarantee that traffic on the socket stays outside
-/// the tunnel.
+/// The returned [BypassSocket]'s guard must be kept alive for as long as the socket is in use.
+/// Dropping it revokes the bypass, after which there is no guarantee that traffic on the socket
+/// stays outside the tunnel.
 pub async fn create_remote_socket(
     bypass: &Arc<dyn SocketBypass>,
     ipv4: bool,
-) -> Result<(UdpSocket, BypassGuard), Error> {
+) -> Result<BypassSocket<UdpSocket>, Error> {
     let random_bind_addr = if ipv4 {
         SocketAddr::new("0.0.0.0".parse().unwrap(), 0)
     } else {
@@ -21,6 +21,5 @@ pub async fn create_remote_socket(
     let socket = UdpSocket::bind(random_bind_addr)
         .await
         .map_err(Error::BindRemoteUdp)?;
-    let guard = BypassGuard::new(Arc::clone(bypass), &socket).map_err(Error::Bypass)?;
-    Ok((socket, guard))
+    BypassSocket::new(Arc::clone(bypass), socket).map_err(Error::Bypass)
 }

--- a/tunnel-obfuscation/src/socket.rs
+++ b/tunnel-obfuscation/src/socket.rs
@@ -12,7 +12,6 @@ use crate::Error;
 pub async fn create_remote_socket(
     bypass: &Arc<dyn SocketBypass>,
     ipv4: bool,
-    #[cfg(target_os = "linux")] fwmark: Option<u32>,
 ) -> Result<(UdpSocket, BypassGuard), Error> {
     let random_bind_addr = if ipv4 {
         SocketAddr::new("0.0.0.0".parse().unwrap(), 0)
@@ -22,13 +21,6 @@ pub async fn create_remote_socket(
     let socket = UdpSocket::bind(random_bind_addr)
         .await
         .map_err(Error::BindRemoteUdp)?;
-    #[cfg(target_os = "linux")]
-    if let Some(fwmark) = fwmark {
-        use nix::sys::socket::{setsockopt, sockopt};
-
-        setsockopt(&socket, sockopt::Mark, &fwmark).map_err(Error::SetFwmark)?;
-    }
-
     let guard = BypassGuard::new(Arc::clone(bypass), &socket).map_err(Error::Bypass)?;
     Ok((socket, guard))
 }

--- a/tunnel-obfuscation/src/socket.rs
+++ b/tunnel-obfuscation/src/socket.rs
@@ -1,12 +1,19 @@
-use std::net::SocketAddr;
+use std::{net::SocketAddr, sync::Arc};
+use talpid_net::bypass::{BypassGuard, SocketBypass};
 use tokio::net::UdpSocket;
 
 use crate::Error;
 
+/// Bind a UDP socket for talking to a remote obfuscator, and exclude it from tunnel traffic.
+///
+/// The returned [BypassGuard] must be kept alive for as long as the socket is in use. Dropping it
+/// revokes the bypass, after which there is no guarantee that traffic on the socket stays outside
+/// the tunnel.
 pub async fn create_remote_socket(
+    bypass: &Arc<dyn SocketBypass>,
     ipv4: bool,
     #[cfg(target_os = "linux")] fwmark: Option<u32>,
-) -> Result<UdpSocket, Error> {
+) -> Result<(UdpSocket, BypassGuard), Error> {
     let random_bind_addr = if ipv4 {
         SocketAddr::new("0.0.0.0".parse().unwrap(), 0)
     } else {
@@ -22,5 +29,6 @@ pub async fn create_remote_socket(
         setsockopt(&socket, sockopt::Mark, &fwmark).map_err(Error::SetFwmark)?;
     }
 
-    Ok(socket)
+    let guard = BypassGuard::new(Arc::clone(bypass), &socket).map_err(Error::Bypass)?;
+    Ok((socket, guard))
 }

--- a/tunnel-obfuscation/src/udp2tcp.rs
+++ b/tunnel-obfuscation/src/udp2tcp.rs
@@ -10,8 +10,6 @@ use udp_over_tcp::{
 #[derive(Debug, Clone)]
 pub struct Settings {
     pub peer: SocketAddr,
-    #[cfg(target_os = "linux")]
-    pub fwmark: Option<u32>,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -47,10 +45,6 @@ impl Udp2Tcp {
         };
 
         let mut tcp_options = TcpOptions::default();
-        #[cfg(target_os = "linux")]
-        {
-            tcp_options.fwmark = settings.fwmark;
-        }
         // Disables the Nagle algorithm on the TCP socket. Improves performance
         tcp_options.nodelay = true;
 

--- a/tunnel-obfuscation/src/udp2tcp.rs
+++ b/tunnel-obfuscation/src/udp2tcp.rs
@@ -105,11 +105,6 @@ impl Obfuscator for Udp2Tcp {
             .map_err(crate::Error::RunUdp2TcpObfuscator)
     }
 
-    #[cfg(target_os = "android")]
-    fn remote_socket_fd(&self) -> std::os::unix::io::RawFd {
-        self.instance.remote_tcp_fd()
-    }
-
     fn packet_overhead(&self) -> u16 {
         let max_tcp_header_len = 60; // https://datatracker.ietf.org/doc/html/rfc9293#section-3.1-6.22.1
         let udp_header_len = 8; // https://datatracker.ietf.org/doc/html/rfc768

--- a/tunnel-obfuscation/src/udp2tcp.rs
+++ b/tunnel-obfuscation/src/udp2tcp.rs
@@ -1,7 +1,7 @@
 use crate::Obfuscator;
 use async_trait::async_trait;
 use std::{net::SocketAddr, sync::Arc};
-use talpid_net::bypass::{BypassGuard, SocketBypass};
+use talpid_net::bypass::{BypassGuard, BypassSocket, SocketBypass};
 use udp_over_tcp::{
     TcpOptions,
     udp2tcp::{self, Udp2Tcp as Udp2TcpImpl},
@@ -64,7 +64,7 @@ impl Udp2Tcp {
                 // SAFETY: The fd is a valid socket and valid for the lifetime of instance
                 let fd = unsafe { BorrowedFd::borrow_raw(instance.remote_tcp_fd()) };
 
-                let _bypass = BypassGuard::new(bypass, &fd).map_err(crate::Error::Bypass)?;
+                let _bypass = BypassSocket::new(bypass, &fd).map_err(crate::Error::Bypass)?.guard;
             }
             windows => {
                 use std::os::windows::io::BorrowedSocket;
@@ -72,7 +72,7 @@ impl Udp2Tcp {
                 // SAFETY: This is a valid socket and valid for the lifetime of instance
                 let sock = unsafe { BorrowedSocket::borrow_raw(instance.remote_tcp_socket()) };
 
-                let _bypass = BypassGuard::new(bypass, &sock).map_err(crate::Error::Bypass)?;
+                let _bypass = BypassSocket::new(bypass, &sock).map_err(crate::Error::Bypass)?.guard;
             }
             _ => unimplemented!("unsupported OS")
         }

--- a/tunnel-obfuscation/src/udp2tcp.rs
+++ b/tunnel-obfuscation/src/udp2tcp.rs
@@ -1,6 +1,7 @@
 use crate::Obfuscator;
 use async_trait::async_trait;
-use std::net::SocketAddr;
+use std::{net::SocketAddr, sync::Arc};
+use talpid_net::bypass::{BypassGuard, SocketBypass};
 use udp_over_tcp::{
     TcpOptions,
     udp2tcp::{self, Udp2Tcp as Udp2TcpImpl},
@@ -12,8 +13,6 @@ pub struct Settings {
     #[cfg(target_os = "linux")]
     pub fwmark: Option<u32>,
 }
-
-type Result<T> = std::result::Result<T, Error>;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -33,10 +32,14 @@ pub enum Error {
 pub struct Udp2Tcp {
     local_addr: SocketAddr,
     instance: Udp2TcpImpl,
+    _bypass: BypassGuard,
 }
 
 impl Udp2Tcp {
-    pub(crate) async fn new(settings: &Settings) -> Result<Self> {
+    pub(crate) async fn new(
+        bypass: Arc<dyn SocketBypass>,
+        settings: &Settings,
+    ) -> crate::Result<Self> {
         let listen_addr = if settings.peer.is_ipv4() {
             SocketAddr::new("127.0.0.1".parse().unwrap(), 0)
         } else {
@@ -53,14 +56,37 @@ impl Udp2Tcp {
 
         let instance = Udp2TcpImpl::new(listen_addr, settings.peer, tcp_options)
             .await
-            .map_err(Error::CreateObfuscator)?;
+            .map_err(Error::CreateObfuscator)
+            .map_err(crate::Error::CreateUdp2TcpObfuscator)?;
         let local_addr = instance
             .local_udp_addr()
-            .map_err(Error::GetUdpSocketDetails)?;
+            .map_err(Error::GetUdpSocketDetails)
+            .map_err(crate::Error::CreateUdp2TcpObfuscator)?;
+
+        cfg_select! {
+            unix => {
+                use std::os::fd::BorrowedFd;
+
+                // SAFETY: The fd is a valid socket and valid for the lifetime of instance
+                let fd = unsafe { BorrowedFd::borrow_raw(instance.remote_tcp_fd()) };
+
+                let _bypass = BypassGuard::new(bypass, &fd).map_err(crate::Error::Bypass)?;
+            }
+            windows => {
+                use std::os::windows::io::BorrowedSocket;
+
+                // SAFETY: This is a valid socket and valid for the lifetime of instance
+                let sock = unsafe { BorrowedSocket::borrow_raw(instance.remote_tcp_socket()) };
+
+                let _bypass = BypassGuard::new(bypass, &sock).map_err(crate::Error::Bypass)?;
+            }
+            _ => unimplemented!("unsupported OS")
+        }
 
         Ok(Self {
             local_addr,
             instance,
+            _bypass,
         })
     }
 }


### PR DESCRIPTION
Add a `SocketBypass` trait to support socket-level split tunneling. The PR implements it only on Android (using `VpnService.bypass(fd)`) and on Linux (using `fwmark`), so it's really just a refactor of `tunnel-obfuscation`.

### What this is for

The main use case is for running multiple obfuscators (i.e. the `multiplexer` obfuscator) and closing the holes when we're done with them.

It should also be possible to use this to simplify split tunneling for API access methods in `mullvad-daemon`, i.e. by getting rid of `allowed_endpoint` in `FirewallPolicy`. But it is currently not exposed on `TunnelCommand`.

### Future PRs

I believe we could implement `SocketBypass` on Windows and macOS by adding temporary firewall rules (and maybe routes) that allow outgoing traffic to `(socket.local_addr(), transport_protocol[, destination])` outside the tunnel.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10790)
<!-- Reviewable:end -->
