### PR TITLE
Pin the build container images by digest instead of tag

### DIFF
--- a/android/docker/Dockerfile
+++ b/android/docker/Dockerfile
@@ -13,7 +13,8 @@
 # for more information.
 
 # === Base image (built from: ../../Dockerfile) ===
-FROM ghcr.io/mullvad/mullvadvpn-app-build:da84604a2e
+# By digest, not by tag, so this can never be repointed at a different image.
+FROM ghcr.io/mullvad/mullvadvpn-app-build@sha256:67adca4e557b697ecf5a8cd46a70015447514e9c2846da4573ed00df036ce6f9
 
 # === Metadata ===
 LABEL org.opencontainers.image.source=https://github.com/mullvad/mullvadvpn-app

--- a/building/README.md
+++ b/building/README.md
@@ -49,8 +49,19 @@ GIT_SSH_COMMAND="ssh -i ~/.ssh/id_ed25519-mullvadvpn-app-deploy" git push
 ```
 
 When satisfied with how the new image works, the `building/{linux,android}-container-image.txt`
-files can be updated to point to the new image. The tag name of the new image is in the
-commit message for the signed commit where the build server added the sigstore files.
+files can be updated to point to the new image. They name it by digest:
+
+```
+ghcr.io/mullvad/mullvadvpn-app-build@sha256:<digest>
+```
+
+Not by tag. A tag can be repointed at a different image, which would silently change
+what everyone builds in. A digest cannot.
+
+`build-and-publish-container-image.sh` prints the exact line to use when it is done. To go the
+other way, from a digest to the commit the image was built from, find the signed commit that added
+`building/sigstore/mullvad/<image>@sha256=<digest>/`. Its message names the tag.
+
 This update is usually done in a separate PR by a developer
 
 ## Building and publishing a development image container image

--- a/building/android-container-image.txt
+++ b/building/android-container-image.txt
@@ -1,1 +1,1 @@
-ghcr.io/mullvad/mullvadvpn-app-build-android:b40e0e28c2
+ghcr.io/mullvad/mullvadvpn-app-build-android@sha256:ca22c11fb8a15321f897fa169c9c9d1f7d0d9edfeea16fa04af4de71ebcf4286

--- a/building/build-and-publish-container-image.sh
+++ b/building/build-and-publish-container-image.sh
@@ -23,11 +23,13 @@ case ${1-:""} in
         container_name="mullvadvpn-app-build"
         containerfile_path="$SCRIPT_DIR/Dockerfile"
         container_context_dir="$REPO_DIR"
+        image_reference_file="building/linux-container-image.txt"
     ;;
     android)
         container_name="mullvadvpn-app-build-android"
         containerfile_path="$REPO_DIR/android/docker/Dockerfile"
         container_context_dir="$REPO_DIR/android/docker/"
+        image_reference_file="building/android-container-image.txt"
     ;;
     *)
         log_error "Invalid platform. Specify 'linux' or 'android' as first argument"
@@ -86,5 +88,10 @@ log_success "***********************"
 log_success ""
 log_success "Done building and pushing $full_container_name with tags '$tag' and 'latest'"
 log_success "Make sure to push the changes to git"
+log_success ""
+log_success "When you are satisfied with the new image, put this line in"
+log_success "$image_reference_file:"
+log_success ""
+log_success "    $full_container_name@$digest"
 log_success ""
 log_success "***********************"

--- a/building/linux-container-image.txt
+++ b/building/linux-container-image.txt
@@ -1,1 +1,1 @@
-ghcr.io/mullvad/mullvadvpn-app-build:da84604a2e
+ghcr.io/mullvad/mullvadvpn-app-build@sha256:67adca4e557b697ecf5a8cd46a70015447514e9c2846da4573ed00df036ce6f9

--- a/test/scripts/Dockerfile
+++ b/test/scripts/Dockerfile
@@ -1,3 +1,4 @@
+# The app build image to build on. Passed in by container-run.sh in this directory.
 ARG IMAGE=ghcr.io/mullvad/mullvadvpn-app-build:latest
 FROM $IMAGE
 


### PR DESCRIPTION
The image reference files named only a tag. Tags are mutable: whoever can push to the registry can point one at a different image, and then everybody silently builds in something else. We never reuse a tag, since it is the commit the image was built from, but that is a promise the files themselves do not make and nobody downstream can check.

Name both, as `<image>:<tag>@sha256:<digest>`. Container tooling resolves such a reference by digest and ignores the tag, so the pin is real rather than decorative, and the tag stays for a reader to see which commit the image came from.

The build environment is an input to a reproducible build just as much as the source is, so it has to be named as precisely.

Both digests are already in git: they are the directory names under `./building/sigstore/` where the signatures for those images live. build-and-publish-container-image.sh now also prints the line to put in the file, so the digest does not have to be looked up by hand.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10838)
<!-- Reviewable:end -->
