### PR TITLE
Fix issue where user could select entry when "when needed" multihop was active

### DIFF
--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/select-location/SelectLocationViewContext.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/select-location/SelectLocationViewContext.tsx
@@ -55,7 +55,7 @@ export function SelectLocationViewProvider({ children }: SelectLocationViewProvi
   const { multihop } = useMultihop();
 
   const locationType = React.useMemo(() => {
-    const allowEntryLocations = multihop !== 'never';
+    const allowEntryLocations = multihop === 'always';
     if (allowEntryLocations) {
       return locationTypeSelector;
     }

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/select-location/components/header-menu/HeaderMenu.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/select-location/components/header-menu/HeaderMenu.tsx
@@ -19,26 +19,29 @@ export function HeaderMenu({ onOpenChange, ...props }: HeaderMenuProps) {
   const [disableRecentsDialogOpen, setDisableRecentsDialogOpen] = React.useState(false);
 
   const openDisableRecentsDialog = React.useCallback(() => {
-    setDisableRecentsDialogOpen(true);
     onOpenChange?.(false);
+    setDisableRecentsDialogOpen(true);
   }, [onOpenChange]);
 
   const enableRecents = React.useCallback(async () => {
-    await setEnabledRecents(true);
     onOpenChange?.(false);
+    await setEnabledRecents(true);
   }, [onOpenChange, setEnabledRecents]);
 
-  const handleMultihopAlways = useCallback(
-    () => setMultihop({ multihop: 'always' }),
-    [setMultihop],
-  );
+  const handleMultihopAlways = useCallback(async () => {
+    onOpenChange?.(false);
+    await setMultihop({ multihop: 'always' });
+  }, [onOpenChange, setMultihop]);
 
-  const handleMultihopNever = useCallback(() => setMultihop({ multihop: 'never' }), [setMultihop]);
+  const handleMultihopNever = useCallback(async () => {
+    onOpenChange?.(false);
+    await setMultihop({ multihop: 'never' });
+  }, [onOpenChange, setMultihop]);
 
-  const handleMultihopWhenNeeded = useCallback(
-    () => setMultihop({ multihop: 'when-needed' }),
-    [setMultihop],
-  );
+  const handleMultihopWhenNeeded = useCallback(async () => {
+    onOpenChange?.(false);
+    await setMultihop({ multihop: 'when-needed' });
+  }, [onOpenChange, setMultihop]);
 
   return (
     <>

--- a/desktop/packages/mullvad-vpn/src/renderer/features/locations/components/disable-recents-dialog/DisableRecentsDialog.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/features/locations/components/disable-recents-dialog/DisableRecentsDialog.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
 import { messages } from '../../../../../shared/gettext';
-import { Dialog, type DialogProps } from '../../../../lib/components/dialog';
+import { StatusDialog, type StatusDialogProps } from '../../../../components/status-dialog';
 import { useRecents } from '../../hooks';
 
-export type DisableRecentsDialogProps = Omit<DialogProps, 'children'>;
+export type DisableRecentsDialogProps = Omit<StatusDialogProps, 'variant'>;
 
 export function DisableRecentsDialog({ onOpenChange, ...props }: DisableRecentsDialogProps) {
   const { setEnabledRecents } = useRecents();
@@ -19,25 +19,18 @@ export function DisableRecentsDialog({ onOpenChange, ...props }: DisableRecentsD
   }, [onOpenChange]);
 
   return (
-    <Dialog onOpenChange={onOpenChange} {...props}>
-      <Dialog.Portal>
-        <Dialog.Popup>
-          <Dialog.PopupContent>
-            <Dialog.Icon icon="info-circle" />
-            <Dialog.Text>
-              {messages.pgettext('locations-feature', 'Disabling recents will also clear history.')}
-            </Dialog.Text>
-            <Dialog.ButtonGroup>
-              <Dialog.Button variant="destructive" onClick={disableRecents}>
-                <Dialog.Button.Text>{messages.gettext('Disable')}</Dialog.Button.Text>
-              </Dialog.Button>
-              <Dialog.Button key="cancel" onClick={handleCancel}>
-                <Dialog.Button.Text>{messages.gettext('Cancel')}</Dialog.Button.Text>
-              </Dialog.Button>
-            </Dialog.ButtonGroup>
-          </Dialog.PopupContent>
-        </Dialog.Popup>
-      </Dialog.Portal>
-    </Dialog>
+    <StatusDialog variant="info" onOpenChange={onOpenChange} {...props}>
+      <StatusDialog.Text>
+        {messages.pgettext('locations-feature', 'Disabling recents will also clear history.')}
+      </StatusDialog.Text>
+      <StatusDialog.ButtonGroup>
+        <StatusDialog.Button variant="destructive" onClick={disableRecents}>
+          <StatusDialog.Button.Text>{messages.gettext('Disable')}</StatusDialog.Button.Text>
+        </StatusDialog.Button>
+        <StatusDialog.Button key="cancel" onClick={handleCancel}>
+          <StatusDialog.Button.Text>{messages.gettext('Cancel')}</StatusDialog.Button.Text>
+        </StatusDialog.Button>
+      </StatusDialog.ButtonGroup>
+    </StatusDialog>
   );
 }

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/dialog/components/dialog-popup-content/DialogPopupContent.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/dialog/components/dialog-popup-content/DialogPopupContent.tsx
@@ -10,6 +10,8 @@ const StyledDialogContainer = styled(Alert)`
   > ${StyledAlertIcon}:first-child {
     margin-top: ${spacings.small};
   }
+
+  flex: 1;
 `;
 export function DialogPopupContent(props: DialogPopupContentProps) {
   return <StyledDialogContainer {...props} />;


### PR DESCRIPTION
- Fixes an issue where user could select entry when "when needed" multihop was active.
- Fixes a visual bug where the recents dialog content was not centered.
- Updates multihop menu to close before performing the selected action.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10809)
<!-- Reviewable:end -->
