### PR TITLE
Migrate account data operation to async task

### DIFF
--- a/ios/MullvadMockData/MullvadTypes/DeviceMock.swift
+++ b/ios/MullvadMockData/MullvadTypes/DeviceMock.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import MullvadSettings
 import MullvadTypes
 
 extension Device {
@@ -19,6 +20,25 @@ extension Device {
             created: Date(),
             ipv4Address: IPAddressRange(from: "127.0.0.1/32")!,
             ipv6Address: IPAddressRange(from: "::ff/64")!
+        )
+    }
+
+    public static var loggedInDeviceState: DeviceState {
+        .loggedIn(
+            StoredAccountData(
+                identifier: "",
+                number: "",
+                expiry: .distantFuture
+            ),
+            StoredDeviceData(
+                creationDate: Date(),
+                identifier: "",
+                name: "",
+                hijackDNS: false,
+                ipv4Address: IPAddressRange(from: "127.0.0.1/32")!,
+                ipv6Address: IPAddressRange(from: "::ff/64")!,
+                wgKeyData: StoredWgKeyData(creationDate: Date(), privateKey: WireGuard.PrivateKey())
+            )
         )
     }
 }

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -196,7 +196,7 @@
 		583832292AC3DF1300EA2071 /* PacketTunnelActorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583832282AC3DF1300EA2071 /* PacketTunnelActorCommand.swift */; };
 		5838322B2AC3EF9600EA2071 /* EventChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5838322A2AC3EF9600EA2071 /* EventChannel.swift */; };
 		583D86482A2678DC0060D63B /* DeviceStateAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583D86472A2678DC0060D63B /* DeviceStateAccessor.swift */; };
-		58421030282D8A3C00F24E46 /* UpdateAccountDataOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5842102F282D8A3C00F24E46 /* UpdateAccountDataOperation.swift */; };
+		58421030282D8A3C00F24E46 /* UpdateAccountDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5842102F282D8A3C00F24E46 /* UpdateAccountDataTask.swift */; };
 		58421032282E42B000F24E46 /* UpdateDeviceDataOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58421031282E42B000F24E46 /* UpdateDeviceDataOperation.swift */; };
 		5846227326E22A160035F7C2 /* StorePaymentObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5846227226E22A160035F7C2 /* StorePaymentObserver.swift */; };
 		584D26C4270C855B004EA533 /* VPNSettingsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584D26C3270C855A004EA533 /* VPNSettingsDataSource.swift */; };
@@ -584,6 +584,7 @@
 		7A6389ED2B7FADA1008E77E1 /* SettingsFieldValidationErrorConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6389EC2B7FADA1008E77E1 /* SettingsFieldValidationErrorConfiguration.swift */; };
 		7A6389F82B864CDF008E77E1 /* LocationNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6389F72B864CDF008E77E1 /* LocationNode.swift */; };
 		7A6652B82BB44C3E0042D848 /* LocationDiffableDataSourceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6652B62BB44B120042D848 /* LocationDiffableDataSourceProtocol.swift */; };
+		7A679701302077F200D75401 /* UpdateAccountDataTaskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A679700302077F200D75401 /* UpdateAccountDataTaskTests.swift */; };
 		7A6811542DC8EC6E009CB61A /* UIFont+Weight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ABE318C2A1CDD4500DF4963 /* UIFont+Weight.swift */; };
 		7A6AA3AB2EC5C8FB00F1C80C /* StoreSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A2F41082EC38FC00013D3C5 /* StoreSubscription.swift */; };
 		7A6B4F592AB8412E00123853 /* TunnelMonitorTimings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6B4F582AB8412E00123853 /* TunnelMonitorTimings.swift */; };
@@ -910,7 +911,7 @@
 		A9A5FA222ACB05160083449F /* TunnelObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5823FA5326CE49F600283BF8 /* TunnelObserver.swift */; };
 		A9A5FA232ACB05160083449F /* TunnelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B93A1226C3F13600A55733 /* TunnelState.swift */; };
 		A9A5FA242ACB05160083449F /* TunnelStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5803B4B12940A48700C23744 /* TunnelStore.swift */; };
-		A9A5FA252ACB05160083449F /* UpdateAccountDataOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5842102F282D8A3C00F24E46 /* UpdateAccountDataOperation.swift */; };
+		A9A5FA252ACB05160083449F /* UpdateAccountDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5842102F282D8A3C00F24E46 /* UpdateAccountDataTask.swift */; };
 		A9A5FA262ACB05160083449F /* UpdateDeviceDataOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58421031282E42B000F24E46 /* UpdateDeviceDataOperation.swift */; };
 		A9A5FA272ACB05160083449F /* VPNConnectionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F360332AAB626300F53531 /* VPNConnectionProtocol.swift */; };
 		A9A5FA282ACB05160083449F /* WgKeyRotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581DA2742A1E283E0046ED47 /* WgKeyRotation.swift */; };
@@ -1963,7 +1964,7 @@
 		5840250322B11AB700E4CFEC /* MullvadEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MullvadEndpoint.swift; sourceTree = "<group>"; };
 		5840BE34279EDB16002836BA /* OperationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationError.swift; sourceTree = "<group>"; };
 		5842102D282D3FC200F24E46 /* ResultBlockOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultBlockOperation.swift; sourceTree = "<group>"; };
-		5842102F282D8A3C00F24E46 /* UpdateAccountDataOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateAccountDataOperation.swift; sourceTree = "<group>"; };
+		5842102F282D8A3C00F24E46 /* UpdateAccountDataTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateAccountDataTask.swift; sourceTree = "<group>"; };
 		58421031282E42B000F24E46 /* UpdateDeviceDataOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateDeviceDataOperation.swift; sourceTree = "<group>"; };
 		5846227226E22A160035F7C2 /* StorePaymentObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePaymentObserver.swift; sourceTree = "<group>"; };
 		584B26F3237434D00073B10E /* RelaySelectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaySelectorTests.swift; sourceTree = "<group>"; };
@@ -2298,6 +2299,7 @@
 		7A6389EC2B7FADA1008E77E1 /* SettingsFieldValidationErrorConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsFieldValidationErrorConfiguration.swift; sourceTree = "<group>"; };
 		7A6389F72B864CDF008E77E1 /* LocationNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationNode.swift; sourceTree = "<group>"; };
 		7A6652B62BB44B120042D848 /* LocationDiffableDataSourceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDiffableDataSourceProtocol.swift; sourceTree = "<group>"; };
+		7A679700302077F200D75401 /* UpdateAccountDataTaskTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateAccountDataTaskTests.swift; sourceTree = "<group>"; };
 		7A6B4F582AB8412E00123853 /* TunnelMonitorTimings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelMonitorTimings.swift; sourceTree = "<group>"; };
 		7A6B96892FEC01E100DBF9BD /* View+TypeErase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+TypeErase.swift"; sourceTree = "<group>"; };
 		7A6B968B2FEC0F3500DBF9BD /* StaticButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticButtonStyle.swift; sourceTree = "<group>"; };
@@ -3062,15 +3064,16 @@
 		440E9EF02BDA93CB00B1FD11 /* MullvadVPN */ = {
 			isa = PBXGroup;
 			children = (
-				F9EDB26A2EC4C03A0015DE36 /* Interactors */,
-				F0A7EBB02CEF6C5F005BB671 /* Log */,
 				440E9EF62BDA957300B1FD11 /* Classes */,
 				440E9F002BDA997C00B1FD11 /* Extensions */,
 				440E9EFB2BDA97C600B1FD11 /* GeneralAPIs */,
+				F9EDB26A2EC4C03A0015DE36 /* Interactors */,
+				F0A7EBB02CEF6C5F005BB671 /* Log */,
 				440E9EF12BDA940500B1FD11 /* Notifications */,
 				440E9EF72BDA95AC00B1FD11 /* PacketTunnel */,
 				44B3C43B2C00CB570079782C /* PacketTunnelCore */,
 				440E9EFE2BDA991200B1FD11 /* RelayCacheTracker */,
+				7A6796FD302077C300D75401 /* Tasks */,
 				440E9EFF2BDA995800B1FD11 /* TunnelManager */,
 				440E9EFC2BDA982200B1FD11 /* View controllers */,
 			);
@@ -3396,7 +3399,7 @@
 				A9E0317D2ACC32920095D843 /* TunnelStatusBlockObserver.swift */,
 				5803B4B12940A48700C23744 /* TunnelStore.swift */,
 				A9E031762ACB08950095D843 /* BackgroundTaskProvider.swift */,
-				5842102F282D8A3C00F24E46 /* UpdateAccountDataOperation.swift */,
+				5842102F282D8A3C00F24E46 /* UpdateAccountDataTask.swift */,
 				58421031282E42B000F24E46 /* UpdateDeviceDataOperation.swift */,
 				A9F360332AAB626300F53531 /* VPNConnectionProtocol.swift */,
 				581DA2742A1E283E0046ED47 /* WgKeyRotation.swift */,
@@ -4628,6 +4631,14 @@
 				7AB2B66E2BA1EB8C00B03E3B /* ListCustomListViewController.swift */,
 			);
 			path = CustomLists;
+			sourceTree = "<group>";
+		};
+		7A6796FD302077C300D75401 /* Tasks */ = {
+			isa = PBXGroup;
+			children = (
+				7A679700302077F200D75401 /* UpdateAccountDataTaskTests.swift */,
+			);
+			path = Tasks;
 			sourceTree = "<group>";
 		};
 		7A83C3FC2A55B39500DFB83A /* TestPlans */ = {
@@ -6355,6 +6366,7 @@
 				A9A5FA3A2ACB05910083449F /* UIEdgeInsets+Extensions.swift in Sources */,
 				A9A5FA3B2ACB05910083449F /* UIMetrics.swift in Sources */,
 				7A9246AB2EB0C765008FE31A /* StorePaymentManagerInteractor.swift in Sources */,
+				7A679701302077F200D75401 /* UpdateAccountDataTaskTests.swift in Sources */,
 				58B07C182AEFDD6C00A09625 /* StoreTransactionLog.swift in Sources */,
 				A9A5FA382ACB05600083449F /* InputTextFormatter.swift in Sources */,
 				F022EBA62CF0C6AE009484B9 /* ConsolidatedApplicationLog.swift in Sources */,
@@ -6477,7 +6489,7 @@
 				A9A5FA232ACB05160083449F /* TunnelState.swift in Sources */,
 				F052964D2FAE1A2D00B1C5BE /* MultihopMigrationTrackerFactory.swift in Sources */,
 				A9A5FA242ACB05160083449F /* TunnelStore.swift in Sources */,
-				A9A5FA252ACB05160083449F /* UpdateAccountDataOperation.swift in Sources */,
+				A9A5FA252ACB05160083449F /* UpdateAccountDataTask.swift in Sources */,
 				44A515302FF2C68D00FFFB82 /* TopSlideTransition.swift in Sources */,
 				A9A5FA262ACB05160083449F /* UpdateDeviceDataOperation.swift in Sources */,
 				A9A5FA272ACB05160083449F /* VPNConnectionProtocol.swift in Sources */,
@@ -6730,7 +6742,7 @@
 				7A11DD0B2A9495D400098CD8 /* AppRoutes.swift in Sources */,
 				5827B0902B0CAA0500CCBBA1 /* EditAccessMethodCoordinator.swift in Sources */,
 				F97C38E52DEEDFD6006DCB08 /* Image+Assets.swift in Sources */,
-				58421030282D8A3C00F24E46 /* UpdateAccountDataOperation.swift in Sources */,
+				58421030282D8A3C00F24E46 /* UpdateAccountDataTask.swift in Sources */,
 				7A8A190A2CE5FFE9000BCB5B /* SettingsDAITAView.swift in Sources */,
 				449E9A6D2D283A2500F8574A /* ConnectionViewComponentPreview.swift in Sources */,
 				F04789ED2E3A4FEB0011E3A5 /* ApplicationLanguage.swift in Sources */,

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -451,30 +451,15 @@ final class TunnelManager: @unchecked Sendable {
     }
 
     func updateAccountData(_ completionHandler: (@Sendable (Error?) -> Void)? = nil) {
-        let operation = UpdateAccountDataOperation(
-            dispatchQueue: internalQueue,
+        let task = UpdateAccountDataTask(
             interactor: TunnelInteractorProxy(self),
             accountsProxy: accountsProxy
         )
 
-        operation.completionQueue = .main
-        operation.completionHandler = { completion in
-            completionHandler?(completion.error)
+        Task {
+            let result = await task.start()
+            completionHandler?(result.error)
         }
-
-        operation.addObserver(
-            BackgroundObserver(
-                backgroundTaskProvider: backgroundTaskProvider,
-                name: "Update account data",
-                cancelUponExpiration: true
-            )
-        )
-
-        operation.addCondition(
-            MutuallyExclusive(category: OperationCategory.deviceStateUpdate.category)
-        )
-
-        operationQueue.addOperation(operation)
     }
 
     func redeemVoucher(

--- a/ios/MullvadVPN/TunnelManager/UpdateAccountDataTask.swift
+++ b/ios/MullvadVPN/TunnelManager/UpdateAccountDataTask.swift
@@ -1,61 +1,59 @@
 //
-//  UpdateAccountDataOperation.swift
+//  UpdateAccountDataTask.swift
 //  MullvadVPN
 //
-//  Created by pronebird on 12/05/2022.
+//  Created by Jon Petersson on 31/07/2026.
 //  Copyright © 2026 Mullvad VPN AB. All rights reserved.
 //
 
-import Foundation
 import MullvadLogging
 import MullvadREST
 import MullvadSettings
 import MullvadTypes
-import Operations
 
-class UpdateAccountDataOperation: ResultOperation<Void>, @unchecked Sendable {
-    private let logger = Logger(label: "UpdateAccountDataOperation")
+actor UpdateAccountDataTask {
+    private let logger = Logger(label: "UpdateAccountDataTask")
     private let interactor: TunnelInteractor
     private let accountsProxy: RESTAccountHandling
     private var task: Cancellable?
 
     init(
-        dispatchQueue: DispatchQueue,
         interactor: TunnelInteractor,
         accountsProxy: RESTAccountHandling
     ) {
         self.interactor = interactor
         self.accountsProxy = accountsProxy
-
-        super.init(dispatchQueue: dispatchQueue)
     }
 
-    override func main() {
+    func start() async -> Result<Void, Error> {
         guard case let .loggedIn(accountData, _) = interactor.deviceState else {
-            finish(result: .failure(InvalidDeviceStateError()))
-            return
+            return .failure(InvalidDeviceStateError())
         }
 
-        task = accountsProxy.getAccountData(
-            accountNumber: accountData.number,
-            retryStrategy: .default,
-            completion: { result in
-                self.dispatchQueue.async {
-                    self.didReceiveAccountData(result: result)
-                }
+        let result: Result<Account, Error> = await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                task = accountsProxy.getAccountData(
+                    accountNumber: accountData.number,
+                    retryStrategy: .default,
+                    completion: { result in
+                        continuation.resume(returning: result)
+                    }
+                )
             }
-        )
+        } onCancel: {
+            Task { await cancel() }
+        }
+
+        return didReceiveAccountData(result: result)
     }
 
-    override func operationDidCancel() {
+    func cancel() {
         task?.cancel()
         task = nil
     }
 
-    private func didReceiveAccountData(result: Result<Account, Error>) {
+    private func didReceiveAccountData(result: Result<Account, Error>) -> Result<Void, Error> {
         let result = result.inspectError { error in
-            guard !error.isOperationCancellationError else { return }
-
             self.logger.error(
                 error: error,
                 message: "Failed to fetch account expiry."
@@ -64,16 +62,14 @@ class UpdateAccountDataOperation: ResultOperation<Void>, @unchecked Sendable {
             switch interactor.deviceState {
             case .loggedIn(var storedAccountData, let storedDeviceData):
                 storedAccountData.expiry = accountData.expiry
-
                 let newDeviceState = DeviceState.loggedIn(storedAccountData, storedDeviceData)
 
                 interactor.setDeviceState(newDeviceState, persist: true)
-
             default:
                 throw InvalidDeviceStateError()
             }
         }
 
-        finish(result: result)
+        return result
     }
 }

--- a/ios/MullvadVPNTests/MullvadVPN/Tasks/UpdateAccountDataTaskTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/Tasks/UpdateAccountDataTaskTests.swift
@@ -1,0 +1,55 @@
+//
+//  UpdateAccountDataTaskTests.swift
+//  MullvadVPNTests
+//
+//  Created by Jon Petersson on 2026-08-03.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+import MullvadSettings
+import MullvadTypes
+import Testing
+@testable import MullvadMockData
+
+struct UpdateAccountDataTaskTests {
+    @Test func canDoAccountDataUpdate() async throws {
+        let task = UpdateAccountDataTask(
+            interactor: makeInteractor(deviceState: Device.loggedInDeviceState),
+            accountsProxy: AccountsProxyStub()
+        )
+
+        let result = await task.start()
+
+        #expect(result.isSuccess)
+    }
+
+    @Test func canCancelAccountDataUpdate() async throws {
+        let task = UpdateAccountDataTask(
+            interactor: makeInteractor(deviceState: Device.loggedInDeviceState),
+            accountsProxy: AccountsProxyStub()
+        )
+
+        Task {
+            let result = await task.start()
+            result.inspectError({ error in
+                #expect(error.isOperationCancellationError)
+            })
+        }
+
+        await task.cancel()
+    }
+}
+
+extension UpdateAccountDataTaskTests {
+    private func makeInteractor(deviceState: DeviceState, tunnelState: TunnelState? = nil) -> MockTunnelInteractor {
+        let interactor = MockTunnelInteractor(
+            isConfigurationLoaded: true,
+            settings: LatestTunnelSettings(),
+            deviceState: deviceState
+        )
+        if let tunnelState {
+            interactor.tunnelStatus = TunnelStatus(state: tunnelState)
+        }
+        return interactor
+    }
+}

--- a/ios/MullvadVPNTests/MullvadVPN/TunnelManager/StartTunnelOperationTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/TunnelManager/StartTunnelOperationTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2026 Mullvad VPN AB. All rights reserved.
 //
 
+import MullvadMockData
 import MullvadSettings
 import MullvadTypes
 import Network
@@ -19,23 +20,6 @@ class StartTunnelOperationTests: XCTestCase {
 
     let testQueue = DispatchQueue(label: "StartTunnelOperationTests.testQueue")
     let operationQueue = AsyncOperationQueue()
-
-    let loggedInDeviceState = DeviceState.loggedIn(
-        StoredAccountData(
-            identifier: "",
-            number: "",
-            expiry: .distantFuture
-        ),
-        StoredDeviceData(
-            creationDate: Date(),
-            identifier: "",
-            name: "",
-            hijackDNS: false,
-            ipv4Address: IPAddressRange(from: "127.0.0.1/32")!,
-            ipv6Address: IPAddressRange(from: "::ff/64")!,
-            wgKeyData: StoredWgKeyData(creationDate: Date(), privateKey: WireGuard.PrivateKey())
-        )
-    )
 
     func makeInteractor(deviceState: DeviceState, tunnelState: TunnelState? = nil) -> MockTunnelInteractor {
         let interactor = MockTunnelInteractor(
@@ -69,7 +53,7 @@ class StartTunnelOperationTests: XCTestCase {
     }
 
     func testSetsReconnectIfDisconnecting() {
-        let interactor = makeInteractor(deviceState: loggedInDeviceState, tunnelState: .disconnecting(.nothing))
+        let interactor = makeInteractor(deviceState: Device.loggedInDeviceState, tunnelState: .disconnecting(.nothing))
         nonisolated(unsafe) var tunnelStatus = TunnelStatus()
         interactor.onUpdateTunnelStatus = { status in tunnelStatus = status }
         let expectation = expectation(description: "Tunnel status set to reconnect")
@@ -86,7 +70,7 @@ class StartTunnelOperationTests: XCTestCase {
     }
 
     func testStartsTunnelIfDisconnected() {
-        let interactor = makeInteractor(deviceState: loggedInDeviceState, tunnelState: .disconnected)
+        let interactor = makeInteractor(deviceState: Device.loggedInDeviceState, tunnelState: .disconnected)
         let expectation = expectation(description: "Make tunnel provider and start tunnel")
         let operation = StartTunnelOperation(
             dispatchQueue: testQueue,


### PR DESCRIPTION
**Why this needs to be done**

Migrate UpdateAccountDataOperation from Operation and callbacks to Swift concurrency using Task and async/await, potentially removing the separate operation class entirely.

**Acceptance criteria**

- Wrap callback-based APIs with checked continuations where needed.
- Propagate task cancellation to the underlying Cancellable.
- Handle cancellation races before and during request execution.
- Preserve existing success, error, retry, and data-mapping behavior.
- Resolve concurrency-safety issues without using @unchecked Sendable.

**How should this be tested?**

Update unit and E2E tests to cover success, failure, cancellation, and race conditions.

**Note:**

Remove inheritance from AsyncOperation, ResultOperation, and related.
Resolve concurrency warnings properly without using @unchecked Sendable, if applicable

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10841)
<!-- Reviewable:end -->
