### PR TITLE
Reproducible builds: rustc remap path prefix for desktop

### DIFF
--- a/BuildInstructions.md
+++ b/BuildInstructions.md
@@ -190,6 +190,13 @@ Building this requires at least 1GB of memory.
 
 - `--daemon-only` - This will build daemon only Linux packages (e.g. `mullvad-vpn-daemon`). You will need to install additional build tools: `cargo install cargo-deb cargo-generate-rpm`.
 
+## Notes on environment variables
+
+- `MULLVAD_DISABLE_PATH_REMAPPING` - Set to anything but `0` to stop the build from replacing the
+  machine specific file paths that rustc embeds in the binaries with fixed values. The replacement
+  is required for the build to be reproducible, but it prevents debuggers and backtraces from
+  locating the sources, so turn it off when debugging.
+
 ## Notes on targeting ARM64
 
 ### macOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Line wrap the file at 100 chars.                                              Th
 - Old `mullvad log set-level` command has been renamed to `mullvad log set-rust-log`.
 - Update `gotatun` to 0.8.1.
 - Remove `mullvad tunnel set daita-direct-only` command. Superseded by automatic multihop setting.
+- Stop embedding absolute machine-specific paths in the desktop Rust binaries. Required for
+  reproducible builds.
 
 #### Linux
 - Make all timestamps embedded in `.deb` and `.rpm` packages deterministic by deriving them from

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -334,10 +334,9 @@ cargo {
     extraCargoBuildArguments = buildList {
         add("--package=mullvad-jni")
         add("--locked")
-    }
-
-    if (getBooleanProperty("mullvad.app.build.replaceRustPathPrefix")) {
-        environmentalOverrides["RUSTFLAGS"] = generateRemapArguments()
+        if (getBooleanProperty("mullvad.app.build.replaceRustPathPrefix")) {
+            add(generateRemapArguments())
+        }
     }
 }
 

--- a/build-windows-modules.sh
+++ b/build-windows-modules.sh
@@ -137,7 +137,12 @@ function get_solution_output_path {
 }
 
 function build_nsis_plugins {
-    cargo build --release --target i686-pc-windows-msvc -p mullvad-nsis
+    # Shipped in the installer, so they need the same path remapping as the
+    # other Rust binaries.
+    local remap_path_prefix_arg
+    remap_path_prefix_arg=$("$SCRIPT_DIR/building/rustc-remap-path-prefix.sh")
+
+    cargo build --release --target i686-pc-windows-msvc -p mullvad-nsis "$remap_path_prefix_arg"
 }
 
 function clean_all {

--- a/build.sh
+++ b/build.sh
@@ -76,6 +76,9 @@ export SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-$(git log -1 --pretty=%ct)}
 CARGO_ARGS=()
 NPM_PACK_ARGS=()
 
+# Replace the machine specific paths rustc embeds in the binaries.
+CARGO_ARGS+=("$("$SCRIPT_DIR/building/rustc-remap-path-prefix.sh")")
+
 if [[ -n ${TARGETS:-""} ]]; then
     NPM_PACK_ARGS+=(--targets "${TARGETS[*]}")
 fi

--- a/building/cargo-with-path-remapping.sh
+++ b/building/cargo-with-path-remapping.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Runs cargo with the path remapping argument added.
+#
+# Exists for the npm scripts building the native node modules, which cannot
+# obtain the argument themselves since npm runs them through cmd.exe on
+# Windows, where command substitution is unavailable.
+#
+# Usage: building/cargo-with-path-remapping.sh build --release --target <triple>
+
+set -eu
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Assigned first because `set -e` does not catch a failing command substitution
+# used directly as an argument.
+remap_path_prefix_arg=$("$SCRIPT_DIR/rustc-remap-path-prefix.sh")
+
+exec cargo "$@" "$remap_path_prefix_arg"

--- a/building/rustc-remap-path-prefix.sh
+++ b/building/rustc-remap-path-prefix.sh
@@ -1,23 +1,70 @@
 #!/usr/bin/env bash
 
-# Returns the rustc `--remap-path-prefix` flags needed to replace file paths
-# that gets put in the build artifacts with fixed values in order to make
-# the build reproducible across different machines.
+# Returns a cargo argument that makes rustc replace the machine specific file
+# paths it would otherwise record in the build artifacts with fixed values.
+# Required for reproducible builds, where the same source has to build into
+# the same bytes no matter who builds it or where.
+#
+# A `--config` argument rather than RUSTFLAGS, because RUSTFLAGS replaces the
+# rustflags from `.cargo/config.toml` while `--config` is merged with them.
+#
+# Setting MULLVAD_DISABLE_PATH_REMAPPING to anything but 0 returns an argument
+# that remaps nothing. Remapped paths keep debuggers and backtraces from
+# finding the sources.
 
 set -eu
 
+# Emits a cargo `--config` argument setting rustflags to its arguments.
+#
+# `cfg(all())` matches every target, and cargo joins the rustflags of all
+# matching target sections, so one argument covers them all and adds to what
+# `.cargo/config.toml` sets rather than replacing it. No arguments is a no-op.
+#
+# cargo parses --config as TOML, so each flag becomes a TOML basic string, in
+# which backslash and double quote have to be escaped.
+function emit_config {
+    local toml=""
+    for flag in "$@"; do
+        local escaped=${flag//\\/\\\\}     # backslashes, which Windows paths are full of
+        escaped=${escaped//\"/\\\"}        # double quotes, which Unix paths may contain
+        toml+="${toml:+,}\"$escaped\""
+    done
+    printf -- '--config=target."cfg(all())".rustflags=[%s]\n' "$toml"
+}
+
+if [[ ${MULLVAD_DISABLE_PATH_REMAPPING:-0} != "0" ]]; then
+    emit_config
+    exit 0
+fi
+
+# `pwd -P` because cargo resolves symlinks in the paths it records.
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd -P )"
+
 CARGO_HOME_PATH=${CARGO_HOME:-$HOME/.cargo}
 RUSTUP_HOME_PATH=${RUSTUP_HOME:-$HOME/.rustup}
-SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 CARGO_TARGET_DIR_PATH=${CARGO_TARGET_DIR:-$SOURCE_DIR/target}
+
+# cygpath converts Git-Bash style paths ("/c/Users/...") into native Windows
+# paths ("C:\Users\..."). rustc matches the prefixes as plain text against the
+# native Windows paths.
+case "$(uname -s)" in
+    MINGW*|MSYS_NT*)
+        CARGO_HOME_PATH=$(cygpath -w "$CARGO_HOME_PATH")
+        RUSTUP_HOME_PATH=$(cygpath -w "$RUSTUP_HOME_PATH")
+        SOURCE_DIR=$(cygpath -w "$SOURCE_DIR")
+        CARGO_TARGET_DIR_PATH=$(cygpath -w "$CARGO_TARGET_DIR_PATH")
+        ;;
+esac
 
 # The order is significant. Iterated over in reverse, so last argument is
 # treated as most significant. Since CARGO_TARGET_DIR_PATH might be located
 # under $SOURCE_DIR, it's important to keep it last.
 # See: https://github.com/rust-lang/rust/blob/55459598c250d985eb5f840306dfb59f267c03b6/compiler/rustc_span/src/source_map.rs#L1125-L1127
-echo "\
---remap-path-prefix $CARGO_HOME_PATH=/CARGO_HOME \
---remap-path-prefix $RUSTUP_HOME_PATH=/RUSTUP_HOME \
---remap-path-prefix $SOURCE_DIR=/SOURCE_DIR \
---remap-path-prefix $CARGO_TARGET_DIR_PATH=/CARGO_TARGET_DIR \
-" | xargs
+remap_flags=(
+    "--remap-path-prefix=$CARGO_HOME_PATH=/CARGO_HOME"
+    "--remap-path-prefix=$RUSTUP_HOME_PATH=/RUSTUP_HOME"
+    "--remap-path-prefix=$SOURCE_DIR=/SOURCE_DIR"
+    "--remap-path-prefix=$CARGO_TARGET_DIR_PATH=/CARGO_TARGET_DIR"
+)
+
+emit_config "${remap_flags[@]}"

--- a/code-owners.json
+++ b/code-owners.json
@@ -1,6 +1,7 @@
 {
   "appteam-desktop": [
     ".github/workflows/rust-min-publish-age.yml",
+    "building/cargo-with-path-remapping.sh",
     "building/Dockerfile",
     "building/linux-container-image.txt",
     "building/sigstore/mullvad/mullvadvpn-app-build@**",

--- a/desktop/packages/nseventforwarder/package.json
+++ b/desktop/packages/nseventforwarder/package.json
@@ -8,7 +8,7 @@
   "main": "./lib/index.cjs",
   "module": "./lib/index.mjs",
   "scripts": {
-    "cargo-build": "npm run build-typescript && cargo build",
+    "cargo-build": "npm run build-typescript && bash ../../../building/cargo-with-path-remapping.sh build",
     "build-typescript": "tsc",
     "build-debug": "npm run cargo-build && mkdir -p debug && cp ${CARGO_TARGET_DIR:-../../../target}/debug/libnseventforwarder.dylib debug/index.node",
     "build-arm": "npm run cargo-build -- --release --locked --target aarch64-apple-darwin && mkdir -p dist/darwin-arm64 && cp ${CARGO_TARGET_DIR:-../../../target}/aarch64-apple-darwin/release/libnseventforwarder.dylib dist/darwin-arm64/index.node",

--- a/desktop/packages/windows-utils/package.json
+++ b/desktop/packages/windows-utils/package.json
@@ -8,7 +8,7 @@
   "main": "./lib/index.cjs",
   "module": "./lib/index.mjs",
   "scripts": {
-    "cargo-build": "npm run build-typescript && cargo build",
+    "cargo-build": "npm run build-typescript && bash ../../../building/cargo-with-path-remapping.sh build",
     "build-debug": "npm run cargo-build && bash -c \"(test -d debug || mkdir debug) && cp ../../../target/debug/windows_utils.dll debug/index.node\"",
     "build-arm": "npm run cargo-build -- --release --target aarch64-pc-windows-msvc && bash -c \"(test -d dist || mkdir dist) && (test -d dist/win32-arm64-msvc || mkdir dist/win32-arm64-msvc) && cp ../../../target/aarch64-pc-windows-msvc/release/windows_utils.dll dist/win32-arm64-msvc/index.node\"",
     "build-typescript": "tsc",


### PR DESCRIPTION
Rustc embeds absolute paths to various things in the binaries. This can be prevented with the `--remap-path-prefix` flag to rustc, telling it to remap certain paths to leave out the absolute prefix that is specific to that machine.

Android already has done this for quite some time (they are already reproducible). This builds on their work and extends this functionality to desktop builds. The existing `building/rustc-remap-path-prefix.sh` script is extended to work on desktop as well.

The script was written for the Android build and set the flags through `RUSTFLAGS`. That variable replaces the rustflags from `.cargo/config.toml` rather than merging with them, which on Windows would drop the linker arguments set there. Emit a `--config` argument instead, which cargo merges, keyed on `cfg(all())` so that it covers every target.

Regarding `MULLVAD_DISABLE_PATH_REMAPPING`. I'm not sure how many developers rely on running debuggers in a way that require these absolute paths to be intact. I'm open to feedback about if having path remapping on by default and opt-out is too intrusive. We could potentially turn it around and require opting in to path remapping.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10804)
<!-- Reviewable:end -->
