### PR TITLE
Increase update default location flag test stability

### DIFF
--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/DefaultLocationTest.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/DefaultLocationTest.kt
@@ -1,6 +1,10 @@
 package net.mullvad.mullvadvpn.test.e2e
 
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.Until
 import java.io.File
+import net.mullvad.mullvadvpn.lib.ui.tag.LOGIN_TITLE_TEST_TAG
+import net.mullvad.mullvadvpn.test.common.constant.LONG_TIMEOUT
 import net.mullvad.mullvadvpn.test.common.page.ConnectPage
 import net.mullvad.mullvadvpn.test.common.page.LoginPage
 import net.mullvad.mullvadvpn.test.common.page.on
@@ -24,6 +28,8 @@ class DefaultLocationTest : EndToEndTest() {
         on<LoginPage> {
             enterAccountNumber(accountTestRule.validAccountNumber)
             clickLoginButton()
+            val isGone = uiDevice.wait(Until.gone(By.res(LOGIN_TITLE_TEST_TAG)), LONG_TIMEOUT)
+            assert(isGone)
         }
 
         on<ConnectPage>()


### PR DESCRIPTION
Due to the `testUpdateDefaultLocationFlag` test not using the `launchAndLogIn` helper function it previously had a very short timeout when waiting for the app to login. Since this test can not use the `launchAndLogIn` function the longer timeout used in that function was added to the test directly.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10817)
<!-- Reviewable:end -->
