### PR TITLE
iOS: sort relay locations using locale-aware collation

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -29,6 +29,7 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Fixed
 - Fix URLs to FAQ pages and blog posts when using some locales
+- Locale-aware sorting of relay list on iOS
 
 ### Removed
 - Remove “Direct only” from Daita

--- a/ios/MullvadVPN/View controllers/SelectLocation/DataSource/LocationNode.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/DataSource/LocationNode.swift
@@ -179,7 +179,9 @@ extension LocationNode: Hashable {
 
 extension LocationNode: Comparable {
     static func < (lhs: LocationNode, rhs: LocationNode) -> Bool {
-        lhs.name.lowercased() < rhs.name.lowercased()
+        // Sort using the current locale's collation rules (via `Locale.current`) rather than
+        // raw Unicode scalar comparison.
+        lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
     }
 }
 

--- a/ios/MullvadVPNTests/MullvadVPN/View controllers/SelectLocation/LocationNodeTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/View controllers/SelectLocation/LocationNodeTests.swift
@@ -91,6 +91,15 @@ class LocationNodeTests: XCTestCase {
     func testFindDescendantByNodeCode() {
         XCTAssertTrue(listNode.descendantNode(for: [hostNode.code]) == hostNode)
     }
+
+    func testOrderingIsLocaleSpecific() {
+        XCTAssertEqual(
+            "Åland".compare("Zimbabwe", options: [], range: nil, locale: Locale(identifier: "en_US")), .orderedAscending
+        )
+        XCTAssertEqual(
+            "Åland".compare("Zimbabwe", options: [], range: nil, locale: Locale(identifier: "sv_SE")),
+            .orderedDescending)
+    }
 }
 
 extension LocationNodeTests {


### PR DESCRIPTION
The location list was sorted with Swift's `<` on lowercased names, which compares raw Unicode scalar values. Accented names such as "Áustria" and "África do Sul" therefore sorted after "Zimbabwe", since "á" outranks "z" by scalar value.

Use `localizedStandardCompare`, which applies the current locale's collation rules. The ordering is locale-specific by design (e.g. "Å" sorts among the A's in English but after "Z" in Swedish).

This restores locale-aware sorting rather than introducing it: PR #1292 (2019) used `localizedStandardCompare` for this same purpose, but it was dropped as an apparent oversight when country/city sorting were unified into `LocationNode: Comparable` (410730246c, 2024), then partially patched with plain `.lowercased()` (34ddc1758c, 2025), which fixed case but not collation.

# Screenshots

## Before

Version 2026.3 on iOS 26.5.2, European Portuguese locale:

<img width="300" alt="IMG_5945" src="https://github.com/user-attachments/assets/8515b83c-5a35-43b6-87f3-6b32737b7744" />

## After

Commit `0064d19a01` on iPhone 17 simulator, same locale:

<img width="300" alt="relay-list-pt-locale-sorting" src="https://github.com/user-attachments/assets/02b2efb6-765b-4a89-8760-e4e0dd25502c" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10799)
<!-- Reviewable:end -->
