### PR TITLE
Reproducible builds: Enable `trim-paths` on nightly rust and add companion build script

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,4 @@
+[unstable]
 # Supply-chain hardening: refuse dependency versions published within the cooldown
 # window set below, giving malicious releases time to be caught before we
 # depend on them.
@@ -6,8 +7,14 @@
 # via ci/check-rust-min-publish-age.py, which reads global-min-publish-age from here
 # as the single source of truth.
 # Tracking issue: https://github.com/rust-lang/cargo/issues/17009
-[unstable]
 min-publish-age = true
+
+# Makes rustc record fixed file paths instead of machine specific ones into built
+# binaries. Required for reproducible builds. Nightly-only, and
+# ignored by stable cargo, so it does nothing in the builds we ship.
+# Use this with building/reproducible-build.sh.
+# Tracking issue: https://github.com/rust-lang/cargo/issues/12137
+trim-paths = true
 
 [registry]
 global-min-publish-age = "7 days"

--- a/building/reproducible-build.sh
+++ b/building/reproducible-build.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Overrides the Rust toolchain in rust-toolchain.toml with a pinned nightly toolchain,
+# and runs build.sh, passing on the arguments given here.
+#
+# Unstable `trim-paths` keep machine specific paths out of the Rust binaries.
+
+set -eu
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
+
+# An exact nightly rather than plain "nightly", so that everyone rebuilding a given commit
+# uses the same compiler. Bumping it changes the bytes that come out.
+# Takes precedence over rust-toolchain.toml, and is inherited by the cargo invocations we
+# do not make ourselves: npm's native module builds, MSBuild and cargo-deb.
+# https://rust-lang.github.io/rustup/overrides.html
+export RUSTUP_TOOLCHAIN="nightly-2026-07-27"
+
+echo "Building with $RUSTUP_TOOLCHAIN for reproducibility. Not a release build."
+
+exec "$REPO_DIR/build.sh" "$@"

--- a/code-owners.json
+++ b/code-owners.json
@@ -3,6 +3,7 @@
     ".github/workflows/rust-min-publish-age.yml",
     "building/Dockerfile",
     "building/linux-container-image.txt",
+    "building/reproducible-build.sh",
     "building/sigstore/mullvad/mullvadvpn-app-build@**",
     "building/sigstore/mullvad/mullvadvpn-app-build-node-grpc-bindings@**",
     "ci/buildserver-build.sh",


### PR DESCRIPTION
This PR enables the nightly-only feature `trim-paths` (Tracking issue: https://github.com/rust-lang/cargo/issues/12137). This is a cargo-native way of getting rid of absolute paths from the build machine getting injected into the produced binaries. This is a much cleaner and simpler way to achieve what #10804 is trying to do with `--remap-path-prefix`. Only downside is that it's nightly only.

My idea here about why we supersede #10804 with this nightly-only solution is that...
1) We don't need to deliver fully reproducible builds over night. It's fine if it's a bit experimental and require a custom way to build for now. And ...
2) By using the built in native feature, we can provide feedback upstream and maybe help `trim-paths` get stabilized sooner, which would really help both us and everyone else. Using `--remap-path-prefix` is really dirty, and I would love to avoid it. The problem mainly is that our build process calls `cargo build` in many layers and from many places. So correctly wiring up `--remap-path-prefix` everywhere is dirty and error prone.

The accompanying script, `building/reproducible-build.sh`, serves two purposes. The first is to pin to a specific version of nightly, that is checked in to git. This is required to actually get reproducible results. The second is to provide some discovery entry point for reproducible builds. I expect this script to maybe grow later if there are more quirks needed to build everything reproducibly.

When building with the new `building/reproducible-build.sh` script, all our Rust binaries now come out bit identical on both Windows and Linux for me, when I built it on the same machine but in different checkouts (different paths, which is what `trim-paths` is all about). The DEB file is reproducible for me, but the RPM is not. The problem with the RPM is because of mtimes on files. I will attempt to solve that in a separate PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10829)
<!-- Reviewable:end -->
