### PR TITLE
Reject prefixed version strings

### DIFF
--- a/mullvad-version/src/lib.rs
+++ b/mullvad-version/src/lib.rs
@@ -132,7 +132,7 @@ impl Display for Version {
 static VERSION_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r"(?x)                                     # enable insignificant whitespace mode
-                (?<year>\d{4})\.                   # the year
+                ^(?<year>\d{4})\.                  # the year
                 (?<incremental>[1-9]\d?)           # the incrementing version number
                 (?:                                # (optional) alpha or beta or dev
                   -alpha(?<alpha>[1-9]\d?\d?)|
@@ -416,6 +416,7 @@ mod tests {
     fn test_returns_error_on_invalid_version() {
         assert!("2021".parse::<Version>().is_err());
         assert!("not-a-version".parse::<Version>().is_err());
+        assert!("prefix2025.1".parse::<Version>().is_err());
         assert!("".parse::<Version>().is_err());
     }
 


### PR DESCRIPTION
## what

Require version strings to match from the first character and add regression coverage for prefixed versions

Fixes #10782

## why

`VERSION_REGEX` was only anchored at the end, so inputs like `prefix2025.1` were parsed as `2025.1`

## testing

- `ci/cargo-ci.sh test -p mullvad-version --no-default-features`
- `ci/cargo-ci.sh test -p mullvad-version --all-features`
- `ci/cargo-ci.sh clippy -p mullvad-version --all-targets --no-default-features`
- `ci/cargo-ci.sh clippy -p mullvad-version --all-targets --all-features`
- `ci/cargo-ci.sh doc -p mullvad-version --document-private-items --no-deps`
- verified `prefix2025.1` is rejected while `2025.1` still produces `25019000`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10808)
<!-- Reviewable:end -->
