### PR TITLE
Fix link declaration in modulemap

### DIFF
--- a/ios/MullvadRustRuntime/module.private.modulemap
+++ b/ios/MullvadRustRuntime/module.private.modulemap
@@ -1,6 +1,6 @@
 framework module MullvadRustRuntimeProxy {
    header "mullvad_rust_runtime.h"
    header "mullvad_gotatunFFI.h"
-   link "libmullvad_ios"
+   link "mullvad_ios"
    export *
 }

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -588,8 +588,8 @@
 		7A6811542DC8EC6E009CB61A /* UIFont+Weight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ABE318C2A1CDD4500DF4963 /* UIFont+Weight.swift */; };
 		7A6AA3AB2EC5C8FB00F1C80C /* StoreSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A2F41082EC38FC00013D3C5 /* StoreSubscription.swift */; };
 		7A6B4F592AB8412E00123853 /* TunnelMonitorTimings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6B4F582AB8412E00123853 /* TunnelMonitorTimings.swift */; };
-		7A6B968C2FEC0F3B00DBF9BD /* StaticButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6B968B2FEC0F3500DBF9BD /* StaticButtonStyle.swift */; };
 		7A6B968A2FEC01EC00DBF9BD /* View+TypeErase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6B96892FEC01E100DBF9BD /* View+TypeErase.swift */; };
+		7A6B968C2FEC0F3B00DBF9BD /* StaticButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6B968B2FEC0F3500DBF9BD /* StaticButtonStyle.swift */; };
 		7A6D6BA62F7D477A001EA05C /* AutomaticLocationListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6D6BA52F7D4773001EA05C /* AutomaticLocationListItem.swift */; };
 		7A6F2FA52AFA3CB2006D0856 /* AccountExpiryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6F2FA42AFA3CB2006D0856 /* AccountExpiryTests.swift */; };
 		7A6F2FA72AFBB9AE006D0856 /* AccountExpiry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6F2FA62AFBB9AE006D0856 /* AccountExpiry.swift */; };
@@ -954,7 +954,6 @@
 		A9C342C12ACC37E30045F00E /* TunnelStatusBlockObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E0317D2ACC32920095D843 /* TunnelStatusBlockObserver.swift */; };
 		A9C342C32ACC3EE90045F00E /* RelayCacheTracker+Stubs.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C342C22ACC3EE90045F00E /* RelayCacheTracker+Stubs.swift */; };
 		A9C7B62C2EB9F71D002CABB1 /* LoggerBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C7B62B2EB9F71D002CABB1 /* LoggerBuilderTests.swift */; };
-		A9D4A4792C2DAB5F00F1E522 /* libmullvad_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A9C75BC12C2D8C9E00B4CDF5 /* libmullvad_ios.a */; };
 		A9D9A4B22C36D12D004088DD /* TunnelObfuscator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584023212A406BF5007B27AC /* TunnelObfuscator.swift */; };
 		A9D9A4BB2C36D397004088DD /* EphemeralPeerNegotiator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EB4F9C2B7FAB21002A2D7A /* EphemeralPeerNegotiator.swift */; };
 		A9D9A4C42C36D53C004088DD /* MullvadRustRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A992DA1D2C24709F00DE7CE5 /* MullvadRustRuntime.framework */; };
@@ -2304,8 +2303,8 @@
 		7A6389F72B864CDF008E77E1 /* LocationNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationNode.swift; sourceTree = "<group>"; };
 		7A6652B62BB44B120042D848 /* LocationDiffableDataSourceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDiffableDataSourceProtocol.swift; sourceTree = "<group>"; };
 		7A6B4F582AB8412E00123853 /* TunnelMonitorTimings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelMonitorTimings.swift; sourceTree = "<group>"; };
-		7A6B968B2FEC0F3500DBF9BD /* StaticButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticButtonStyle.swift; sourceTree = "<group>"; };
 		7A6B96892FEC01E100DBF9BD /* View+TypeErase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+TypeErase.swift"; sourceTree = "<group>"; };
+		7A6B968B2FEC0F3500DBF9BD /* StaticButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticButtonStyle.swift; sourceTree = "<group>"; };
 		7A6D6BA52F7D4773001EA05C /* AutomaticLocationListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticLocationListItem.swift; sourceTree = "<group>"; };
 		7A6F2FA42AFA3CB2006D0856 /* AccountExpiryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountExpiryTests.swift; sourceTree = "<group>"; };
 		7A6F2FA62AFBB9AE006D0856 /* AccountExpiry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountExpiry.swift; sourceTree = "<group>"; };
@@ -3006,7 +3005,6 @@
 				A9173C372C36CD2B00F6A08C /* MullvadTypes.framework in Frameworks */,
 				44A262672D63745C00085380 /* WireGuardKitTypes in Frameworks */,
 				0107F42D2F5F62950012451B /* MullvadSettings.framework in Frameworks */,
-				A9D4A4792C2DAB5F00F1E522 /* libmullvad_ios.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Linking against `mullvad-ios` fails when updating Rust to 1.97.1 (https://github.com/mullvad/mullvadvpn-app/pull/10797). The `lib-` prefix is prepended automatically to whatever is specified in the modulemap, and removing it fixes it.

(I don't know why this worked previously, and for some reason it's only affecting symbols in `device.rs`.)

```
Ld /Users/<me>/Library/Developer/Xcode/DerivedData/MullvadVPN-azbxbugtjzuntqfienfznmjasjhn/Build/Products/Debug-iphonesimulator/MullvadREST.framework/MullvadREST normal (in target 'MullvadREST' from project 'MullvadVPN')
    cd /Users/<me>/mullvadvpn-app/ios
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -Xlinker -reproducible -target arm64-apple-ios17.0-simulator -dynamiclib -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.2.sdk -O0 -L/Users/<me>/Library/Developer/Xcode/DerivedData/MullvadVPN-azbxbugtjzuntqfienfznmjasjhn/Build/Intermediates.noindex/EagerLinkingTBDs/Debug-iphonesimulator -L/Users/<me>/Library/Developer/Xcode/DerivedData/MullvadVPN-azbxbugtjzuntqfienfznmjasjhn/Build/Products/Debug-iphonesimulator -L/Users/<me>/mullvadvpn-app/target/aarch64-apple-ios-sim/debug -F/Users/<me>/Library/Developer/Xcode/DerivedData/MullvadVPN-azbxbugtjzuntqfienfznmjasjhn/Build/Intermediates.noindex/EagerLinkingTBDs/Debug-iphonesimulator -F/Users/<me>/Library/Developer/Xcode/DerivedData/MullvadVPN-azbxbugtjzuntqfienfznmjasjhn/Build/Products/Debug-iphonesimulator/PackageFrameworks -F/Users/<me>/Library/Developer/Xcode/DerivedData/MullvadVPN-azbxbugtjzuntqfienfznmjasjhn/Build/Products/Debug-iphonesimulator/PackageFrameworks -F/Users/<me>/Library/Developer/Xcode/DerivedData/MullvadVPN-azbxbugtjzuntqfienfznmjasjhn/Build/Products/Debug-iphonesimulator/PackageFrameworks -F/Users/<me>/Library/Developer/Xcode/DerivedData/MullvadVPN-azbxbugtjzuntqfienfznmjasjhn/Build/Products/Debug-iphonesimulator -filelist /Users/<me>/Library/Developer/Xcode/DerivedData/MullvadVPN-azbxbugtjzuntqfienfznmjasjhn/Build/Intermediates.noindex/MullvadVPN.build/Debug-iphonesimulator/MullvadREST.build/Objects-normal/arm64/MullvadREST.LinkFileList -install_name @rpath/MullvadREST.framework/MullvadREST -Xlinker -rpath -Xlinker /usr/lib/swift -Xlinker -rpath -Xlinker /Users/<me>/Library/Developer/Xcode/DerivedData/MullvadVPN-azbxbugtjzuntqfienfznmjasjhn/Build/Products/Debug-iphonesimulator/PackageFrameworks -Xlinker -rpath -Xlinker @executable_path/Frameworks -Xlinker -rpath -Xlinker @loader_path/Frameworks -dead_strip -Xlinker -object_path_lto -Xlinker /Users/<me>/Library/Developer/Xcode/DerivedData/MullvadVPN-azbxbugtjzuntqfienfznmjasjhn/Build/Intermediates.noindex/MullvadVPN.build/Debug-iphonesimulator/MullvadREST.build/Objects-normal/arm64/MullvadREST_lto.o -rdynamic -Xlinker -no_deduplicate -Xlinker -objc_abi_version -Xlinker 2 -Xlinker -debug_variant -Xlinker -dependency_info -Xlinker /Users/<me>/Library/Developer/Xcode/DerivedData/MullvadVPN-azbxbugtjzuntqfienfznmjasjhn/Build/Intermediates.noindex/MullvadVPN.build/Debug-iphonesimulator/MullvadREST.build/Objects-normal/arm64/MullvadREST_dependency_info.dat -fapplication-extension -fprofile-instr-generate -fobjc-link-runtime -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator -L/usr/lib/swift -Xlinker -add_ast_path -Xlinker /Users/<me>/Library/Developer/Xcode/DerivedData/MullvadVPN-azbxbugtjzuntqfienfznmjasjhn/Build/Intermediates.noindex/MullvadVPN.build/Debug-iphonesimulator/MullvadREST.build/Objects-normal/arm64/MullvadREST.swiftmodule @/Users/<me>/Library/Developer/Xcode/DerivedData/MullvadVPN-azbxbugtjzuntqfienfznmjasjhn/Build/Intermediates.noindex/MullvadVPN.build/Debug-iphonesimulator/MullvadREST.build/Objects-normal/arm64/MullvadREST-linker-args.resp -Wl,-no_warn_duplicate_libraries -Wl,-no_warn_duplicate_libraries -Wl,-no_warn_duplicate_libraries -framework MullvadSettings -framework Operations -framework MullvadLogging -framework MullvadTypes -framework MullvadRustRuntime /Users/<me>/Library/Developer/Xcode/DerivedData/MullvadVPN-azbxbugtjzuntqfienfznmjasjhn/Build/Products/Debug-iphonesimulator/PackageFrameworks/WireGuardKitTypes.framework/WireGuardKitTypes -Xlinker -no_adhoc_codesign -compatibility_version 1 -current_version 4 -o /Users/<me>/Library/Developer/Xcode/DerivedData/MullvadVPN-azbxbugtjzuntqfienfznmjasjhn/Build/Products/Debug-iphonesimulator/MullvadREST.framework/MullvadREST

ld: warning: Could not find or use auto-linked library 'libmullvad_ios': library 'libmullvad_ios' not found
ld: warning: Could not find or use auto-linked framework 'UIUtilities': framework 'UIUtilities' not found
ld: warning: Could not parse or use implicit file '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/Frameworks/SwiftUICore.framework/SwiftUICore.tbd': cannot link directly with 'SwiftUICore' because product being built is not an allowed client of it
Undefined symbols for architecture arm64:
  "_mullvad_ios_create_device", referenced from:
      closure #1 (((MullvadRustRuntime.MullvadApiResponse) throws -> ())?) throws -> MullvadRustRuntime.MullvadApiCancellable in MullvadREST.MullvadApiRequestFactory.makeRequest(MullvadREST.APIRequest) -> (((MullvadRustRuntime.MullvadApiResponse) throws -> ())?) throws -> MullvadRustRuntime.MullvadApiCancellable in MullvadApiRequestFactory.o
  "_mullvad_ios_delete_device", referenced from:
      closure #1 (((MullvadRustRuntime.MullvadApiResponse) throws -> ())?) throws -> MullvadRustRuntime.MullvadApiCancellable in MullvadREST.MullvadApiRequestFactory.makeRequest(MullvadREST.APIRequest) -> (((MullvadRustRuntime.MullvadApiResponse) throws -> ())?) throws -> MullvadRustRuntime.MullvadApiCancellable in MullvadApiRequestFactory.o
  "_mullvad_ios_get_device", referenced from:
      closure #1 (((MullvadRustRuntime.MullvadApiResponse) throws -> ())?) throws -> MullvadRustRuntime.MullvadApiCancellable in MullvadREST.MullvadApiRequestFactory.makeRequest(MullvadREST.APIRequest) -> (((MullvadRustRuntime.MullvadApiResponse) throws -> ())?) throws -> MullvadRustRuntime.MullvadApiCancellable in MullvadApiRequestFactory.o
  "_mullvad_ios_get_devices", referenced from:
      closure #1 (((MullvadRustRuntime.MullvadApiResponse) throws -> ())?) throws -> MullvadRustRuntime.MullvadApiCancellable in MullvadREST.MullvadApiRequestFactory.makeRequest(MullvadREST.APIRequest) -> (((MullvadRustRuntime.MullvadApiResponse) throws -> ())?) throws -> MullvadRustRuntime.MullvadApiCancellable in MullvadApiRequestFactory.o
  "_mullvad_ios_rotate_device_key", referenced from:
      closure #1 (((MullvadRustRuntime.MullvadApiResponse) throws -> ())?) throws -> MullvadRustRuntime.MullvadApiCancellable in MullvadREST.MullvadApiRequestFactory.makeRequest(MullvadREST.APIRequest) -> (((MullvadRustRuntime.MullvadApiResponse) throws -> ())?) throws -> MullvadRustRuntime.MullvadApiCancellable in MullvadApiRequestFactory.o
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)

Could not find or use auto-linked library 'libmullvad_ios': library 'libmullvad_ios' not found

Could not find or use auto-linked framework 'UIUtilities': framework 'UIUtilities' not found

Could not parse or use implicit file '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/Frameworks/SwiftUICore.framework/SwiftUICore.tbd': cannot link directly with 'SwiftUICore' because product being built is not an allowed client of it

Undefined symbol: _mullvad_ios_create_device

Undefined symbol: _mullvad_ios_delete_device

Undefined symbol: _mullvad_ios_get_device

Undefined symbol: _mullvad_ios_get_devices

Undefined symbol: _mullvad_ios_rotate_device_key

Linker command failed with exit code 1 (use -v to see invocation)
```

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10813)
<!-- Reviewable:end -->
