### PR TITLE
Reproducible builds: Normalize modification times of everything we package

### DIFF
--- a/BuildInstructions.md
+++ b/BuildInstructions.md
@@ -46,7 +46,7 @@ on your platform please submit an issue or a pull request.
 
 - **`bash` must be installed and available in PATH on all platforms**. This is required for building
   the desktop app:
-- Bash version 4.0 or later is required for all platforms and must be added to your PATH environment variable.
+- Bash version 4.2 or later is required for all platforms and must be added to your PATH environment variable.
   - Linux: Bash is typically installed by default, otherwise refer to your distribution for instructions on how to install it.
   - macOS: The default installed version (3.2.5) is not supported. Install a newer version via Homebrew: `brew install bash`
   - Windows: Install [Git for Windows] which includes Git Bash and other required unix utilities.

--- a/build.sh
+++ b/build.sh
@@ -390,6 +390,17 @@ else
     mkdir -p "build"
 fi
 
+# Everything that goes into the installers and packages is in place by now, so give it all one
+# deterministic modification time. The packaging tools record these timestamps, and they would
+# otherwise be whenever this machine happened to compile a binary or check out a file, which
+# differs between builds of the same commit. This is needed for reproducible builds.
+# Some of the packaging tools respect SOURCE_DATE_EPOCH and don't need this. But some don't,
+# and setting the mtime on all artifacts we are going to pack does not hurt.
+log_info "Normalizing modification times of everything to be packaged..."
+# An ISO 8601 timestamp, since that is the only form of `touch` argument both GNU and macOS take
+TZ=UTC printf -v source_date_iso '%(%Y-%m-%dT%H:%M:%SZ)T' "$SOURCE_DATE_EPOCH"
+find dist-assets build -exec touch -h -d "$source_date_iso" {} +
+
 RELAY_LIST_PATH="dist-assets/relays/relays.json"
 if [[ "$IS_RELEASE" == "true" && ! -s "$RELAY_LIST_PATH" ]]; then
     log_error "Release build requires a non-empty $RELAY_LIST_PATH."


### PR DESCRIPTION
This is a follow up to #10765. Not all packaging tools honor `SOURCE_DATE_EPOCH` for all files they package. The packaging tools record the mtime of every file they pack. Those are whenever this machine happened to compile a binary or check out a file, so they differ between builds of the same commit.

fpm stamps the .deb from SOURCE_DATE_EPOCH on its own, but rpmbuild only **lowers** the timestamps that are newer than it. Files checked out from git are usually older than the commit being built, so they reached the .rpm untouched: two builds of the same commit in separate checkouts differed in relays.json and the two systemd units, and nothing else.

Needs bash 4.2 for `printf's %(fmt)T`, up from 4.0. Documented as such. I had newer Bash versions on all my machines, so I hope this is not a problem. But we should check the build servers before merging. We can solve it by calling `date` also, but it's more cumbersome to make that portable between all supported platforms.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10831)
<!-- Reviewable:end -->
