### PR TITLE
Reproducible builds: Write the rpm changelog entry with a fixed date

### DIFF
--- a/desktop/packages/mullvad-vpn/tasks/distribution.cjs
+++ b/desktop/packages/mullvad-vpn/tasks/distribution.cjs
@@ -4,6 +4,8 @@ const builder = require('electron-builder');
 const { Arch } = require('electron-builder');
 const { execFileSync } = require('child_process');
 
+const { author } = require('../package.json');
+
 const noCompression = process.argv.includes('--no-compression');
 const shouldNotarize = process.argv.includes('--notarize');
 
@@ -231,6 +233,9 @@ function newConfig() {
         '--rpm-rpmbuild-define=use_source_date_epoch_as_buildtime 1',
         // Set the BUILDHOST header to a fixed value instead of the build machine's hostname
         '--rpm-rpmbuild-define=_buildhost reproducible',
+        // Written by writeRpmChangelog. The entry fpm generates on its own carries the build date
+        '--rpm-changelog',
+        rpmChangelogPath(),
         '--directories=/opt/Mullvad VPN/',
         '--before-install',
         distAssets('linux/before-install.sh'),
@@ -424,6 +429,8 @@ async function packMac() {
 }
 
 function packLinux() {
+  writeRpmChangelog();
+
   const config = newConfig();
 
   if (noCompression) {
@@ -533,6 +540,38 @@ function getLinuxVersion() {
 function productVersion() {
   const args = ['run', '-q', '--bin', 'mullvad-version'];
   return execFileSync('cargo', args, { encoding: 'utf-8' }).trim();
+}
+
+function rpmChangelogPath() {
+  return buildAssets('rpm-changelog');
+}
+
+// fpm dates the rpm %changelog entry it generates from the wall clock. Its deb output honors
+// SOURCE_DATE_EPOCH, its rpm output does not, so two rpms built from the same commit on different
+// days differ. Write the entry ourselves instead, honoring SOURCE_DATE_EPOCH, to enable
+// reproducible builds.
+// Upstream bug report: https://github.com/jordansissel/fpm/issues/2154
+function writeRpmChangelog() {
+  const sourceDateEpoch = process.env.SOURCE_DATE_EPOCH;
+  const date = new Date(sourceDateEpoch ? Number(sourceDateEpoch) * 1000 : Date.now());
+
+  // rpm expects '<weekday> <month> <dayOfMonth> <year>'. toUTCString has a format fixed by the
+  // ECMAScript spec, 'Tue, 14 Nov 2023 22:13:20 GMT', so just reorder its parts. Being UTC also
+  // keeps the time zone of the build machine from shifting the date, which it does for fpm.
+  const [weekday, dayOfMonth, month, year] = date.toUTCString().replace(',', '').split(' ');
+  const formattedDate = `${weekday} ${month} ${dayOfMonth} ${year}`;
+
+  // The rest mirrors what fpm would have generated: it replaces dashes in the rpm version with
+  // underscores, and defaults the iteration ('Release' in rpm) to 1.
+  const rpmVersion = `${getLinuxVersion().replace(/-/g, '_')}-1`;
+  const maintainer = `${author.name} <${author.email}>`;
+
+  const changelogPath = rpmChangelogPath();
+  fs.mkdirSync(path.dirname(changelogPath), { recursive: true });
+  fs.writeFileSync(
+    changelogPath,
+    `* ${formattedDate}  ${maintainer} - ${rpmVersion}\n- Package created with FPM\n`,
+  );
 }
 
 async function removeNseventforwarderNativeModules() {


### PR DESCRIPTION
Another day, another reproducible builds PR. Joke intended (the fact that this PR stops the RPM build to break on different days)

fpm stamps the `%changelog` entry it generates with the build machine current date at build time. Its deb output copies `SOURCE_DATE_EPOCH` (as it should) into the attribute that date is read from, but its rpm output never does, so the entry followed the wall clock. rpm parses the date into the `CHANGELOGTIME` header, so two rpms built from the same commit on different days differed.

Pass the entry to fpm instead of letting it generate one, since reproducible builds require it to be fixed. The date is formatted in UTC, so the time zone of the build machine cannot shift it across a day boundary either. fpm renders it in local time.

This workaround is due to a bug in fpm. It *should* honor `SOURCE_DATE_EPOCH`, but it does not. I reported it upstream at https://github.com/jordansissel/fpm/issues/2154.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10834)
<!-- Reviewable:end -->
