### PR TITLE
Use `build.warnings` (`CARGO_BUILD_WARNINGS`) instead of `RUSTFLAGS` to deny CI warnings

### DIFF
--- a/ci/cargo-ci.sh
+++ b/ci/cargo-ci.sh
@@ -2,12 +2,12 @@
 
 set -eux
 
-# Hard deny on all warnings when running in CI
-export RUSTFLAGS="--deny warnings"
+# Hard deny on all warnings when running in CI. Covers rustc, clippy and rustdoc
+# lints in local packages.
+export CARGO_BUILD_WARNINGS=deny
 
-# Deny broken docstrings when running in CI
 # Allow private-intra-doc-links, since they are still useful in editor,
 # and we're not publishing these crates on docs.rs anyway.
-export RUSTDOCFLAGS="--deny warnings --allow rustdoc::private-intra-doc-links"
+export RUSTDOCFLAGS="--allow rustdoc::private-intra-doc-links"
 
 exec cargo --locked --color=always "$@"


### PR DESCRIPTION
`RUSTFLAGS` and the `target.*.rustflags` keys in `.cargo/config.toml` are mutually exclusive, so setting `RUSTFLAGS` here silently dropped `-Ctarget-feature=+crt-static` and the reproducible-build link args from Windows target builds in CI. `build.warnings` is a separate config channel and leaves those intact.

It also does not change the rustc fingerprint, so different builds can can share a build cache more. Hopefully this cause a bit less recompilation overall in some situations.

Overall avoiding to use `RUSTFLAGS` seems like a good idea to me, since it has quite a few downsides.

Requires cargo 1.97+. Covers rustc, clippy and rustdoc lints.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10822)
<!-- Reviewable:end -->
