### PR TITLE
Make it possible to focus on the reveal input button on TV devices

### DIFF
--- a/android/lib/feature/login/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/login/impl/LoginScreen.kt
+++ b/android/lib/feature/login/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/login/impl/LoginScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.autofill.ContentType
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.layout.AlignmentLine
 import androidx.compose.ui.layout.FirstBaseline
 import androidx.compose.ui.layout.layout
@@ -353,15 +354,18 @@ private fun ColumnScope.LoginInput(
     LaunchedEffect(accountState) {
         snapshotFlow { accountState.text.toString() }.collectLatest { onAccountNumberChange(it) }
     }
-    LaunchedEffect(accountState) {}
+    val revealInputRequester = remember { FocusRequester() }
+    val inputRequester = remember { FocusRequester() }
     TextField(
         modifier =
             // Fix for DPad navigation
             Modifier.semantics { contentType = ContentType.Password }
                 .focusProperties {
-                    left = FocusRequester.Cancel
-                    right = FocusRequester.Cancel
+                    start = FocusRequester.Cancel
+                    // So that it is possible to use the reveal input button with DPad navigation.
+                    end = revealInputRequester
                 }
+                .focusRequester(inputRequester)
                 .fillMaxWidth()
                 .testTag(LOGIN_INPUT_TEST_TAG)
                 .let {
@@ -389,7 +393,13 @@ private fun ColumnScope.LoginInput(
             if (state.loginState is LoginState.Idle) {
                 {
                     IconButton(
-                        modifier = Modifier.testTag(LOGIN_REVEAL_INPUT_BUTTON_TEST_TAG),
+                        modifier =
+                            Modifier.focusRequester(revealInputRequester)
+                                .focusProperties {
+                                    start = inputRequester
+                                    end = FocusRequester.Cancel
+                                }
+                                .testTag(LOGIN_REVEAL_INPUT_BUTTON_TEST_TAG),
                         onClick = { showPassword = !showPassword },
                     ) {
                         Icon(


### PR DESCRIPTION
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10812)
<!-- Reviewable:end -->
