### PR TITLE
Stop signing deb packages with `dpkg-sig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Line wrap the file at 100 chars.                                              Th
 - De-couple `mullvad-daemon.service` "After=" dependencies from systemd.resolved and NetworkManager.
 - Start `mullvad-early-boot-blocking.service` before `network-pre.target` instead of `basic.target`.
 - Remove dependency on `iproute2` when using GotaTun with IPv6.
+- Stop embedding a `dpkg-sig` signature in `.deb` packages. apt verifies the signature on the
+  repository, not one inside the package, and the tool making these signatures has been removed
+  from Debian. `.rpm` packages are still signed, since dnf does verify that signature.
 
 #### Windows
 - Update `wireguard-nt` to version 1.1. This retires the Mullvad fork at

--- a/ci/buildserver-build.sh
+++ b/ci/buildserver-build.sh
@@ -109,12 +109,9 @@ function run_in_build_env {
     fi
 }
 
-# Sign DEB+RPM on Linux
-function sign_linux_packages {
-    for installer_path in dist/MullvadVPN-*.deb; do
-        echo "Signing $installer_path"
-        dpkg-sig --sign builder "$installer_path"
-    done
+# Sign RPM packages on Linux. We don't sign the deb file since that's not standard
+# and dpkg-sig has been deprecated since long.
+function sign_rpm_packages {
     for installer_path in dist/MullvadVPN-*.rpm; do
         echo "Signing $installer_path"
         rpm --addsign "$installer_path"
@@ -131,7 +128,7 @@ function build {
 
     run_in_build_env TARGETS="$target" ./build.sh "${build_args[@]}" || return 1
     if [[ "$(uname -s)" == "Linux" ]]; then
-        sign_linux_packages
+        sign_rpm_packages
     fi
     mv dist/*.{deb,rpm,exe,pkg} "$artifact_dir" || return 1
 

--- a/ci/linux-repository-builder/build-linux-repositories.sh
+++ b/ci/linux-repository-builder/build-linux-repositories.sh
@@ -117,8 +117,7 @@ function process_inbox {
         echo "Moving artifacts from $src_dir to $artifact_dir"
         # Move all deb and rpm files into the .latest dir
         for src_deb in "$src_dir"/*.deb; do
-            echo "Signing and moving $src_deb into $artifact_dir/"
-            dpkg-sig --sign builder "$src_deb"
+            echo "Moving $src_deb into $artifact_dir/"
             mv "$src_deb" "$artifact_dir/"
         done
         for src_rpm in "$src_dir"/*.rpm; do


### PR DESCRIPTION
apt does not look at a signature inside a package. It verifies the signature on the repository the package came from, which reprepro makes when building our apt repository.

dpkg-sig is not the tool Debian's own per-package scheme would use, and it was removed from Debian unstable in 2023 and from testing in 2021, so users on a current Debian cannot install it to check what we attached. It was ever complicated for us to get hold of a version of `dpkg-sig` for our build servers. We have discussed removing it before, but did not get around to it since the signatures does not hurt. Now they do hurt, when we try to pursue reproducible builds.

A signature can never be reproduced by someone rebuilding the same commit, since it is made with a key they do not have and covers a timestamp. So this is a step towards reproducible builds.

rpm packages keep their signature. dnf does verify it, and our own mullvad.repo sets gpgcheck=1. For verifying reproducibility of RPMs we would need to include instructions on how to drop the signature, because when you do, our RPMs should go back to bit-identical.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10835)
<!-- Reviewable:end -->
