### PR TITLE
Use `assert_matches!` instead of `assert!(matches!(..))`

### DIFF
--- a/mullvad-api/src/abortable_stream.rs
+++ b/mullvad-api/src/abortable_stream.rs
@@ -127,6 +127,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::assert_matches;
     use std::time::Duration;
     use tokio::io::AsyncReadExt;
 
@@ -149,9 +150,7 @@ mod test {
             let result = tokio::time::timeout(Duration::from_secs(1), stream_task)
                 .await
                 .unwrap();
-            assert!(
-                matches!(result, Ok(Err(error)) if error.kind() == io::ErrorKind::ConnectionReset)
-            );
+            assert_matches!(result, Ok(Err(error)) if error.kind() == io::ErrorKind::ConnectionReset);
         });
     }
 

--- a/mullvad-daemon/src/migrations/multihop/mod.rs
+++ b/mullvad-daemon/src/migrations/multihop/mod.rs
@@ -58,6 +58,8 @@ pub(crate) fn version_matches(settings: &Value) -> bool {
 #[cfg(test)]
 /// The setup for each scenario is broken down in [scenario].
 mod test {
+    use std::assert_matches;
+
     use crate::migrations::multihop::settings::v17::SettingsBuilder;
 
     use super::*;
@@ -157,7 +159,7 @@ mod test {
             .filters(true)
             .build();
         let scenario = migration::detect(&settings);
-        assert!(matches!(scenario, Scenario::ThreeB { .. }));
+        assert_matches!(scenario, Scenario::ThreeB { .. });
         let mut settings = json!(settings);
         insta::assert_snapshot!(serde_json::to_string_pretty(&settings)?);
         migration::migrate(&mut settings, scenario);

--- a/mullvad-daemon/src/settings/patch.rs
+++ b/mullvad-daemon/src/settings/patch.rs
@@ -17,6 +17,8 @@
 
 use super::SettingsPersister;
 use mullvad_types::settings::Settings;
+#[cfg(test)]
+use std::assert_matches;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -440,10 +442,10 @@ fn test_overflow() {
     let patch = r#"[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]"#;
     let patch: serde_json::Value = serde_json::from_str(patch).unwrap();
 
-    assert!(matches!(
+    assert_matches!(
         validate_patch_value(PERMITTED_SUBKEYS, &patch, 0),
         Err(Error::RecursionLimit)
-    ));
+    );
 }
 
 /// Test whether valid patches from documentation are accepted by the implementation

--- a/mullvad-daemon/src/version/router.rs
+++ b/mullvad-daemon/src/version/router.rs
@@ -523,6 +523,7 @@ where
     #[cfg(in_app_upgrade)]
     fn cancel_upgrade(&mut self) {
         use mullvad_types::version::AppUpgradeEvent;
+        use std::debug_assert_matches;
 
         match mem::replace(&mut self.state, State::NoVersion) {
             // If we're upgrading, emit an event if a version was received during the upgrade
@@ -546,10 +547,7 @@ where
             state => self.state = state,
         };
 
-        debug_assert!(matches!(
-            self.state,
-            State::HasVersion { .. } | State::NoVersion
-        ));
+        debug_assert_matches!(self.state, State::HasVersion { .. } | State::NoVersion);
     }
 }
 
@@ -647,6 +645,7 @@ fn recommended_version_upgrade(
 
 #[cfg(all(test, in_app_upgrade))]
 mod test {
+    use std::assert_matches;
     use std::time::SystemTime;
 
     use super::downloader::ProgressUpdater;
@@ -872,8 +871,9 @@ mod test {
         let (mut version_router, _channels) = make_version_router::<SuccessfulAppDownloader>();
         let upgrade_events = version_router.app_upgrade_broadcast.subscribe();
         version_router.update_application();
-        assert!(
-            matches!(version_router.state, State::NoVersion),
+        assert_matches!(
+            version_router.state,
+            State::NoVersion,
             "State should stay as NoVersion after calling update_application"
         );
         assert!(
@@ -889,19 +889,21 @@ mod test {
 
         // Test that new beta version is ignored if beta program is off
         version_router.set_beta_program(false); // This is default value, but set it for clarity
-        assert!(
-            matches!(version_router.state, State::NoVersion),
+        assert_matches!(
+            version_router.state,
+            State::NoVersion,
             "State should not transition"
         );
         version_router.on_new_version(version_cache);
-        assert!(matches!(version_router.state, State::HasVersion { .. }));
+        assert_matches!(version_router.state, State::HasVersion { .. });
         assert!(
             channels.version_event_receiver.try_recv().is_err(),
             "No version event should be sent on beta program change"
         );
         version_router.update_application();
-        assert!(
-            matches!(version_router.state, State::HasVersion { .. }),
+        assert_matches!(
+            version_router.state,
+            State::HasVersion { .. },
             "State should not transition to Downloading as the beta version is ignored"
         );
 
@@ -913,8 +915,9 @@ mod test {
             "Version event should be sent on beta program change"
         );
         version_router.update_application();
-        assert!(
-            matches!(version_router.state, State::Downloading { .. }),
+        assert_matches!(
+            version_router.state,
+            State::Downloading { .. },
             "State should transition to Downloading as the beta version is accepted"
         );
     }
@@ -1003,8 +1006,9 @@ mod test {
         }
 
         version_router.update_application();
-        assert!(
-            matches!(version_router.state, State::Downloading { .. }),
+        assert_matches!(
+            version_router.state,
+            State::Downloading { .. },
             "Triggering an update while in the downloading shout be ignored"
         );
 
@@ -1059,14 +1063,16 @@ mod test {
             .expect_err("Channel should not have any messages");
 
         version_router.update_application();
-        assert!(
-            matches!(version_router.state, State::Downloaded { .. }),
+        assert_matches!(
+            version_router.state,
+            State::Downloaded { .. },
             "Triggering an update while in the downloaded shout be ignored"
         );
 
         version_router.cancel_upgrade();
-        assert!(
-            matches!(version_router.state, State::HasVersion { .. }),
+        assert_matches!(
+            version_router.state,
+            State::HasVersion { .. },
             "State should be HasVersion after cancelling the upgrade"
         );
 
@@ -1114,7 +1120,7 @@ mod test {
         let mut app_upgrade_listener = version_router.app_upgrade_broadcast.subscribe();
         version_router.update_application();
         // Check that the state is now downloading
-        assert!(matches!(version_router.state, State::Downloading { .. }),);
+        assert_matches!(version_router.state, State::Downloading { .. });
 
         // Advance the download to the point where we have started downloading
         tokio::time::sleep(DOWNLOAD_DURATION / 2).await;
@@ -1144,7 +1150,7 @@ mod test {
         let mut app_upgrade_listener = version_router.app_upgrade_broadcast.subscribe();
         version_router.update_application();
         // Check that the state is now downloading
-        assert!(matches!(version_router.state, State::Downloading { .. }),);
+        assert_matches!(version_router.state, State::Downloading { .. });
 
         // Drive the download to completion
         assert_eq!(version_router.run_step().await, ControlFlow::Continue(()));
@@ -1177,52 +1183,32 @@ mod test {
         // Start upgrading
         version_router.update_application();
         // Check that the state is now downloading
-        assert!(matches!(version_router.state, State::Downloading { .. }),);
+        assert_matches!(version_router.state, State::Downloading { .. });
 
         // Should remain in downloading state if same version is received
         version_router.on_new_version(version_cache_test.clone());
-        assert!(
-            matches!(version_router.state, State::Downloading { .. }),
-            "state should be Downloading, was {:?}",
-            version_router.state,
-        );
+        assert_matches!(version_router.state, State::Downloading { .. });
 
         // Unless the version is different
         version_cache_test.version_info.stable.version.incremental += 1;
         version_router.on_new_version(version_cache_test.clone());
-        assert!(
-            matches!(version_router.state, State::HasVersion { .. }),
-            "state should be HasVersion, was {:?}",
-            version_router.state,
-        );
+        assert_matches!(version_router.state, State::HasVersion { .. });
 
         // Restart upgrade
         version_router.update_application();
 
         // Drive the download to completion
         assert_eq!(version_router.run_step().await, ControlFlow::Continue(()));
-        assert!(
-            matches!(version_router.state, State::Downloaded { .. }),
-            "state should be Downloaded, was {:?}",
-            version_router.state,
-        );
+        assert_matches!(version_router.state, State::Downloaded { .. });
 
         // Should remain in downloaded state if same version is received
         version_router.on_new_version(version_cache_test.clone());
-        assert!(
-            matches!(version_router.state, State::Downloaded { .. }),
-            "state should be Downloaded, was {:?}",
-            version_router.state,
-        );
+        assert_matches!(version_router.state, State::Downloaded { .. });
 
         // Unless the version is different
         version_cache_test.version_info.stable.version.incremental += 1;
         version_router.on_new_version(version_cache_test.clone());
-        assert!(
-            matches!(version_router.state, State::HasVersion { .. }),
-            "state should be HasVersion, was {:?}",
-            version_router.state,
-        );
+        assert_matches!(version_router.state, State::HasVersion { .. });
     }
 
     #[tokio::test]
@@ -1236,7 +1222,7 @@ mod test {
         let mut app_upgrade_listener = version_router.app_upgrade_broadcast.subscribe();
         version_router.update_application();
         // Check that the state is now downloading
-        assert!(matches!(version_router.state, State::Downloading { .. }),);
+        assert_matches!(version_router.state, State::Downloading { .. });
 
         // Drive the download to completion
         assert_eq!(version_router.run_step().await, ControlFlow::Continue(()));

--- a/mullvad-ios/src/tunnel_adapter/mod.rs
+++ b/mullvad-ios/src/tunnel_adapter/mod.rs
@@ -113,6 +113,7 @@ impl TunnelConfig {
 }
 
 /// Obfuscation configuration for the tunnel.
+#[cfg_attr(test, derive(Debug))]
 pub enum ObfuscationConfig {
     Off,
     UdpOverTcp,
@@ -926,6 +927,7 @@ impl Devices {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
     use std::sync::Mutex;
     use std::sync::atomic::AtomicUsize;
 
@@ -1115,6 +1117,6 @@ mod tests {
         // Non-LWO obfuscation is left untouched.
         let mut off = config();
         IosTunnelAdapter::apply_lwo_ingress_key(&mut off, &pq_singlehop);
-        assert!(matches!(off.obfuscation, ObfuscationConfig::Off));
+        assert_matches!(off.obfuscation, ObfuscationConfig::Off);
     }
 }

--- a/mullvad-relay-selector/tests/relay_selector.rs
+++ b/mullvad-relay-selector/tests/relay_selector.rs
@@ -1,6 +1,7 @@
 //! Tests for verifying that the relay selector works as expected.
 
 use std::{
+    assert_matches,
     collections::HashSet,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
     sync::LazyLock,
@@ -385,13 +386,13 @@ mod relay_selection {
         for _ in 0..100 {
             let query = RelayQueryBuilder::new().multihop().build();
             let relay = relay_selector.get_relay_by_query(query.clone()).unwrap();
-            assert!(matches!(
+            assert_matches!(
                 relay,
                 GetRelay {
                     inner: WireguardConfig::Multihop { .. },
                     ..
                 }
-            ))
+            )
         }
     }
 
@@ -751,11 +752,11 @@ mod relay_selection {
             let Some(obfuscator) = relay.obfuscator else {
                 panic!("Relay selector should have picked an obfuscator")
             };
-            assert!(matches!(
+            assert_matches!(
                 obfuscator,
                 Obfuscators::Single(ObfuscatorConfig::Udp2Tcp { endpoint }) if
-                    TCP2UDP_PORTS.contains(&endpoint.port()),
-            ));
+                    TCP2UDP_PORTS.contains(&endpoint.port())
+            );
         }
     }
 
@@ -797,10 +798,10 @@ mod relay_selection {
 
         // Country-level (default Constraint::Any) query: every relay has
         // include_in_country=false → no relay should be selectable.
-        assert!(matches!(
+        assert_matches!(
             relay_selector.get_relay_by_query(RelayQueryBuilder::new().build()),
             Err(Error::NoRelay(_))
-        ));
+        );
 
         // Hostname-level query targeting an include_in_country=false relay: the
         // explicit, specific choice wins.
@@ -835,9 +836,10 @@ mod relay_selection {
                 .expect("expected match"),
         );
 
-        assert!(
-            matches!(relay.inner, Relay { ref hostname, .. } if hostname == &expected_hostname),
-            "found {relay:?}, expected {expected_hostname:?}",
+        assert_matches!(
+            &relay.inner,
+            Relay { hostname, .. } if hostname == &expected_hostname,
+            "expected {expected_hostname:?}"
         )
     }
 
@@ -1065,10 +1067,10 @@ mod relay_selection {
 
         // Country-level multihop must fail: only one relay (`se-sto-wg-204`) is
         // selectable at country level, so no entry/exit pair can be formed.
-        assert!(matches!(
+        assert_matches!(
             relay_selector.get_relay_by_query(country_query),
             Err(Error::NoRelay(_) | Error::NoRelayEntry(_) | Error::NoRelayExit(_))
-        ));
+        );
 
         // Hostname-level multihop targeting both relays explicitly must succeed.
         relay_selector.get_relay_by_query(hostname_query)?;

--- a/mullvad-update/src/format/deserializer.rs
+++ b/mullvad-update/src/format/deserializer.rs
@@ -132,6 +132,7 @@ pub(super) fn deserialize_and_verify(
 
 #[cfg(test)]
 mod test {
+    use std::assert_matches;
     use std::str::FromStr;
 
     use vec1::vec1;
@@ -211,17 +212,15 @@ mod test {
         let expected_sig = Signature::from_hex(fakesig).unwrap();
 
         // Ed25519 key
-        assert!(
-            matches!(&response.signatures[0], ResponseSignature::Ed25519 { keyid, sig } if keyid == &expected_key && sig == &expected_sig),
-            "unexpected response sig: {:?}",
-            response.signatures[0]
+        assert_matches!(
+            &response.signatures[0],
+            ResponseSignature::Ed25519 { keyid, sig } if keyid == &expected_key && sig == &expected_sig
         );
 
         // Unrecognized key type
-        assert!(
-            matches!(&response.signatures[1], ResponseSignature::Other { keyid, sig } if keyid == "test 1" && sig == "test 2"),
-            "expected unrecognized key: {:?}",
-            response.signatures[1]
+        assert_matches!(
+            &response.signatures[1],
+            ResponseSignature::Other { keyid, sig } if keyid == "test 1" && sig == "test 2"
         );
     }
 }

--- a/mullvad-update/src/format/serializer.rs
+++ b/mullvad-update/src/format/serializer.rs
@@ -71,6 +71,7 @@ fn sign<T: Serialize>(
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::assert_matches;
 
     use serde_json::json;
     use vec1::vec1;
@@ -90,11 +91,9 @@ mod test {
         // Verify that we can deserialize and verify the data
         let partial = sign(&key, &data).context("Signing failed")?;
 
-        assert!(
-            matches!(&partial.signatures[0], ResponseSignature::Ed25519 {
-            keyid,
-            ..
-        } if keyid == &pubkey)
+        assert_matches!(
+            &partial.signatures[0],
+            ResponseSignature::Ed25519 { keyid, .. } if keyid == &pubkey
         );
 
         let bytes = serde_json::to_vec(&partial)?;

--- a/talpid-tunnel-config-client/src/lib.rs
+++ b/talpid-tunnel-config-client/src/lib.rs
@@ -343,6 +343,7 @@ async fn connect_relay_config_client(ip: Ipv4Addr) -> Result<RelayConfigService,
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
 
     fn daita_response(max_padding_frac: f64, max_blocking_frac: f64) -> proto::DaitaResponseV2 {
         proto::DaitaResponseV2 {
@@ -382,7 +383,7 @@ mod tests {
     fn parse_daita_response_if_requested_requires_requested_response() {
         let error = parse_daita_response_if_requested_error(None, true);
 
-        assert!(matches!(error, Error::MissingDaitaResponse));
+        assert_matches!(error, Error::MissingDaitaResponse);
     }
 
     #[test]

--- a/talpid-windows/src/fs.rs
+++ b/talpid-windows/src/fs.rs
@@ -49,6 +49,7 @@ pub fn is_admin_owned<T: AsRawHandle>(handle: T) -> io::Result<bool> {
 
 #[cfg(test)]
 mod test {
+    use std::assert_matches;
     use std::os::windows::fs::OpenOptionsExt;
     use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_BACKUP_SEMANTICS;
 
@@ -59,9 +60,10 @@ mod test {
         // The kernel image is owned by "TrustedInstaller", so we expect the function to return 'false'
         let path = std::fs::File::open(r"C:\Windows\System32\ntoskrnl.exe").unwrap();
         let result = is_admin_owned(path);
-        assert!(
-            matches!(result, Ok(false)),
-            "expected ntoskrnl.exe to be owned by TrustedInstaller (false), got {result:?}"
+        assert_matches!(
+            result,
+            Ok(false),
+            "expected ntoskrnl.exe to be owned by TrustedInstaller"
         );
 
         // The Windows system temp directory is owned by SYSTEM, so we expect 'true'
@@ -71,9 +73,6 @@ mod test {
             .open(r"C:\Windows\Temp")
             .unwrap();
         let result = is_admin_owned(path);
-        assert!(
-            matches!(result, Ok(true)),
-            "expected TEMP to be owned by SYSTEM (true), got {result:?}"
-        );
+        assert_matches!(result, Ok(true), "expected TEMP to be owned by SYSTEM");
     }
 }

--- a/talpid-windows/src/string.rs
+++ b/talpid-windows/src/string.rs
@@ -52,6 +52,7 @@ pub fn multibyte_to_wide(mb_string: &CStr, codepage: u32) -> Result<Vec<u16>, io
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::assert_matches;
     use windows_sys::Win32::Globalization::CP_UTF8;
 
     #[test]
@@ -59,16 +60,10 @@ mod test {
         // € = 0x20AC in UTF-16
         let converted = multibyte_to_wide(c"€€", CP_UTF8);
         const EXPECTED: &[u16] = &[0x20AC, 0x20AC];
-        assert!(
-            matches!(converted.as_deref(), Ok(EXPECTED)),
-            "expected Ok({EXPECTED:?}), got {converted:?}",
-        );
+        assert_matches!(converted.as_deref(), Ok(EXPECTED));
 
         // boundary case
         let converted = multibyte_to_wide(c"", CP_UTF8);
-        assert!(
-            matches!(converted.as_deref(), Ok([])),
-            "unexpected result {converted:?}"
-        );
+        assert_matches!(converted.as_deref(), Ok([]));
     }
 }

--- a/talpid-wireguard/src/mtu_detection.rs
+++ b/talpid-wireguard/src/mtu_detection.rs
@@ -214,6 +214,7 @@ fn mtu_spacing(mtu_min: u16, mtu_max: u16, step_size: u16) -> Vec<u16> {
 mod tests {
     use super::*;
     use proptest::prelude::*;
+    use std::assert_matches;
 
     proptest! {
         #[test]
@@ -333,10 +334,7 @@ mod tests {
             pings.push(err_ping(SurgeError::NetworkError));
 
             let e = max_ping_size(pings).await.unwrap_err();
-            assert!(matches!(
-                e,
-                Error::MtuDetectionUnexpected(SurgeError::NetworkError)
-            ));
+            assert_matches!(e, Error::MtuDetectionUnexpected(SurgeError::NetworkError));
         }
 
         /// An error of type [`SurgeError::Timeout`] signals that the total [`PING_TIMEOUT`] has
@@ -354,7 +352,7 @@ mod tests {
             pings.push(delayed_ping(Ok(100), PING_TIMEOUT + Duration::from_secs(1)));
 
             let e = max_ping_size(pings).await.unwrap_err();
-            assert!(matches!(e, Error::MtuDetectionAllDropped));
+            assert_matches!(e, Error::MtuDetectionAllDropped);
         }
 
         /// In the rare case that [`PING_TIMEOUT`] triggers before [`PING_OFFSET_TIMEOUT`], even
@@ -372,10 +370,10 @@ mod tests {
             ));
 
             let e = max_ping_size(pings).await.unwrap_err();
-            assert!(matches!(
+            assert_matches!(
                 e,
                 Error::MtuDetectionUnexpected(SurgeError::Timeout { seq: _ })
-            ));
+            );
         }
     }
 }

--- a/test/test-manager/src/tests/account.rs
+++ b/test/test-manager/src/tests/account.rs
@@ -8,7 +8,7 @@ use mullvad_types::{
     device::{Device, DeviceState},
     states::TunnelState,
 };
-use std::time::Duration;
+use std::{assert_matches, time::Duration};
 use talpid_types::net::{wireguard, wireguard::PublicKey};
 use test_macro::test_function;
 use test_rpc::ServiceClient;
@@ -75,12 +75,10 @@ pub async fn test_too_many_devices(
     log::info!("Log in with too many devices");
     let login_result = login_with_retries(&mut mullvad_client).await;
 
-    assert!(
-        matches!(
-            login_result,
-            Err(mullvad_management_interface::Error::TooManyDevices)
-        ),
-        "Expected too many devices error, got {login_result:?}"
+    assert_matches!(
+        login_result,
+        Err(mullvad_management_interface::Error::TooManyDevices),
+        "Expected too many devices error"
     );
 
     mullvad_client.logout_account("test-manager").await?;
@@ -161,9 +159,10 @@ pub async fn test_revoked_device(
     // Ensure that the tunnel state transitions to "error". Fail if it transitions to some other
     // state.
     let new_state = next_state.await?;
-    assert!(
-        matches!(&new_state, TunnelState::Error(error_state) if error_state.is_blocking()),
-        "expected blocking error state, got {new_state:?}"
+    assert_matches!(
+        &new_state,
+        TunnelState::Error(error_state) if error_state.is_blocking(),
+        "expected blocking error state"
     );
 
     // Verify that the device state is `Revoked`.
@@ -171,8 +170,9 @@ pub async fn test_revoked_device(
         .get_device()
         .await
         .context("Failed to get device data")?;
-    assert!(
-        matches!(device_state, DeviceState::Revoked),
+    assert_matches!(
+        device_state,
+        DeviceState::Revoked,
         "expected device to be revoked"
     );
 

--- a/test/test-manager/src/tests/helpers.rs
+++ b/test/test-manager/src/tests/helpers.rs
@@ -60,7 +60,7 @@ const CONN_CHECKER_TIMEOUT: Duration = Duration::from_secs(
 macro_rules! assert_tunnel_state {
     ($mullvad_client:expr, $pattern:pat) => {{
         let state = $mullvad_client.get_tunnel_state().await?;
-        assert!(matches!(state, $pattern), "state: {:?}", state);
+        ::std::assert_matches!(state, $pattern);
     }};
 }
 

--- a/test/test-manager/src/tests/tunnel.rs
+++ b/test/test-manager/src/tests/tunnel.rs
@@ -14,6 +14,7 @@ use mullvad_management_interface::MullvadProxyClient;
 use mullvad_relay_selector::query::builder::RelayQueryBuilder;
 use mullvad_types::wireguard;
 use std::{
+    assert_matches,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
     str::FromStr,
 };
@@ -63,7 +64,7 @@ pub async fn test_wireguard_tunnel_ipvx(
 
             let endpoint = connection_result.endpoint().expect("must have endpoint");
             let endpoint = endpoint.entry_endpoint.unwrap_or(endpoint.endpoint);
-            assert!(matches!(endpoint.address.ip(), IpAddr::VX(..)));
+            assert_matches!(endpoint.address.ip(), IpAddr::VX(..));
 
             assert!(
                 helpers::using_mullvad_exit(&rpc).await,

--- a/test/test-manager/src/tests/tunnel_state.rs
+++ b/test/test-manager/src/tests/tunnel_state.rs
@@ -18,7 +18,7 @@ use mullvad_types::{
     relay_constraints::{GeographicLocationConstraint, LocationConstraint},
     states::TunnelState,
 };
-use std::{net::SocketAddr, time::Duration};
+use std::{assert_matches, net::SocketAddr, time::Duration};
 use talpid_types::net::{Endpoint, TransportProtocol, TunnelEndpoint};
 use test_macro::test_function;
 use test_rpc::ServiceClient;
@@ -201,9 +201,10 @@ pub async fn test_connecting_state(
     })
     .await?;
 
-    assert!(
-        matches!(new_state, TunnelState::Connecting { .. }),
-        "failed to enter connecting state: {new_state:?}"
+    assert_matches!(
+        new_state,
+        TunnelState::Connecting { .. },
+        "failed to enter connecting state"
     );
 
     // Leak test


### PR DESCRIPTION
`assert_matches!` was stabilized in Rust 1.96. It reports the actual value alongside the expected pattern on failure, so custom messages that only re-printed the scrutinee with `{:?}` have been dropped.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10832)
<!-- Reviewable:end -->
