### PR TITLE
Remove git commit date from daemon startup log

### DIFF
--- a/mullvad-daemon/build.rs
+++ b/mullvad-daemon/build.rs
@@ -1,4 +1,4 @@
-use std::{env, fs, path::PathBuf, process::Command};
+use std::env;
 
 #[cfg(windows)]
 fn make_lang_id(p: u16, s: u16) -> u16 {
@@ -6,9 +6,6 @@ fn make_lang_id(p: u16, s: u16) -> u16 {
 }
 
 fn main() {
-    let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    fs::write(out_dir.join("git-commit-date.txt"), commit_date()).unwrap();
-
     #[cfg(windows)]
     {
         let mut res = winresource::WindowsResource::new();
@@ -44,17 +41,6 @@ fn main() {
             _ => {}
         }
     }
-}
-
-fn commit_date() -> String {
-    let output = Command::new("git")
-        .args(["log", "-1", "--date=short", "--pretty=format:%cd"])
-        .output()
-        .expect("Unable to get git commit date");
-    std::str::from_utf8(&output.stdout)
-        .unwrap()
-        .trim()
-        .to_owned()
 }
 
 #[derive(PartialEq, Eq, Clone, Copy)]

--- a/mullvad-daemon/src/version/mod.rs
+++ b/mullvad-daemon/src/version/mod.rs
@@ -40,9 +40,6 @@ pub enum Error {
     UpdateAborted,
 }
 
-/// Contains the date of the git commit this was built from
-pub const COMMIT_DATE: &str = include_str!(concat!(env!("OUT_DIR"), "/git-commit-date.txt"));
-
 pub fn is_beta_version() -> bool {
     mullvad_version::VERSION.contains("beta")
 }
@@ -53,9 +50,8 @@ pub fn is_dev_version() -> bool {
 
 pub fn log_version() {
     log::info!(
-        "Starting {} - {} {}",
+        "Starting {} - {}",
         env!("CARGO_PKG_NAME"),
         mullvad_version::VERSION,
-        COMMIT_DATE,
     )
 }


### PR DESCRIPTION
This was the only hard dependency on the `git` binary in the Rust build. The build script panicked if `git` was missing, and silently baked in an empty string when built outside a git repository.

The date was not used for anything except printing in the --version output of the daemon. So purely decoration with very little value.

Removing this since it provided very little value, at the cost of having `git` as a hard dependency on the build process.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10845)
<!-- Reviewable:end -->
