### PR TITLE
Set gitattributes to `-text` on files embedded verbatim into binaries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,13 @@
 
 # Use LF for Rust because rustfmt works best like that
 *.rs text eol=lf
+
+# Files embedded verbatim into binaries via include_bytes!/include_str! or the
+# Windows resource compiler (*.manifest, via winresource::set_manifest_file).
+# Must have their line endings (LF vs CRLF) untouched. If they are different
+# that breaks reproducible builds.
+# `-text` disables EOL conversion so every checkout embeds
+# identical bytes regardless of platform or core.autocrlf.
+mullvad-api/le_root_cert.pem -text
+mullvad-update/trusted-metadata-signing-pubkeys -text
+*.manifest -text


### PR DESCRIPTION
Needed for reproducible builds. If the line endings differ between builds, the resulting binaries will also differ. We need to make git not mess with the content of these files. Only relevant on Windows since it's the only platform that mess with line endings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10802)
<!-- Reviewable:end -->
