### PR TITLE
Build installer-downloader with a cargo profile instead of `RUSTFLAGS`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,6 +209,16 @@ quinn-proto.opt-level = 3
 quinn-udp.opt-level = 3
 ring.opt-level = 3
 
+# The installer-downloader is a standalone binary users download directly, so it is
+# optimized for size harder than the rest of the workspace. Used by
+# `installer-downloader/build.sh`. Profiles can only be set for the entire workspace,
+# which is why this lives here and not in `installer-downloader/Cargo.toml`.
+[profile.installer-downloader]
+inherits = "release"
+opt-level = "z"
+panic = "abort"
+codegen-units = 1
+
 [profile.release-debuginfo]
 inherits = "release"
 debug = true

--- a/installer-downloader/build.sh
+++ b/installer-downloader/build.sh
@@ -2,19 +2,15 @@
 
 # This script is used to build, and optionally sign, the downloader, always in release mode.
 
-# This script performs the equivalent of the following profile:
-#
-# [profile.release]
-# strip = true
-# opt-level = 'z'
-# codegen-units = 1
-# lto = true
-# panic = 'abort'
-#
-# We cannot set all of the above directly in Cargo.toml since some must be set for the entire
-# workspace.
+# The build settings live in the `installer-downloader` cargo profile, defined in the
+# workspace root Cargo.toml. Do not set RUSTFLAGS here: RUSTFLAGS and the
+# `target.*.rustflags` keys in `.cargo/config.toml` are mutually exclusive.
 
 set -eu
+
+# Cargo profile to build with. Also the name of the target subdirectory cargo puts the
+# resulting binaries in.
+CARGO_PROFILE="installer-downloader"
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR"
@@ -121,13 +117,7 @@ function build_executable {
     # Old bash versions complain about empty array expansion when -u is set
     set +u
 
-    local rustflags="-C codegen-units=1 -C panic=abort -C strip=symbols -C opt-level=z"
-
-    if [[ -z "$1" && "$(uname -s)" == "MINGW"* ]] || [[ $1 == *"windows"* ]]; then
-        rustflags+=" -Ctarget-feature=+crt-static"
-    fi
-
-    RUSTFLAGS="$rustflags" cargo build --bin installer-downloader --release "${target_args[@]}"
+    cargo build --bin installer-downloader --profile "$CARGO_PROFILE" "${target_args[@]}"
 
     set -u
 }
@@ -141,13 +131,13 @@ function lipo_executables {
 
     case $HOST in
         x86_64-apple-darwin) target_exes=(
-            "$CARGO_TARGET_DIR/release/installer-downloader"
-            "$CARGO_TARGET_DIR/aarch64-apple-darwin/release/installer-downloader"
+            "$CARGO_TARGET_DIR/$CARGO_PROFILE/installer-downloader"
+            "$CARGO_TARGET_DIR/aarch64-apple-darwin/$CARGO_PROFILE/installer-downloader"
         )
         ;;
         aarch64-apple-darwin) target_exes=(
-            "$CARGO_TARGET_DIR/release/installer-downloader"
-            "$CARGO_TARGET_DIR/x86_64-apple-darwin/release/installer-downloader"
+            "$CARGO_TARGET_DIR/$CARGO_PROFILE/installer-downloader"
+            "$CARGO_TARGET_DIR/x86_64-apple-darwin/$CARGO_PROFILE/installer-downloader"
         )
         ;;
     esac
@@ -313,7 +303,7 @@ function sign_win {
 
 # Copy executable and optionally sign it.
 function dist_windows_app {
-    cp "$CARGO_TARGET_DIR/release/installer-downloader.exe" "$BUILD_DIR/$FILENAME.exe"
+    cp "$CARGO_TARGET_DIR/$CARGO_PROFILE/installer-downloader.exe" "$BUILD_DIR/$FILENAME.exe"
     if [[ "$SIGN" != "false" ]]; then
         sign_win "$BUILD_DIR/$FILENAME.exe"
     fi


### PR DESCRIPTION
`RUSTFLAGS` and the `target.*.rustflags` keys in `.cargo/config.toml` are mutually exclusive, so setting `RUSTFLAGS` here dropped the config's Windows rustflags.

Move the settings that can be expressed as a profile into a new `installer-downloader` profile in the workspace root Cargo.toml, and drop RUSTFLAGS entirely. `.cargo/config.toml` is now the only place that sets rustflags, so all three Windows flags apply again. `strip` and `lto` come from the inherited `release` profile.

Binaries now land in `target/installer-downloader/` instead of `target/release/`.

This brings in the `/Brepro /PDBALTPATH:%_PDB%` linker args to the Windows installer downloader builds and is a step towards reproducible builds for the installer downloader.

I have tried this change on Windows. I have not tried it on macOS, simply because `installer-downloader/build.sh` fails for me even on main.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10825)
<!-- Reviewable:end -->
