### PR TITLE
Decouple Rust version used by Dockerfile from rust-toolchain.toml

### DIFF
--- a/building/Dockerfile
+++ b/building/Dockerfile
@@ -48,7 +48,7 @@ RUN dpkg --add-architecture arm64 && apt-get update -y && apt-get install -y \
 
 # === Rust ===
 
-ARG RUST_VERSION=stable
+ARG RUST_VERSION=1.97.1
 
 # Install the Rust toolchain for both x86_64-unknown-linux-gnu and aarch64-unknown-linux-gnu,
 # plus x86_64-pc-windows-gnu for Windows cross-compilation/linting

--- a/building/build-and-publish-container-image.sh
+++ b/building/build-and-publish-container-image.sh
@@ -35,11 +35,8 @@ case ${1-:""} in
 esac
 full_container_name="$REGISTRY_HOST/$REGISTRY_ORG/$container_name"
 
-RUST_VERSION=$(rg -o "channel = \"(.*)\"" -r '$1' "$REPO_DIR/rust-toolchain.toml")
-
 log_header "Building $full_container_name tagged as '$tag' and 'latest'"
 podman build -f "$containerfile_path" "$container_context_dir" --no-cache \
-    --build-arg="RUST_VERSION=$RUST_VERSION" \
     -t "$full_container_name:$tag" \
     -t "$full_container_name:latest"
 


### PR DESCRIPTION
See the commit message for a rationale.

This also updates the version used by the Dockerfile to 1.97.1.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10803)
<!-- Reviewable:end -->
