### PR TITLE
Restructure MullvadButton view hierarchy to disambiguate accessibility

### DIFF
--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ButtonPanel.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ButtonPanel.swift
@@ -43,9 +43,9 @@ extension ConnectionView {
             MullvadButton(
                 text: viewModel.localizedTitleForSelectLocationButton,
                 style: .primary,
+                mainAccessibilityIdentifier: .selectLocationButton,
                 trailingAccessory: reloadButton,
             ) { action?(.selectLocation) }
-            .accessibilityIdentifier(AccessibilityIdentifier.selectLocationButton.asString)
         }
 
         @ViewBuilder
@@ -55,16 +55,16 @@ extension ConnectionView {
                 MullvadButton(
                     text: LocalizedStringKey("Connect"),
                     style: .success,
+                    mainAccessibilityIdentifier: .connectButton,
                     action: { action?(.connect) }
                 )
-                .accessibilityIdentifier(AccessibilityIdentifier.connectButton.asString)
             case .disconnect:
                 MullvadButton(
                     text: LocalizedStringKey("Disconnect"),
                     style: .destructive,
+                    mainAccessibilityIdentifier: .disconnectButton,
                     action: { action?(.disconnect) }
                 )
-                .accessibilityIdentifier(AccessibilityIdentifier.disconnectButton.asString)
             case .cancel:
                 MullvadButton(
                     text: LocalizedStringKey(
@@ -73,12 +73,9 @@ extension ConnectionView {
                             : "Cancel"
                     ),
                     style: .destructive,
+                    mainAccessibilityIdentifier: viewModel.tunnelStatus.state == .waitingForConnectivity(.noConnection)
+                        ? .disconnectButton : .cancelButton,
                     action: { action?(.cancel) }
-                )
-                .accessibilityIdentifier(
-                    viewModel.tunnelStatus.state == .waitingForConnectivity(.noConnection)
-                        ? AccessibilityIdentifier.disconnectButton.asString
-                        : AccessibilityIdentifier.cancelButton.asString
                 )
             }
         }

--- a/ios/MullvadVPN/Views/MullvadButton.swift
+++ b/ios/MullvadVPN/Views/MullvadButton.swift
@@ -56,6 +56,8 @@ struct MullvadButton: View {
     var text: LocalizedStringKey
     /// The style to present this button in
     var style: Style
+    /// the accessibility identifier for the main button.
+    var mainAccessibilityIdentifier: AccessibilityIdentifier?
     /// An optional accessory to present on the leading edge of the button
     var leadingAccessory: Accessory?
     /// An optional accessory to present on the trailing edge of the button
@@ -67,59 +69,50 @@ struct MullvadButton: View {
     @State private var leadingAccessorySize: CGSize = .zero
     @State private var trailingAccessorySize: CGSize = .zero
     private let imageHeight: CGFloat = 24.0
+    @Environment(\.isEnabled) private var isEnabled: Bool
 
     var body: some View {
-        Button(
-            action: action,
-            label: {
-                ZStack {
-                    HStack {
-                        Text(text)
-                            .lineLimit(nil)
-                            .multilineTextAlignment(.center)
-                            .if(leadingAccessory != nil || trailingAccessory != nil) { view in
-                                // Reserve space for image if present
-                                view.padding(.horizontal, imageHeight)
+        ZStack {
+            Button(
+                action: action,
+                label: {
+                    ZStack {
+                        HStack {
+                            Spacer()
+                            Text(text)
+                                .lineLimit(nil)
+                                .multilineTextAlignment(.center)
+                            Spacer()
+                        }
+                        .if(leadingAccessory != nil || trailingAccessory != nil) { view in
+                            // Reserve space for image if present
+                            view.padding(.horizontal, imageHeight)
+                        }
+                    }
+                    .sizeOfView {
+                        mainAreaHeight = $0.height
+                    }
+                }
+            )
+            .accessibilityIdentifier(mainAccessibilityIdentifier)
+            .buttonStyle(MullvadButton.ButtonStyle(style: style))
+            HStack {
+                if let leadingAccessory {
+                    accessory(leadingAccessory, position: .leading)
+                        .buttonStyle(MullvadButton.ButtonStyle(style: style))
+                        .sizeOfView { leadingAccessorySize = $0 }
+                }
+                Spacer()
+                if let trailingAccessory {
+                    accessory(trailingAccessory, position: .trailing)
+                        .buttonStyle(MullvadButton.ButtonStyle(style: style))
+                        .sizeOfView { trailingAccessorySize = $0 }
+                }
+            }
 
-                            }
-                    }
-                    HStack {
-                        if let leadingAccessory {
-                            accessory(leadingAccessory, position: .leading)
-                                .sizeOfView { leadingAccessorySize = $0 }
-                        }
-                        Spacer()
-                        if let trailingAccessory {
-                            accessory(trailingAccessory, position: .trailing)
-                                .sizeOfView { trailingAccessorySize = $0 }
-                        }
-                    }
-                }
-                .sizeOfView {
-                    mainAreaHeight = $0.height
-                }
-            }
-        ).buttonStyle(MullvadButton.ButtonStyle(style: style))
-            .clipShape(Capsule())
-            .accessibilityRepresentation {
-                HStack {
-                    leadingAccessory.map { self.accessory($0, position: .leading) }
-                    Button(
-                        action: action,
-                        label: {
-                            HStack {
-                                Spacer()
-                                Text(text)
-                                    .lineLimit(nil)
-                                    .multilineTextAlignment(.center)
-                                Spacer()
-                            }
-                        }
-                    ).buttonStyle(MullvadButton.ButtonStyle(style: style))
-                        .clipShape(Capsule())
-                    trailingAccessory.map { self.accessory($0, position: .trailing) }
-                }
-            }
+        }
+        .background(style.backgroundColor(for: .normal))
+        .clipShape(Capsule())
     }
 
     @ViewBuilder
@@ -131,6 +124,11 @@ struct MullvadButton: View {
                 .resizable()
                 .scaledToFit()
                 .padding(10)
+                .foregroundStyle(
+                    isEnabled
+                        ? Color.mullvadTextPrimary
+                        : Color.mullvadTextPrimaryDisabled
+                )
                 .frame(
                     width: min(max(mainAreaHeight, 44), 60), height: max(mainAreaHeight, 44)
                 )
@@ -151,15 +149,17 @@ struct MullvadButton: View {
             .ifLet(accessibilityLabel) { $0.accessibilityLabel($1) }
             .ifLet(accessibilityHint) { $0.accessibilityHint($1) }
             .ifLet(accessibilityId) { $0.accessibilityIdentifier($1.asString) }
-            .buttonStyle(MullvadButton.ButtonStyle(style: style, isAccessory: true))
+            .buttonStyle(MullvadButton.ButtonStyle(style: style, accessoryPosition: position))
             .overlay {
-                HStack {
-                    if position == .trailing {
-                        VStack { Spacer() }.frame(width: 1).background { Color.mullvadBackground }
-                    }
-                    Spacer()
-                    if position == .leading {
-                        VStack { Spacer() }.frame(width: 1).background { Color.mullvadBackground }
+                if style.rank == .primary {
+                    HStack {
+                        if position == .trailing {
+                            VStack { Spacer() }.frame(width: 1).background { Color.mullvadBackground }
+                        }
+                        Spacer()
+                        if position == .leading {
+                            VStack { Spacer() }.frame(width: 1).background { Color.mullvadBackground }
+                        }
                     }
                 }
 

--- a/ios/MullvadVPN/Views/MullvadButtonStyle.swift
+++ b/ios/MullvadVPN/Views/MullvadButtonStyle.swift
@@ -14,11 +14,17 @@ extension MullvadButton {
 
         var style: Style
 
-        var isAccessory: Bool = false
+        var accessoryPosition: TextAlignment? = nil
 
         @Environment(\.isEnabled) private var isEnabled: Bool
 
         func makeBody(configuration: Configuration) -> some View {
+            let borderInset: CGFloat = accessoryPosition != nil ? 0 : 0
+            let backgroundInsets = EdgeInsets(
+                top: borderInset,
+                leading: (accessoryPosition == .trailing) ? -100 : borderInset,
+                bottom: borderInset,
+                trailing: (accessoryPosition == .leading) ? -100 : borderInset)
             return configuration.label
                 .frame(minHeight: 44)
                 .foregroundStyle(
@@ -29,14 +35,14 @@ extension MullvadButton {
                 .background(
                     style.backgroundColor(for: .init(isEnabled: isEnabled, isPressed: configuration.isPressed))
                 )
-                .if(!isAccessory) { view in
-                    view.overlay {
-                        Capsule()
-                            .stroke(
-                                style.borderColor(for: .init(isEnabled: isEnabled, isPressed: configuration.isPressed)),
-                                lineWidth: 2)
-                    }
-
+                .overlay {
+                    Capsule()
+                        .stroke(
+                            style.borderColor(for: .init(isEnabled: isEnabled, isPressed: configuration.isPressed)),
+                            lineWidth: 2
+                        )
+                        .padding(backgroundInsets)
+                        .clipped()
                 }
                 .font(.body.weight(.semibold))
         }

--- a/ios/MullvadVPN/Views/MullvadButtonStyle.swift
+++ b/ios/MullvadVPN/Views/MullvadButtonStyle.swift
@@ -22,9 +22,9 @@ extension MullvadButton {
             let borderInset: CGFloat = accessoryPosition != nil ? 0 : 0
             let backgroundInsets = EdgeInsets(
                 top: borderInset,
-                leading: (accessoryPosition == .trailing) ? -100 : borderInset,
+                leading: (accessoryPosition == .trailing) ? -.infinity : borderInset,
                 bottom: borderInset,
-                trailing: (accessoryPosition == .leading) ? -100 : borderInset)
+                trailing: (accessoryPosition == .leading) ? -.infinity : borderInset)
             return configuration.label
                 .frame(minHeight: 44)
                 .foregroundStyle(


### PR DESCRIPTION
The replacement of SplitMainButton with MullvadButton introduced a regression: as accessory buttons were contained within the main button, this interfered with UI tests' ability to distinguish them by accessibility ID. 
MullvadButton has now been restructured, with the button elements being separate. This complicates the logic behind making them render as one button, but plays more nicely with UI automation, and also renders redundant the separate `accessibilityRepresentation` (which has now been deleted).
Also, the MullvadButton preview strings which somehow made their way into an earlier PR are now deleted from the strings file.
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10824)
<!-- Reviewable:end -->
