### PR TITLE
Fix trailing slash issue with fdroid

### DIFF
--- a/ci/android/build-server/fdroid.sh
+++ b/ci/android/build-server/fdroid.sh
@@ -120,7 +120,9 @@ function update_and_deploy {
     YUBIKEY_PIN=$YUBIKEY_PIN \
     YUBIKEY_PATH=$(readlink -f /dev/android-jks-signing-key) \
     "$BUILD_DIR/android/scripts/containerized-sign.sh" "$repo_dir" \
-        "JAVA_TOOL_OPTIONS='$java_opts' fdroid update && fdroid deploy"
+        "JAVA_TOOL_OPTIONS='$java_opts' fdroid update && \
+     sed -i 's|<base href=\"index.html\">|<base href=\"/fdroid/repo/\">|' repo/index.html && \
+     fdroid deploy"
 }
 
 main "$@"


### PR DESCRIPTION
When the fdroid tool generates the index.html file it sets a base path `<base href="index.html">`. This means that links to images and other resources gets broken if the path is `https://fdroid.devmole.eu/fdroid/repo` due to it looking for the resources under `/fdroid/` instead of `/fdroid/repo/`.

By changing it to `<base href=\"/fdroid/repo/\">` instead it will now always look for resources under `/fdroid/repo/`.

This was considered as an alternative solution as redirecting `https://fdroid.devmole.eu/fdroid/repo` to `https://fdroid.devmole.eu/fdroid/repo/` breaks rclone.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10830)
<!-- Reviewable:end -->
