### PR TITLE
Add SOCKS5 client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6094,6 +6094,7 @@ dependencies = [
  "async-trait",
  "bitflags 1.3.2",
  "byteorder",
+ "bytes",
  "chrono",
  "futures",
  "gotatun",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,6 +1614,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast-socks5"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9545787d8304a71e1bf1b711705070a4c400cce9b332c4a11800627b7c9a2067"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "log",
+ "socket2 0.5.10",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6788,6 +6803,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "criterion",
+ "fast-socks5",
  "futures",
  "log",
  "mullvad-masque-proxy",
@@ -6799,6 +6815,7 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.18",
  "udp-over-tcp",
+ "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6236,6 +6236,7 @@ dependencies = [
  "async-trait",
  "bitflags 1.3.2",
  "byteorder",
+ "bytes",
  "chrono",
  "futures",
  "gotatun",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6959,6 +6959,7 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.18",
  "udp-over-tcp",
+ "zerocopy",
 ]
 
 [[package]]

--- a/mullvad-cli/src/cmds/anti_censorship.rs
+++ b/mullvad-cli/src/cmds/anti_censorship.rs
@@ -8,6 +8,9 @@ use mullvad_types::{
         Udp2TcpObfuscationSettings, WireguardPortSettings,
     },
 };
+use talpid_types::net::proxy::Socks5Proxy as TalpidSocks5Proxy;
+
+use super::proxies::{Socks5LocalAdd, Socks5RemoteAdd};
 
 #[derive(Subcommand, Debug)]
 pub enum AntiCensorship {
@@ -51,6 +54,23 @@ pub enum SetCommands {
         #[arg(long, short = 'p')]
         port: Constraint<u16>,
     },
+
+    /// Relay the tunnel through a SOCKS5 proxy. Any anti-censorship method is applied on top of
+    /// it, and only those that can be are allowed alongside a proxy.
+    #[clap(subcommand)]
+    Socks5(Socks5Proxy),
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum Socks5Proxy {
+    /// Relay through a SOCKS5 proxy running on localhost
+    Local(Socks5LocalAdd),
+
+    /// Relay through a remote SOCKS5 proxy
+    Remote(Socks5RemoteAdd),
+
+    /// Stop relaying through a SOCKS5 proxy
+    Off,
 }
 
 impl AntiCensorship {
@@ -58,7 +78,8 @@ impl AntiCensorship {
         match self {
             AntiCensorship::Get => {
                 let mut rpc = MullvadProxyClient::new().await?;
-                let obfuscation_settings = rpc.get_settings().await?.obfuscation_settings;
+                let settings = rpc.get_settings().await?;
+                let obfuscation_settings = settings.obfuscation_settings;
                 println!("mode: {}", obfuscation_settings.selected_obfuscation);
                 println!("udp2tcp settings: {}", obfuscation_settings.udp2tcp);
                 println!("shadowsocks settings: {}", obfuscation_settings.shadowsocks);
@@ -67,6 +88,13 @@ impl AntiCensorship {
                     obfuscation_settings.wireguard_port
                 );
                 println!("lwo settings: {}", obfuscation_settings.lwo);
+                println!(
+                    "socks5 proxy: {}",
+                    match settings.tunnel_options.wireguard.socks5_proxy {
+                        Some(proxy) => proxy.to_string(),
+                        None => "off".to_string(),
+                    }
+                );
                 Ok(())
             }
             AntiCensorship::Set(subcmd) => Self::set(subcmd).await,
@@ -124,6 +152,16 @@ impl AntiCensorship {
                     ..current_settings
                 })
                 .await?;
+            }
+            SetCommands::Socks5(proxy) => {
+                let proxy = match proxy {
+                    Socks5Proxy::Local(add) => Some(TalpidSocks5Proxy::Local(add.into())),
+                    Socks5Proxy::Remote(add) => {
+                        Some(TalpidSocks5Proxy::Remote(add.try_into()?))
+                    }
+                    Socks5Proxy::Off => None,
+                };
+                rpc.set_wireguard_socks5_proxy(proxy).await?;
             }
         }
 

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -112,7 +112,10 @@ use talpid_types::android::AndroidContext;
 use talpid_types::split_tunnel::ExcludedProcess;
 use talpid_types::{
     ErrorExt,
-    net::{IpVersion, proxy::ShadowsocksCipher},
+    net::{
+        IpVersion,
+        proxy::{ShadowsocksCipher, Socks5Proxy},
+    },
     tunnel::{ErrorStateCause, TunnelStateTransition},
 };
 use tokio::io;
@@ -299,6 +302,8 @@ pub enum DaemonCommand {
     SetEnableIpv6(ResponseTx<(), settings::Error>, bool),
     /// Set if userspace WireGuard should be forced.
     SetUserspaceWireguard(ResponseTx<(), settings::Error>, bool),
+    /// Set the SOCKS5 proxy to relay the tunnel through, if any.
+    SetWireguardSocks5Proxy(ResponseTx<(), settings::Error>, Option<Socks5Proxy>),
     /// Set if recents should be enabled
     SetEnableRecents(ResponseTx<(), settings::Error>, bool),
     /// Set whether to enable PQ PSK exchange in the tunnel
@@ -1557,6 +1562,9 @@ impl Daemon {
             SetUserspaceWireguard(tx, userspace) => {
                 self.on_set_userspace_wireguard(tx, userspace).await
             }
+            SetWireguardSocks5Proxy(tx, proxy) => {
+                self.on_set_wireguard_socks5_proxy(tx, proxy).await
+            }
             SetEnableRecents(tx, enable_recents) => {
                 self.on_set_enable_recents(tx, enable_recents).await
             }
@@ -2733,6 +2741,30 @@ impl Daemon {
             Err(e) => {
                 log::error!("{}", e.display_chain_with_msg("Unable to save settings"));
                 Self::oneshot_send(tx, Err(e), "set_userspace_wireguard response");
+            }
+        }
+    }
+
+    async fn on_set_wireguard_socks5_proxy(
+        &mut self,
+        tx: ResponseTx<(), settings::Error>,
+        proxy: Option<Socks5Proxy>,
+    ) {
+        match self
+            .settings
+            .update(|settings| settings.tunnel_options.wireguard.socks5_proxy = proxy)
+            .await
+        {
+            Ok(settings_changed) => {
+                Self::oneshot_send(tx, Ok(()), "set_wireguard_socks5_proxy response");
+                if settings_changed {
+                    log::info!("Initiating tunnel restart because the SOCKS5 proxy changed");
+                    self.reconnect_tunnel();
+                }
+            }
+            Err(e) => {
+                log::error!("{}", e.display_chain_with_msg("Unable to save settings"));
+                Self::oneshot_send(tx, Err(e), "set_wireguard_socks5_proxy response");
             }
         }
     }

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -335,6 +335,24 @@ impl ManagementService for ManagementServiceImpl {
         Ok(Response::new(()))
     }
 
+    async fn set_wireguard_socks5_proxy(
+        &self,
+        request: Request<types::Socks5ProxySettings>,
+    ) -> ServiceResult<()> {
+        let proxy = request
+            .into_inner()
+            .proxy
+            .map(talpid_types::net::proxy::Socks5Proxy::try_from)
+            .transpose()
+            .map_err(map_protobuf_type_err)?;
+
+        log::debug!("set_wireguard_socks5_proxy({proxy:?})");
+        let (tx, rx) = oneshot::channel();
+        self.send_command_to_daemon(DaemonCommand::SetWireguardSocks5Proxy(tx, proxy))?;
+        self.wait_for_result(rx).await??;
+        Ok(Response::new(()))
+    }
+
     async fn set_quantum_resistant_tunnel(
         &self,
         request: Request<types::QuantumResistantState>,

--- a/mullvad-daemon/src/tunnel.rs
+++ b/mullvad-daemon/src/tunnel.rs
@@ -228,8 +228,7 @@ fn socks5_proxy_override() -> Option<Socks5Proxy> {
                     // VLESS over TLS or REALITY uses TCP, but one speaking QUIC, mKCP or
                     // Hysteria uses UDP, and the firewall matches the protocol along with the
                     // address. It cannot be derived from SOCKS5, so it has to come from the
-                    // configuration -- along with the rest of what the local case needs, since
-                    // `get_next_hop_endpoints` cannot express `AllowedClients::all()` either.
+                    // configuration.
                     Socks5Proxy::Local(Socks5Local {
                         remote_endpoint: Endpoint::from_socket_address(
                             upstream,

--- a/mullvad-daemon/src/tunnel.rs
+++ b/mullvad-daemon/src/tunnel.rs
@@ -13,10 +13,23 @@ use mullvad_types::{
     settings::{Settings, TunnelOptions},
 };
 use talpid_core::tunnel_state_machine::TunnelParametersGenerator;
-use talpid_types::net::{obfuscation::Obfuscators, wireguard};
+use talpid_types::net::{
+    Endpoint, TransportProtocol,
+    obfuscation::Obfuscators,
+    proxy::{Socks5Local, Socks5Proxy, Socks5Remote},
+    wireguard,
+};
 use talpid_types::{ErrorExt, net::IpAvailability, tunnel::ParameterGenerationError};
 
 use crate::device::{AccountManagerHandle, Error as DeviceError, PrivateAccountAndDevice};
+
+/// Relay the tunnel through a SOCKS5 proxy. Intended for development, until the proxy can be
+/// configured through the settings.
+///
+/// Accepts either `<proxy address>` for a remote proxy, or `<local port>@<upstream address>` for
+/// a proxy running on localhost, where the upstream address is whatever the proxy itself forwards
+/// to.
+const SOCKS5_PROXY_VAR: &str = "MULLVAD_SOCKS5_PROXY";
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -187,7 +200,7 @@ impl InnerParametersGenerator {
                 .into_talpid_tunnel_options(),
             generic_options: self.tunnel_options.generic.clone(),
             obfuscation: obfuscator_config,
-            proxy: None,
+            proxy: socks5_proxy_override(),
         }
     }
 
@@ -195,6 +208,49 @@ impl InnerParametersGenerator {
         let device_state = self.account_manager.data().await?;
         device_state.into_device().ok_or(Error::NoAuthDetails)
     }
+}
+
+/// Parse [`SOCKS5_PROXY_VAR`], if set.
+///
+/// An unparseable value is logged and ignored rather than failing the connection, since this is a
+/// development aid.
+fn socks5_proxy_override() -> Option<Socks5Proxy> {
+    let value = std::env::var(SOCKS5_PROXY_VAR).ok()?;
+
+    let proxy = match value.split_once('@') {
+        Some((local_port, upstream)) => {
+            local_port
+                .parse()
+                .ok()
+                .zip(upstream.parse().ok())
+                .map(|(local_port, upstream)| {
+                    // TODO: The upstream protocol is not always TCP. A local proxy speaking
+                    // VLESS over TLS or REALITY uses TCP, but one speaking QUIC, mKCP or
+                    // Hysteria uses UDP, and the firewall matches the protocol along with the
+                    // address. It cannot be derived from SOCKS5, so it has to come from the
+                    // configuration -- along with the rest of what the local case needs, since
+                    // `get_next_hop_endpoints` cannot express `AllowedClients::all()` either.
+                    Socks5Proxy::Local(Socks5Local {
+                        remote_endpoint: Endpoint::from_socket_address(
+                            upstream,
+                            TransportProtocol::Tcp,
+                        ),
+                        local_port,
+                    })
+                })
+        }
+        None => value.parse().ok().map(|endpoint| {
+            Socks5Proxy::Remote(Socks5Remote {
+                endpoint,
+                auth: None,
+            })
+        }),
+    };
+
+    if proxy.is_none() {
+        log::error!("Ignoring malformed {SOCKS5_PROXY_VAR}: {value}");
+    }
+    proxy
 }
 
 impl TunnelParametersGenerator for ParametersGenerator {

--- a/mullvad-daemon/src/tunnel.rs
+++ b/mullvad-daemon/src/tunnel.rs
@@ -187,6 +187,7 @@ impl InnerParametersGenerator {
                 .into_talpid_tunnel_options(),
             generic_options: self.tunnel_options.generic.clone(),
             obfuscation: obfuscator_config,
+            proxy: None,
         }
     }
 

--- a/mullvad-daemon/src/tunnel.rs
+++ b/mullvad-daemon/src/tunnel.rs
@@ -187,7 +187,7 @@ impl InnerParametersGenerator {
                 .into_talpid_tunnel_options(),
             generic_options: self.tunnel_options.generic.clone(),
             obfuscation: obfuscator_config,
-            proxy: None,
+            proxy: self.tunnel_options.wireguard.socks5_proxy.clone(),
         }
     }
 

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -56,6 +56,7 @@ service ManagementService {
   rpc ClearAllRelayOverrides(google.protobuf.Empty) returns (google.protobuf.Empty) {}
   rpc SetEnableRecents(google.protobuf.BoolValue) returns (google.protobuf.Empty) {}
   rpc SetUserspaceWireguard(google.protobuf.BoolValue) returns (google.protobuf.Empty) {}
+  rpc SetWireguardSocks5Proxy(Socks5ProxySettings) returns (google.protobuf.Empty) {}
 
   // Account management
   rpc CreateNewAccount(google.protobuf.Empty) returns (google.protobuf.StringValue) {}
@@ -525,6 +526,17 @@ message CustomProxy {
   }
 }
 
+// A SOCKS5 proxy to relay tunnel traffic through.
+message Socks5Proxy {
+  oneof proxy {
+    Socks5Local local = 1;
+    Socks5Remote remote = 2;
+  }
+}
+
+// An unset `proxy` means that no proxy is used.
+message Socks5ProxySettings { Socks5Proxy proxy = 1; }
+
 message AccessMethod {
   message Direct {}
   message Bridges {}
@@ -704,6 +716,8 @@ message TunnelOptions {
   // Force userspace WireGuard.
   // This option does not apply to Android or macOS.
   bool userspace = 7;
+  // SOCKS5 proxy to relay the tunnel through, if any.
+  Socks5Proxy socks5_proxy = 8;
 }
 
 message DefaultDnsOptions {

--- a/mullvad-management-interface/src/client.rs
+++ b/mullvad-management-interface/src/client.rs
@@ -25,6 +25,7 @@ use mullvad_types::{
 use std::net::IpAddr;
 #[cfg(not(target_os = "android"))]
 use std::{path::Path, str::FromStr};
+use talpid_types::net::proxy::Socks5Proxy;
 #[cfg(target_os = "windows")]
 use talpid_types::split_tunnel::ExcludedProcess;
 #[cfg(not(target_os = "android"))]
@@ -288,6 +289,15 @@ impl MullvadProxyClient {
 
     pub async fn set_userspace_wireguard(&mut self, state: bool) -> Result<()> {
         self.0.set_userspace_wireguard(state).await?;
+        Ok(())
+    }
+
+    /// Set the SOCKS5 proxy to relay the tunnel through, or `None` to stop relaying.
+    pub async fn set_wireguard_socks5_proxy(&mut self, proxy: Option<Socks5Proxy>) -> Result<()> {
+        let proxy = types::Socks5ProxySettings {
+            proxy: proxy.map(types::Socks5Proxy::from),
+        };
+        self.0.set_wireguard_socks5_proxy(proxy).await?;
         Ok(())
     }
 

--- a/mullvad-management-interface/src/types/conversions/net.rs
+++ b/mullvad-management-interface/src/types/conversions/net.rs
@@ -226,7 +226,8 @@ mod proxy {
 
     use crate::types::{FromProtobufTypeError, proto};
     use talpid_types::net::proxy::{
-        CustomProxy, Shadowsocks, ShadowsocksCipher, Socks5Local, Socks5Remote, SocksAuth,
+        CustomProxy, Shadowsocks, ShadowsocksCipher, Socks5Local, Socks5Proxy, Socks5Remote,
+        SocksAuth,
     };
 
     impl TryFrom<proto::CustomProxy> for CustomProxy {
@@ -249,6 +250,24 @@ mod proxy {
                     ));
                 }
             })
+        }
+    }
+
+    impl TryFrom<proto::Socks5Proxy> for Socks5Proxy {
+        type Error = FromProtobufTypeError;
+
+        fn try_from(value: proto::Socks5Proxy) -> Result<Self, Self::Error> {
+            match value.proxy {
+                Some(proto::socks5_proxy::Proxy::Local(local)) => {
+                    Ok(Socks5Proxy::Local(Socks5Local::try_from(local)?))
+                }
+                Some(proto::socks5_proxy::Proxy::Remote(remote)) => {
+                    Ok(Socks5Proxy::Remote(Socks5Remote::try_from(remote)?))
+                }
+                None => Err(FromProtobufTypeError::invalid_argument(
+                    "Socks5Proxy missing proxy field",
+                )),
+            }
         }
     }
 
@@ -382,6 +401,21 @@ mod proxy {
                 port: value.endpoint.port() as u32,
                 password: value.plaintext_password().to_string(),
                 cipher: Some(cipher),
+            }
+        }
+    }
+
+    impl From<Socks5Proxy> for proto::Socks5Proxy {
+        fn from(value: Socks5Proxy) -> Self {
+            proto::Socks5Proxy {
+                proxy: Some(match value {
+                    Socks5Proxy::Local(config) => {
+                        proto::socks5_proxy::Proxy::Local(proto::Socks5Local::from(config))
+                    }
+                    Socks5Proxy::Remote(config) => {
+                        proto::socks5_proxy::Proxy::Remote(proto::Socks5Remote::from(config))
+                    }
+                }),
             }
         }
     }

--- a/mullvad-management-interface/src/types/conversions/settings.rs
+++ b/mullvad-management-interface/src/types/conversions/settings.rs
@@ -101,6 +101,11 @@ impl From<&mullvad_types::settings::TunnelOptions> for proto::TunnelOptions {
             enable_ipv6: options.generic.enable_ipv6,
             dns_options: Some(proto::DnsOptions::from(&options.dns_options)),
             userspace: options.wireguard.userspace,
+            socks5_proxy: options
+                .wireguard
+                .socks5_proxy
+                .clone()
+                .map(proto::Socks5Proxy::from),
         }
     }
 }
@@ -237,6 +242,10 @@ impl TryFrom<proto::TunnelOptions> for mullvad_types::settings::TunnelOptions {
                     FromProtobufTypeError::invalid_argument("missing daita settings"),
                 )?,
                 userspace: options.userspace,
+                socks5_proxy: options
+                    .socks5_proxy
+                    .map(net::proxy::Socks5Proxy::try_from)
+                    .transpose()?,
             },
             generic: net::GenericTunnelOptions {
                 enable_ipv6: options.enable_ipv6,

--- a/mullvad-types/src/custom_tunnel.rs
+++ b/mullvad-types/src/custom_tunnel.rs
@@ -49,6 +49,7 @@ impl CustomTunnelEndpoint {
                 options,
                 generic_options: tunnel_options.generic,
                 obfuscation: None,
+                proxy: None,
             }
         };
         Ok(parameters)

--- a/mullvad-types/src/wireguard.rs
+++ b/mullvad-types/src/wireguard.rs
@@ -2,7 +2,7 @@
 use chrono::{DateTime, offset::Utc};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::{fmt, str::FromStr, time::Duration};
-use talpid_types::net::wireguard;
+use talpid_types::net::{proxy::Socks5Proxy, wireguard};
 
 use crate::Intersection;
 
@@ -201,6 +201,8 @@ pub struct TunnelOptions {
     pub userspace: bool,
     /// Interval used for automatic key rotation
     pub rotation_interval: Option<RotationInterval>,
+    /// SOCKS5 proxy to relay the tunnel through.
+    pub socks5_proxy: Option<Socks5Proxy>,
 }
 
 #[expect(clippy::derivable_impls)]
@@ -212,6 +214,7 @@ impl Default for TunnelOptions {
             daita: false,
             userspace: false,
             rotation_interval: None,
+            socks5_proxy: None,
         }
     }
 }

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -3,7 +3,7 @@ use futures::channel::{mpsc, oneshot};
 use futures::stream::Fuse;
 
 use talpid_tunnel::{TunnelEvent, TunnelMetadata};
-use talpid_types::net::{AllowedClients, AllowedEndpoint, wireguard::TunnelParameters};
+use talpid_types::net::{AllowedClients, wireguard::TunnelParameters};
 use talpid_types::tunnel::{ErrorStateCause, FirewallPolicyError};
 use talpid_types::{BoxedError, ErrorExt};
 
@@ -103,8 +103,6 @@ impl ConnectedState {
     }
 
     fn get_firewall_policy(&self, shared_values: &SharedTunnelStateValues) -> FirewallPolicy {
-        let endpoints = self.tunnel_parameters.get_next_hop_endpoints();
-
         #[cfg(target_os = "windows")]
         let clients = AllowedClients::from(vec![std::env::current_exe().unwrap()]);
 
@@ -117,13 +115,9 @@ impl ConnectedState {
             .get_exit_hop_endpoint()
             .map(|ep| ep.address.ip());
 
-        let peer_endpoints = endpoints
-            .into_iter()
-            .map(|endpoint| AllowedEndpoint {
-                endpoint,
-                clients: clients.clone(),
-            })
-            .collect();
+        let peer_endpoints = self
+            .tunnel_parameters
+            .get_allowed_next_hop_endpoints(clients);
 
         #[cfg(target_os = "macos")]
         let redirect_interface = shared_values

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -11,9 +11,7 @@ use talpid_tunnel::tun_provider::TunProvider;
 use talpid_tunnel::{EventHook, SelectedObfuscation, TunnelArgs, TunnelEvent, TunnelMetadata};
 use talpid_types::ErrorExt;
 use talpid_types::net::obfuscation::Obfuscators;
-use talpid_types::net::{
-    AllowedClients, AllowedEndpoint, AllowedTunnelTraffic, wireguard::TunnelParameters,
-};
+use talpid_types::net::{AllowedClients, AllowedTunnelTraffic, wireguard::TunnelParameters};
 use talpid_types::tunnel::{ErrorStateCause, FirewallPolicyError};
 
 use super::connected_state::TunnelEventsReceiver;
@@ -170,8 +168,6 @@ impl ConnectingState {
         #[cfg(target_os = "linux")]
         shared_values.disable_connectivity_check();
 
-        let endpoints = params.get_next_hop_endpoints();
-
         #[cfg(target_os = "windows")]
         let clients = AllowedClients::from(vec![std::env::current_exe().unwrap()]);
 
@@ -181,13 +177,7 @@ impl ConnectingState {
         #[cfg(target_os = "windows")]
         let exit_endpoint_ip = params.get_exit_hop_endpoint().map(|ep| ep.address.ip());
 
-        let peer_endpoints = endpoints
-            .into_iter()
-            .map(|endpoint| AllowedEndpoint {
-                endpoint,
-                clients: clients.clone(),
-            })
-            .collect();
+        let peer_endpoints = params.get_allowed_next_hop_endpoints(clients);
 
         #[cfg(target_os = "macos")]
         let redirect_interface = shared_values

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -10,9 +10,7 @@ use talpid_routing::RouteManagerHandle;
 use talpid_tunnel::tun_provider::TunProvider;
 use talpid_tunnel::{EventHook, TunnelArgs, TunnelEvent, TunnelMetadata};
 use talpid_types::ErrorExt;
-use talpid_types::net::{
-    AllowedClients, AllowedEndpoint, AllowedTunnelTraffic, wireguard::TunnelParameters,
-};
+use talpid_types::net::{AllowedClients, AllowedTunnelTraffic, wireguard::TunnelParameters};
 use talpid_types::tunnel::{ErrorStateCause, FirewallPolicyError};
 
 use super::connected_state::TunnelEventsReceiver;
@@ -169,8 +167,6 @@ impl ConnectingState {
         #[cfg(target_os = "linux")]
         shared_values.disable_connectivity_check();
 
-        let endpoints = params.get_next_hop_endpoints();
-
         #[cfg(target_os = "windows")]
         let clients = AllowedClients::from(vec![std::env::current_exe().unwrap()]);
 
@@ -180,13 +176,7 @@ impl ConnectingState {
         #[cfg(target_os = "windows")]
         let exit_endpoint_ip = params.get_exit_hop_endpoint().map(|ep| ep.address.ip());
 
-        let peer_endpoints = endpoints
-            .into_iter()
-            .map(|endpoint| AllowedEndpoint {
-                endpoint,
-                clients: clients.clone(),
-            })
-            .collect();
+        let peer_endpoints = params.get_allowed_next_hop_endpoints(clients);
 
         #[cfg(target_os = "macos")]
         let redirect_interface = shared_values

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -305,6 +305,11 @@ pub enum AllowedClients {
 
 #[cfg(unix)]
 impl AllowedClients {
+    /// Allow all clients to leak traffic to an allowed [`Endpoint`].
+    pub const fn all() -> Self {
+        AllowedClients::All
+    }
+
     pub fn allow_all(&self) -> bool {
         matches!(self, AllowedClients::All)
     }

--- a/talpid-types/src/net/proxy.rs
+++ b/talpid-types/src/net/proxy.rs
@@ -1,7 +1,11 @@
 use crate::net::Endpoint;
 use safelog::Sensitive;
 use serde::{Deserialize, Serialize};
-use std::{fmt, net::SocketAddr, str::FromStr};
+use std::{
+    fmt,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    str::FromStr,
+};
 
 use super::TransportProtocol;
 
@@ -62,6 +66,47 @@ impl CustomProxy {
                 endpoint: Endpoint::from_socket_address(settings.endpoint, TransportProtocol::Tcp),
                 proxy_type: ProxyType::Shadowsocks,
             },
+        }
+    }
+}
+
+/// A SOCKS5 proxy to relay tunnel traffic through, using `UDP ASSOCIATE`.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum Socks5Proxy {
+    Local(Socks5Local),
+    Remote(Socks5Remote),
+}
+
+impl Socks5Proxy {
+    /// The address to open the SOCKS5 control connection to.
+    pub fn proxy_addr(&self) -> SocketAddr {
+        match self {
+            Socks5Proxy::Local(settings) => {
+                SocketAddr::new(IpAddr::from(Ipv4Addr::LOCALHOST), settings.local_port)
+            }
+            Socks5Proxy::Remote(settings) => settings.endpoint,
+        }
+    }
+
+    pub fn auth(&self) -> Option<&SocksAuth> {
+        match self {
+            Socks5Proxy::Local(_) => None,
+            Socks5Proxy::Remote(settings) => settings.auth.as_ref(),
+        }
+    }
+
+    /// The endpoint that traffic actually leaves the machine for.
+    ///
+    /// For a local proxy this is not the proxy itself, but wherever the proxy forwards to -- for
+    /// instance the server of a VLESS client that exposes a SOCKS5 front-end. It cannot be
+    /// derived from the SOCKS5 protocol, which is why [`Socks5Local`] carries it.
+    pub fn next_hop_endpoint(&self) -> Endpoint {
+        match self {
+            Socks5Proxy::Local(settings) => settings.remote_endpoint,
+            Socks5Proxy::Remote(settings) => {
+                Endpoint::from_socket_address(settings.endpoint, TransportProtocol::Tcp)
+            }
         }
     }
 }

--- a/talpid-types/src/net/proxy.rs
+++ b/talpid-types/src/net/proxy.rs
@@ -1,7 +1,11 @@
 use crate::net::Endpoint;
 use safelog::Sensitive;
 use serde::{Deserialize, Serialize};
-use std::{fmt, net::SocketAddr, str::FromStr};
+use std::{
+    fmt,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    str::FromStr,
+};
 
 use super::TransportProtocol;
 
@@ -62,6 +66,50 @@ impl CustomProxy {
                 endpoint: Endpoint::from_socket_address(settings.endpoint, TransportProtocol::Tcp),
                 proxy_type: ProxyType::Shadowsocks,
             },
+        }
+    }
+}
+
+/// A SOCKS5 proxy to relay tunnel traffic through, using `UDP ASSOCIATE`.
+///
+/// This is a transport, not an obfuscation method: any obfuscation is applied to the payload
+/// before it is handed to the proxy.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum Socks5Proxy {
+    Local(Socks5Local),
+    Remote(Socks5Remote),
+}
+
+impl Socks5Proxy {
+    /// The address to open the SOCKS5 control connection to.
+    pub fn proxy_addr(&self) -> SocketAddr {
+        match self {
+            Socks5Proxy::Local(settings) => {
+                SocketAddr::new(IpAddr::from(Ipv4Addr::LOCALHOST), settings.local_port)
+            }
+            Socks5Proxy::Remote(settings) => settings.endpoint,
+        }
+    }
+
+    pub fn auth(&self) -> Option<&SocksAuth> {
+        match self {
+            Socks5Proxy::Local(_) => None,
+            Socks5Proxy::Remote(settings) => settings.auth.as_ref(),
+        }
+    }
+
+    /// The endpoint that traffic actually leaves the machine for.
+    ///
+    /// For a local proxy this is not the proxy itself, but wherever the proxy forwards to -- for
+    /// instance the server of a VLESS client that exposes a SOCKS5 front-end. It cannot be
+    /// derived from the SOCKS5 protocol, which is why [`Socks5Local`] carries it.
+    pub fn next_hop_endpoint(&self) -> Endpoint {
+        match self {
+            Socks5Proxy::Local(settings) => settings.remote_endpoint,
+            Socks5Proxy::Remote(settings) => {
+                Endpoint::from_socket_address(settings.endpoint, TransportProtocol::Tcp)
+            }
         }
     }
 }

--- a/talpid-types/src/net/proxy.rs
+++ b/talpid-types/src/net/proxy.rs
@@ -111,6 +111,27 @@ impl Socks5Proxy {
     }
 }
 
+impl fmt::Display for Socks5Proxy {
+    /// Note that this says only whether credentials are configured, never what they are, since it
+    /// may end up in a log.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Socks5Proxy::Local(settings) => write!(
+                f,
+                "localhost:{}, forwarding to {}",
+                settings.local_port, settings.remote_endpoint
+            ),
+            Socks5Proxy::Remote(settings) => {
+                write!(f, "{}", settings.endpoint)?;
+                match settings.auth {
+                    Some(_) => f.write_str(" (authenticated)"),
+                    None => Ok(()),
+                }
+            }
+        }
+    }
+}
+
 impl From<Socks5Remote> for CustomProxy {
     fn from(value: Socks5Remote) -> Self {
         CustomProxy::Socks5Remote(value)

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -20,11 +20,17 @@ pub struct TunnelParameters {
     pub options: TunnelOptions,
     pub generic_options: GenericTunnelOptions,
     pub obfuscation: Option<super::obfuscation::Obfuscators>,
+    pub proxy: Option<super::proxy::Socks5Proxy>,
 }
 
 impl TunnelParameters {
     /// Returns the endpoint that will be connected to
     pub fn get_next_hop_endpoints(&self) -> Vec<Endpoint> {
+        // With a proxy, the obfuscation endpoints are reached through it and never appear on the
+        // wire, so the proxy's next hop is the only endpoint that leaves the machine.
+        if let Some(proxy) = &self.proxy {
+            return vec![proxy.next_hop_endpoint()];
+        }
         self.obfuscation
             .as_ref()
             .map(|proxy| proxy.endpoints())
@@ -58,6 +64,8 @@ impl TunnelParameters {
         cfg!(target_os = "macos")
             || self.options.userspace
             || self.options.daita
+            // A SOCKS5 proxy only exists as an inline GotaTun transport
+            || self.proxy.is_some()
             // Always prefer GotaTun for multihop on Windows
             || (cfg!(target_os = "windows") && self.connection.exit_peer.is_some())
     }

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -1,6 +1,6 @@
 use crate::net::{
     AllowedClients, AllowedEndpoint, Endpoint, GenericTunnelOptions, ObfuscationInfo,
-    TransportProtocol, TunnelEndpoint,
+    TransportProtocol, TunnelEndpoint, proxy::Socks5Proxy,
 };
 use base64::{Engine, engine::general_purpose::STANDARD};
 use ipnetwork::IpNetwork;
@@ -22,7 +22,7 @@ pub struct TunnelParameters {
     pub generic_options: GenericTunnelOptions,
     pub obfuscation: Option<super::obfuscation::Obfuscators>,
     /// SOCKS5 proxy to relay the tunnel through. Any obfuscation is applied underneath it.
-    pub proxy: Option<super::proxy::Socks5Proxy>,
+    pub proxy: Option<Socks5Proxy>,
 }
 
 impl TunnelParameters {
@@ -48,11 +48,11 @@ impl TunnelParameters {
         default_clients: AllowedClients,
     ) -> Vec<AllowedEndpoint> {
         // A local SOCKS5 proxy runs as some other process, and is the one connecting to the next
-        // hop, so restricting the exemption to our own clients would block it. The same exemption
-        // applies to a remote proxy, so that it can be shared with other applications.
+        // hop, so restricting the exemption to our own clients would block it. A remote proxy is
+        // reached by us, so it needs no such exemption.
         let clients = match self.proxy {
-            Some(_) => AllowedClients::all(),
-            None => default_clients,
+            Some(Socks5Proxy::Local(_)) => AllowedClients::all(),
+            Some(Socks5Proxy::Remote(_)) | None => default_clients,
         };
 
         self.get_next_hop_endpoints()
@@ -398,7 +398,7 @@ fn key_from_base64<K: From<[u8; 32]>>(key: &str) -> Result<K, InvalidKey> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::net::proxy::{Socks5Local, Socks5Proxy, Socks5Remote};
+    use crate::net::proxy::{Socks5Local, Socks5Remote};
 
     const PEER_ENDPOINT: &str = "192.0.2.1:51820";
     const PROXY_ENDPOINT: &str = "198.51.100.1:1080";
@@ -467,8 +467,7 @@ mod tests {
         );
     }
 
-    /// A remote proxy is exempted for all clients, so that it can be shared with other
-    /// applications.
+    /// Only the daemon connects to a remote proxy, so it needs no exemption for other clients.
     #[test]
     fn test_allowed_next_hop_endpoints_with_remote_proxy() {
         let params = tunnel_parameters(Some(Socks5Proxy::Remote(Socks5Remote {
@@ -485,7 +484,7 @@ mod tests {
                     PROXY_ENDPOINT.parse().unwrap(),
                     TransportProtocol::Tcp
                 ),
-                clients: AllowedClients::all(),
+                clients: default_clients(),
             }]
         );
     }

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -1,5 +1,6 @@
 use crate::net::{
-    Endpoint, GenericTunnelOptions, ObfuscationInfo, TransportProtocol, TunnelEndpoint,
+    AllowedClients, AllowedEndpoint, Endpoint, GenericTunnelOptions, ObfuscationInfo,
+    TransportProtocol, TunnelEndpoint,
 };
 use base64::{Engine, engine::general_purpose::STANDARD};
 use ipnetwork::IpNetwork;
@@ -36,6 +37,31 @@ impl TunnelParameters {
             .as_ref()
             .map(|proxy| proxy.endpoints())
             .unwrap_or_else(|| vec![self.connection.get_endpoint()])
+    }
+
+    /// Returns the endpoints that will be connected to, along with the clients that are allowed
+    /// to reach them outside of the tunnel.
+    ///
+    /// `default_clients` is used for endpoints that only this process connects to.
+    pub fn get_allowed_next_hop_endpoints(
+        &self,
+        default_clients: AllowedClients,
+    ) -> Vec<AllowedEndpoint> {
+        // A local SOCKS5 proxy runs as some other process, and is the one connecting to the next
+        // hop, so restricting the exemption to our own clients would block it. The same exemption
+        // applies to a remote proxy, so that it can be shared with other applications.
+        let clients = match self.proxy {
+            Some(_) => AllowedClients::all(),
+            None => default_clients,
+        };
+
+        self.get_next_hop_endpoints()
+            .into_iter()
+            .map(|endpoint| AllowedEndpoint {
+                endpoint,
+                clients: clients.clone(),
+            })
+            .collect()
     }
 
     pub fn get_tunnel_endpoint(&self) -> TunnelEndpoint {
@@ -367,4 +393,122 @@ fn key_from_base64<K: From<[u8; 32]>>(key: &str) -> Result<K, InvalidKey> {
     let mut key = [0u8; 32];
     key.copy_from_slice(&bytes);
     Ok(From::from(key))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::net::proxy::{Socks5Local, Socks5Proxy, Socks5Remote};
+
+    const PEER_ENDPOINT: &str = "192.0.2.1:51820";
+    const PROXY_ENDPOINT: &str = "198.51.100.1:1080";
+    const PROXY_NEXT_HOP: &str = "203.0.113.1:443";
+
+    /// The clients that are allowed to reach an endpoint that only the daemon connects to.
+    fn default_clients() -> AllowedClients {
+        #[cfg(unix)]
+        {
+            AllowedClients::Root
+        }
+        #[cfg(windows)]
+        {
+            AllowedClients::from(vec![std::path::PathBuf::from("daemon.exe")])
+        }
+    }
+
+    fn tunnel_parameters(proxy: Option<Socks5Proxy>) -> TunnelParameters {
+        TunnelParameters {
+            connection: ConnectionConfig {
+                tunnel: TunnelConfig {
+                    private_key: PrivateKey::new_from_random(),
+                    addresses: vec![IpAddr::from(Ipv4Addr::new(10, 64, 0, 1))],
+                },
+                peer: PeerConfig {
+                    public_key: PrivateKey::new_from_random().public_key(),
+                    allowed_ips: vec!["0.0.0.0/0".parse().unwrap()],
+                    endpoint: PEER_ENDPOINT.parse().unwrap(),
+                    psk: None,
+                    constant_packet_size: false,
+                },
+                exit_peer: None,
+                ipv4_gateway: Ipv4Addr::new(10, 64, 0, 1),
+                ipv6_gateway: None,
+                #[cfg(target_os = "linux")]
+                fwmark: None,
+            },
+            options: TunnelOptions {
+                mtu: None,
+                quantum_resistant: false,
+                daita: false,
+                userspace: false,
+            },
+            generic_options: GenericTunnelOptions { enable_ipv6: false },
+            obfuscation: None,
+            proxy,
+        }
+    }
+
+    /// Without a proxy, only our own clients may reach the relay.
+    #[test]
+    fn test_allowed_next_hop_endpoints_without_proxy() {
+        let params = tunnel_parameters(None);
+
+        let allowed = params.get_allowed_next_hop_endpoints(default_clients());
+
+        assert_eq!(
+            allowed,
+            vec![AllowedEndpoint {
+                endpoint: Endpoint::from_socket_address(
+                    PEER_ENDPOINT.parse().unwrap(),
+                    TransportProtocol::Udp
+                ),
+                clients: default_clients(),
+            }]
+        );
+    }
+
+    /// A remote proxy is exempted for all clients, so that it can be shared with other
+    /// applications.
+    #[test]
+    fn test_allowed_next_hop_endpoints_with_remote_proxy() {
+        let params = tunnel_parameters(Some(Socks5Proxy::Remote(Socks5Remote {
+            endpoint: PROXY_ENDPOINT.parse().unwrap(),
+            auth: None,
+        })));
+
+        let allowed = params.get_allowed_next_hop_endpoints(default_clients());
+
+        assert_eq!(
+            allowed,
+            vec![AllowedEndpoint {
+                endpoint: Endpoint::from_socket_address(
+                    PROXY_ENDPOINT.parse().unwrap(),
+                    TransportProtocol::Tcp
+                ),
+                clients: AllowedClients::all(),
+            }]
+        );
+    }
+
+    /// A local proxy connects to its next hop itself, so that endpoint must be exempted for all
+    /// clients rather than for ours.
+    #[test]
+    fn test_allowed_next_hop_endpoints_with_local_proxy() {
+        let next_hop =
+            Endpoint::from_socket_address(PROXY_NEXT_HOP.parse().unwrap(), TransportProtocol::Tcp);
+        let params = tunnel_parameters(Some(Socks5Proxy::Local(Socks5Local {
+            remote_endpoint: next_hop,
+            local_port: 1080,
+        })));
+
+        let allowed = params.get_allowed_next_hop_endpoints(default_clients());
+
+        assert_eq!(
+            allowed,
+            vec![AllowedEndpoint {
+                endpoint: next_hop,
+                clients: AllowedClients::all(),
+            }]
+        );
+    }
 }

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -1,5 +1,6 @@
 use crate::net::{
-    Endpoint, GenericTunnelOptions, ObfuscationInfo, TransportProtocol, TunnelEndpoint,
+    AllowedClients, AllowedEndpoint, Endpoint, GenericTunnelOptions, ObfuscationInfo,
+    TransportProtocol, TunnelEndpoint, proxy::Socks5Proxy,
 };
 use base64::{Engine, engine::general_purpose::STANDARD};
 use ipnetwork::IpNetwork;
@@ -20,7 +21,7 @@ pub struct TunnelParameters {
     pub options: TunnelOptions,
     pub generic_options: GenericTunnelOptions,
     pub obfuscation: Option<super::obfuscation::Obfuscators>,
-    pub proxy: Option<super::proxy::Socks5Proxy>,
+    pub proxy: Option<Socks5Proxy>,
 }
 
 impl TunnelParameters {
@@ -35,6 +36,31 @@ impl TunnelParameters {
             .as_ref()
             .map(|proxy| proxy.endpoints())
             .unwrap_or_else(|| vec![self.connection.get_endpoint()])
+    }
+
+    /// Returns the endpoints that will be connected to, along with the clients that are allowed
+    /// to reach them outside of the tunnel.
+    ///
+    /// `default_clients` is used for endpoints that only this process connects to.
+    pub fn get_allowed_next_hop_endpoints(
+        &self,
+        default_clients: AllowedClients,
+    ) -> Vec<AllowedEndpoint> {
+        // A local SOCKS5 proxy runs as some other process, and is the one connecting to the next
+        // hop, so restricting the exemption to our own clients would block it. A remote proxy is
+        // reached by us, so it needs no such exemption.
+        let clients = match self.proxy {
+            Some(Socks5Proxy::Local(_)) => AllowedClients::all(),
+            Some(Socks5Proxy::Remote(_)) | None => default_clients,
+        };
+
+        self.get_next_hop_endpoints()
+            .into_iter()
+            .map(|endpoint| AllowedEndpoint {
+                endpoint,
+                clients: clients.clone(),
+            })
+            .collect()
     }
 
     pub fn get_tunnel_endpoint(&self) -> TunnelEndpoint {
@@ -366,4 +392,121 @@ fn key_from_base64<K: From<[u8; 32]>>(key: &str) -> Result<K, InvalidKey> {
     let mut key = [0u8; 32];
     key.copy_from_slice(&bytes);
     Ok(From::from(key))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::net::proxy::{Socks5Local, Socks5Remote};
+
+    const PEER_ENDPOINT: &str = "192.0.2.1:51820";
+    const PROXY_ENDPOINT: &str = "198.51.100.1:1080";
+    const PROXY_NEXT_HOP: &str = "203.0.113.1:443";
+
+    /// The clients that are allowed to reach an endpoint that only the daemon connects to.
+    fn default_clients() -> AllowedClients {
+        #[cfg(unix)]
+        {
+            AllowedClients::Root
+        }
+        #[cfg(windows)]
+        {
+            AllowedClients::from(vec![std::path::PathBuf::from("daemon.exe")])
+        }
+    }
+
+    fn tunnel_parameters(proxy: Option<Socks5Proxy>) -> TunnelParameters {
+        TunnelParameters {
+            connection: ConnectionConfig {
+                tunnel: TunnelConfig {
+                    private_key: PrivateKey::new_from_random(),
+                    addresses: vec![IpAddr::from(Ipv4Addr::new(10, 64, 0, 1))],
+                },
+                peer: PeerConfig {
+                    public_key: PrivateKey::new_from_random().public_key(),
+                    allowed_ips: vec!["0.0.0.0/0".parse().unwrap()],
+                    endpoint: PEER_ENDPOINT.parse().unwrap(),
+                    psk: None,
+                    constant_packet_size: false,
+                },
+                exit_peer: None,
+                ipv4_gateway: Ipv4Addr::new(10, 64, 0, 1),
+                ipv6_gateway: None,
+                #[cfg(target_os = "linux")]
+                fwmark: None,
+            },
+            options: TunnelOptions {
+                mtu: None,
+                quantum_resistant: false,
+                daita: false,
+                userspace: false,
+            },
+            generic_options: GenericTunnelOptions { enable_ipv6: false },
+            obfuscation: None,
+            proxy,
+        }
+    }
+
+    /// Without a proxy, only our own clients may reach the relay.
+    #[test]
+    fn test_allowed_next_hop_endpoints_without_proxy() {
+        let params = tunnel_parameters(None);
+
+        let allowed = params.get_allowed_next_hop_endpoints(default_clients());
+
+        assert_eq!(
+            allowed,
+            vec![AllowedEndpoint {
+                endpoint: Endpoint::from_socket_address(
+                    PEER_ENDPOINT.parse().unwrap(),
+                    TransportProtocol::Udp
+                ),
+                clients: default_clients(),
+            }]
+        );
+    }
+
+    /// Only the daemon connects to a remote proxy, so it needs no exemption for other clients.
+    #[test]
+    fn test_allowed_next_hop_endpoints_with_remote_proxy() {
+        let params = tunnel_parameters(Some(Socks5Proxy::Remote(Socks5Remote {
+            endpoint: PROXY_ENDPOINT.parse().unwrap(),
+            auth: None,
+        })));
+
+        let allowed = params.get_allowed_next_hop_endpoints(default_clients());
+
+        assert_eq!(
+            allowed,
+            vec![AllowedEndpoint {
+                endpoint: Endpoint::from_socket_address(
+                    PROXY_ENDPOINT.parse().unwrap(),
+                    TransportProtocol::Tcp
+                ),
+                clients: default_clients(),
+            }]
+        );
+    }
+
+    /// A local proxy connects to its next hop itself, so that endpoint must be exempted for all
+    /// clients rather than for ours.
+    #[test]
+    fn test_allowed_next_hop_endpoints_with_local_proxy() {
+        let next_hop =
+            Endpoint::from_socket_address(PROXY_NEXT_HOP.parse().unwrap(), TransportProtocol::Tcp);
+        let params = tunnel_parameters(Some(Socks5Proxy::Local(Socks5Local {
+            remote_endpoint: next_hop,
+            local_port: 1080,
+        })));
+
+        let allowed = params.get_allowed_next_hop_endpoints(default_clients());
+
+        assert_eq!(
+            allowed,
+            vec![AllowedEndpoint {
+                endpoint: next_hop,
+                clients: AllowedClients::all(),
+            }]
+        );
+    }
 }

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -20,11 +20,18 @@ pub struct TunnelParameters {
     pub options: TunnelOptions,
     pub generic_options: GenericTunnelOptions,
     pub obfuscation: Option<super::obfuscation::Obfuscators>,
+    /// SOCKS5 proxy to relay the tunnel through. Any obfuscation is applied underneath it.
+    pub proxy: Option<super::proxy::Socks5Proxy>,
 }
 
 impl TunnelParameters {
     /// Returns the endpoint that will be connected to
     pub fn get_next_hop_endpoints(&self) -> Vec<Endpoint> {
+        // With a proxy, the obfuscation endpoints are reached through it and never appear on the
+        // wire, so the proxy's next hop is the only endpoint that leaves the machine.
+        if let Some(proxy) = &self.proxy {
+            return vec![proxy.next_hop_endpoint()];
+        }
         self.obfuscation
             .as_ref()
             .map(|proxy| proxy.endpoints())
@@ -58,6 +65,8 @@ impl TunnelParameters {
         cfg!(target_os = "macos")
             || self.options.userspace
             || self.options.daita
+            // A SOCKS5 proxy only exists as an inline GotaTun transport
+            || self.proxy.is_some()
             // Always prefer GotaTun for multihop on Windows
             || (cfg!(target_os = "windows") && self.connection.exit_peer.is_some())
     }

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 [dependencies]
 async-trait = { workspace = true }
 byteorder = "1"
+bytes.workspace = true
 futures = { workspace = true }
 gotatun = { workspace = true, features = ["daita", "device", "tun"] }
 internet-checksum = "0.2"

--- a/talpid-wireguard/src/config.rs
+++ b/talpid-wireguard/src/config.rs
@@ -1,5 +1,9 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
-use talpid_types::net::{GenericTunnelOptions, obfuscation::Obfuscators, wireguard};
+use talpid_types::net::{
+    GenericTunnelOptions, obfuscation::Obfuscators, proxy::Socks5Proxy, wireguard,
+};
+
+use tunnel_obfuscation::socks5;
 
 /// Name to use for the tunnel device
 #[cfg(target_os = "linux")]
@@ -31,6 +35,8 @@ pub struct Config {
     pub obfuscator_config: Option<Obfuscators>,
     /// MTU including obfuscation overhead.
     pub obfuscation_mtu: u16,
+    /// SOCKS5 proxy to relay the tunnel through. Obfuscation is applied on top of it.
+    pub proxy: Option<Socks5Proxy>,
     /// Enable quantum-resistant PSK exchange
     pub quantum_resistant: bool,
     /// Enable DAITA
@@ -47,6 +53,10 @@ pub enum Error {
     /// Peer has no valid IPs
     #[error("Supplied peer has no valid IPs")]
     InvalidPeerIpError,
+
+    /// The obfuscation opens its own connection, leaving nothing for the proxy to relay.
+    #[error("The selected obfuscation cannot be relayed through a SOCKS5 proxy")]
+    ObfuscationNotProxyable,
 }
 
 impl Config {
@@ -61,6 +71,7 @@ impl Config {
             &params.options,
             &params.generic_options,
             &params.obfuscation,
+            &params.proxy,
             default_mtu,
             obfuscation_mtu,
         )
@@ -72,6 +83,7 @@ impl Config {
         wg_options: &wireguard::TunnelOptions,
         generic_options: &GenericTunnelOptions,
         obfuscator_config: &Option<Obfuscators>,
+        proxy: &Option<Socks5Proxy>,
         default_mtu: u16,
         obfuscation_mtu: u16,
     ) -> Result<Config, Error> {
@@ -103,9 +115,17 @@ impl Config {
             enable_ipv6: generic_options.enable_ipv6,
             obfuscator_config: obfuscator_config.to_owned(),
             obfuscation_mtu,
+            proxy: proxy.to_owned(),
             quantum_resistant: wg_options.quantum_resistant,
             daita: wg_options.daita,
         };
+
+        if config.proxy.is_some()
+            && let Some(settings) = config.obfuscation_settings()
+            && !settings.stacks_on_provided_socket()
+        {
+            return Err(Error::ObfuscationNotProxyable);
+        }
 
         for peer in config.peers_mut() {
             peer.allowed_ips
@@ -131,6 +151,27 @@ impl Config {
                 self.obfuscation_mtu,
             )
         })
+    }
+
+    /// The per-datagram overhead of relaying through a SOCKS5 proxy, in bytes.
+    ///
+    /// This is not covered by [`crate::obfuscation::ObfuscatorHandle::packet_overhead`], since no
+    /// obfuscator is created for an inline transport.
+    pub fn socks5_packet_overhead(&self) -> u16 {
+        if self.proxy.is_none() {
+            return 0;
+        }
+
+        // The header encodes the address that the layer above is sending to: the obfuscation
+        // endpoint when obfuscation is stacked on top, and the peer endpoint otherwise.
+        let destination = self
+            .obfuscator_config
+            .as_ref()
+            .and_then(|obfuscators| obfuscators.endpoints().first().map(|hop| hop.address))
+            .unwrap_or(self.entry_peer.endpoint);
+
+        u16::try_from(socks5::header_len(&destination))
+            .expect("a SOCKS5 header is at most a few dozen bytes")
     }
 
     /// Return whether the config connects to an exit peer from another remote peer.

--- a/talpid-wireguard/src/config.rs
+++ b/talpid-wireguard/src/config.rs
@@ -1,5 +1,11 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
-use talpid_types::net::{GenericTunnelOptions, obfuscation::Obfuscators, wireguard};
+use talpid_types::net::{
+    GenericTunnelOptions, obfuscation::Obfuscators, proxy::Socks5Proxy, wireguard,
+};
+
+use tunnel_obfuscation::socks5;
+
+use crate::obfuscation::is_inline_obfuscation;
 
 /// Name to use for the tunnel device
 #[cfg(target_os = "linux")]
@@ -29,6 +35,8 @@ pub struct Config {
     pub enable_ipv6: bool,
     /// Obfuscator config to be used for reaching the relay.
     pub obfuscator_config: Option<Obfuscators>,
+    /// SOCKS5 proxy to relay the tunnel through. Obfuscation is applied on top of it.
+    pub proxy: Option<Socks5Proxy>,
     /// Enable quantum-resistant PSK exchange
     pub quantum_resistant: bool,
     /// Enable DAITA
@@ -45,6 +53,11 @@ pub enum Error {
     /// Peer has no valid IPs
     #[error("Supplied peer has no valid IPs")]
     InvalidPeerIpError,
+
+    /// The obfuscation method runs as a local proxy socket, which WireGuard reaches over loopback,
+    /// so there is nothing for the SOCKS5 transport to relay.
+    #[error("The selected obfuscation cannot be relayed through a SOCKS5 proxy")]
+    ObfuscationNotProxyable,
 }
 
 impl Config {
@@ -58,6 +71,7 @@ impl Config {
             &params.options,
             &params.generic_options,
             &params.obfuscation,
+            &params.proxy,
             default_mtu,
         )
     }
@@ -68,9 +82,16 @@ impl Config {
         wg_options: &wireguard::TunnelOptions,
         generic_options: &GenericTunnelOptions,
         obfuscator_config: &Option<Obfuscators>,
+        proxy: &Option<Socks5Proxy>,
         default_mtu: u16,
     ) -> Result<Config, Error> {
         let mut tunnel = connection.tunnel.clone();
+
+        if let (Some(obfuscators), Some(_)) = (obfuscator_config, proxy)
+            && !is_inline_obfuscation(obfuscators)
+        {
+            return Err(Error::ObfuscationNotProxyable);
+        }
 
         let mtu = wg_options.mtu.unwrap_or(default_mtu);
 
@@ -97,6 +118,7 @@ impl Config {
             #[cfg(target_os = "linux")]
             enable_ipv6: generic_options.enable_ipv6,
             obfuscator_config: obfuscator_config.to_owned(),
+            proxy: proxy.to_owned(),
             quantum_resistant: wg_options.quantum_resistant,
             daita: wg_options.daita,
         };
@@ -110,6 +132,27 @@ impl Config {
         }
 
         Ok(config)
+    }
+
+    /// The per-datagram overhead of relaying through a SOCKS5 proxy, in bytes.
+    ///
+    /// This is not covered by [`crate::obfuscation::ObfuscatorHandle::packet_overhead`], since no
+    /// obfuscator is created for an inline transport.
+    pub fn socks5_packet_overhead(&self) -> u16 {
+        if self.proxy.is_none() {
+            return 0;
+        }
+
+        // The header encodes the address that the layer above is sending to: the obfuscation
+        // endpoint when obfuscation is stacked on top, and the peer endpoint otherwise.
+        let destination = self
+            .obfuscator_config
+            .as_ref()
+            .and_then(|obfuscators| obfuscators.endpoints().first().map(|hop| hop.address))
+            .unwrap_or(self.entry_peer.endpoint);
+
+        u16::try_from(socks5::header_len(&destination))
+            .expect("a SOCKS5 header is at most a few dozen bytes")
     }
 
     /// Return whether the config connects to an exit peer from another remote peer.

--- a/talpid-wireguard/src/gotatun/mod.rs
+++ b/talpid-wireguard/src/gotatun/mod.rs
@@ -44,9 +44,11 @@ use gotatun::tun::{
 
 mod conversions;
 mod obfuscation;
+mod socks5;
 
 use conversions::to_gotatun_peer;
 use obfuscation::MaybeObfuscatingTransportFactory;
+use socks5::MaybeSocks5TransportFactory;
 
 #[cfg(target_os = "android")]
 type UdpFactory = AndroidUdpSocketFactory;
@@ -54,7 +56,9 @@ type UdpFactory = AndroidUdpSocketFactory;
 #[cfg(not(target_os = "android"))]
 type UdpFactory = UdpSocketFactory;
 
-type TransportFactory = MaybeObfuscatingTransportFactory<UdpFactory>;
+/// Obfuscation is applied to the payload before it is handed to the proxy, so it wraps the SOCKS5
+/// transport rather than the other way around.
+type TransportFactory = MaybeObfuscatingTransportFactory<MaybeSocks5TransportFactory<UdpFactory>>;
 
 type SinglehopDevice = Device<(TransportFactory, GotaTunDevice, GotaTunDevice)>;
 type ExitDevice = Device<(UdpChannelFactory, GotaTunDevice, GotaTunDevice)>;
@@ -519,7 +523,7 @@ async fn create_devices(
         #[cfg(target_os = "android")] android_tun: Arc<Tun>,
         optimize_buffer_size: bool,
     ) -> Result<Devices, gotatun::device::Error> {
-        let factory = udp_obfuscator_factory(
+        let factory = udp_transport_factory(
             config,
             optimize_buffer_size,
             #[cfg(target_os = "android")]
@@ -783,24 +787,31 @@ where
     (ip_send, ip_recv)
 }
 
-/// Provide a [`UdpSocketFactory`] for the entry-device.
+/// Build the UDP transport stack for the entry-device: plain sockets, optionally relayed through a
+/// SOCKS5 proxy, optionally obfuscated on top of that.
 ///
 /// - `optimize_buffer_size`: if UDP socket buffer sizes should be tweaked. Empirically this might
 ///   now always succeed due to suspected hardware related issues / limitations.
-fn udp_obfuscator_factory(
+fn udp_transport_factory(
     config: &Config,
     optimize_buffer_size: bool,
     #[cfg(target_os = "android")] android_tun: Arc<Tun>,
-) -> MaybeObfuscatingTransportFactory<UdpFactory> {
+) -> TransportFactory {
     let factory = cfg_select! {
         target_os = "android" => {
             AndroidUdpSocketFactory {
-                tun: android_tun,
+                tun: Arc::clone(&android_tun),
                 udp: udp_socket_factory(optimize_buffer_size),
             }
         },
         _ => { udp_socket_factory(optimize_buffer_size) }
     };
+    let factory = MaybeSocks5TransportFactory::from_config(
+        factory,
+        config,
+        #[cfg(target_os = "android")]
+        android_tun,
+    );
     MaybeObfuscatingTransportFactory::from_config(factory, config)
 }
 

--- a/talpid-wireguard/src/gotatun/mod.rs
+++ b/talpid-wireguard/src/gotatun/mod.rs
@@ -42,6 +42,7 @@ use gotatun::tun::{
 mod conversions;
 mod lan_filter;
 mod obfuscation;
+mod socks5;
 mod source_filter;
 
 use conversions::to_gotatun_peer;
@@ -480,12 +481,10 @@ async fn create_devices(
     ) -> Result<Devices, gotatun::device::Error> {
         let factory = MaybeObfuscatingTransportFactory::from_settings(
             optimize_buffer_size,
-            config
-                .obfuscation_settings()
-                .as_ref()
-                .and_then(|settings| settings.single()),
+            config.obfuscation_settings().as_ref(),
+            config.proxy.clone(),
             bypass,
-        );
+        )?;
         // The addresses assigned to the tun device, i.e. the only source addresses we accept
         // packets from. See [SourceFilter].
         let source_v4 = config.tunnel.addresses.iter().find_map(|ip| match ip {

--- a/talpid-wireguard/src/gotatun/obfuscation/mod.rs
+++ b/talpid-wireguard/src/gotatun/obfuscation/mod.rs
@@ -14,13 +14,20 @@ use gotatun::{
     },
 };
 use talpid_net::bypass::{BypassSocket, SocketBypass};
-use talpid_types::net::obfuscation::LwoVersion;
-use tunnel_obfuscation::{Settings as ObfuscationSettings, create_transport};
+use talpid_types::net::{obfuscation::LwoVersion, proxy::Socks5Proxy};
+use tunnel_obfuscation::{Settings as TransportSettings, create_transport};
 
+use crate::obfuscation::ObfuscationSettings;
+
+use super::socks5::{MaybeSocks5Recv, MaybeSocks5Send, MaybeSocks5TransportFactory};
 use lwo::{LwoKeys, LwoRecv, LwoSend, LwoUdpTransportFactory};
 use transport::{ObfuscatingRecv, ObfuscatingSend};
 
 pub use lwo::{lwo_timer_params, lwo_version};
+
+type ProxiedFactory = MaybeSocks5TransportFactory<BypassingSocketFactory>;
+type ProxiedSend = MaybeSocks5Send<BypassedUdpSend>;
+type ProxiedRecv = MaybeSocks5Recv<BypassedUdpRecv>;
 
 #[derive(Clone)]
 pub struct BypassedUdpSend(Arc<BypassSocket<UdpSocket>>);
@@ -79,8 +86,8 @@ impl UdpRecv for BypassedUdpRecv {
 /// A [`UdpSend`] wrapper that optionally obfuscates outgoing packets.
 #[derive(Clone)]
 pub enum MaybeObfuscatingSend {
-    Plain(BypassedUdpSend),
-    Lwo(LwoSend<BypassedUdpSend>),
+    Plain(ProxiedSend),
+    Lwo(LwoSend<ProxiedSend>),
     Transport(ObfuscatingSend),
 }
 
@@ -135,8 +142,8 @@ impl UdpSend for MaybeObfuscatingSend {
 
 /// A [`UdpRecv`] enum that either passes through to a plain receiver or applies deobfuscation.
 pub enum MaybeObfuscatingRecv {
-    Plain(BypassedUdpRecv),
-    Lwo(LwoRecv<BypassedUdpRecv>),
+    Plain(ProxiedRecv),
+    Lwo(LwoRecv<ProxiedRecv>),
     Transport(ObfuscatingRecv),
 }
 
@@ -181,24 +188,42 @@ pub struct BypassingSocketFactory {
 /// A [`UdpTransportFactory`] that either passes through to a plain factory or wraps it with
 /// obfuscation.
 pub enum MaybeObfuscatingTransportFactory {
-    Plain(BypassingSocketFactory),
-    Lwo(LwoUdpTransportFactory<BypassingSocketFactory>),
-    Transport(ObfuscationSettings, Arc<dyn SocketBypass>),
+    Plain(ProxiedFactory),
+    Lwo(LwoUdpTransportFactory<ProxiedFactory>),
+    Transport(TransportSettings, Arc<dyn SocketBypass>),
 }
 
 impl MaybeObfuscatingTransportFactory {
     /// Create a transport factory from the tunnel config.
+    ///
+    /// # Errors
+    ///
+    /// Fails if `proxy` is set but the obfuscation cannot be layered on top of it. Connecting
+    /// directly when the caller asked to be relayed would leak their traffic, so this fails closed
+    /// rather than ignoring the proxy.
     pub fn from_settings(
         optimize_buffer_size: bool,
         settings: Option<&ObfuscationSettings>,
+        proxy: Option<Socks5Proxy>,
         bypass: Arc<dyn SocketBypass>,
-    ) -> Self {
-        let make_factory = |bypass| BypassingSocketFactory {
-            bypass,
-            inner: udp_socket_factory(optimize_buffer_size),
+    ) -> io::Result<Self> {
+        if proxy.is_some()
+            && settings.is_some_and(|settings| !settings.stacks_on_provided_socket())
+        {
+            return Err(io::Error::other(
+                "the configured obfuscation cannot be relayed through a SOCKS5 proxy",
+            ));
+        }
+
+        let make_factory = |bypass: Arc<dyn SocketBypass>| {
+            let sockets = BypassingSocketFactory {
+                bypass: Arc::clone(&bypass),
+                inner: udp_socket_factory(optimize_buffer_size),
+            };
+            MaybeSocks5TransportFactory::new(sockets, proxy.clone(), bypass)
         };
-        match settings {
-            Some(ObfuscationSettings::Lwo(settings)) => Self::Lwo(LwoUdpTransportFactory {
+        let factory = match settings.and_then(ObfuscationSettings::single) {
+            Some(TransportSettings::Lwo(settings)) => Self::Lwo(LwoUdpTransportFactory {
                 inner: make_factory(bypass),
                 keys: match settings.version {
                     LwoVersion::V1 => LwoKeys::V1 {
@@ -213,9 +238,11 @@ impl MaybeObfuscatingTransportFactory {
             }),
             Some(settings) => Self::Transport(settings.clone(), bypass),
 
-            // Use `Self::Plain` when there is no obfuscation
+            // No obfuscation, or a multiplexer that WireGuard reaches over a local socket.
             None => Self::Plain(make_factory(bypass)),
-        }
+        };
+
+        Ok(factory)
     }
 }
 

--- a/talpid-wireguard/src/gotatun/socks5.rs
+++ b/talpid-wireguard/src/gotatun/socks5.rs
@@ -1,0 +1,334 @@
+//! A SOCKS5 transport for GotaTun's UDP socket, using `UDP ASSOCIATE`.
+//!
+//! This is not obfuscation. It sits *underneath* the obfuscation layer, so that the bytes handed
+//! to the proxy are whatever the layer above produced. See [`super::obfuscation`].
+//!
+//! Every outgoing datagram gets a SOCKS5 header prepended and is redirected to the relay address
+//! the proxy handed out; incoming datagrams have their header stripped, and report the address the
+//! header says they came from, so that WireGuard's endpoint roaming keeps pointing at the real
+//! peer rather than at the proxy.
+
+use std::{io, net::SocketAddr, sync::Arc};
+
+use bytes::Buf;
+use gotatun::{
+    packet::{Packet, PacketBufPool},
+    udp::{UdpRecv, UdpSend, UdpTransportFactory, UdpTransportFactoryParams},
+};
+use talpid_net::bypass::{BypassGuard, BypassSocket, SocketBypass};
+use talpid_types::net::proxy::Socks5Proxy;
+use tokio::net::TcpSocket;
+use tunnel_obfuscation::socks5::{self, Socks5UdpAssociation};
+
+/// A [`UdpSend`] that optionally relays datagrams through a SOCKS5 proxy.
+#[derive(Clone)]
+pub enum MaybeSocks5Send<S: UdpSend> {
+    Plain(S),
+    Relayed {
+        inner: S,
+        association: Arc<Socks5Association>,
+    },
+}
+
+impl<S: UdpSend> UdpSend for MaybeSocks5Send<S> {
+    type SendManyBuf = S::SendManyBuf;
+
+    async fn send_to(&self, mut packet: Packet, destination: SocketAddr) -> io::Result<()> {
+        match self {
+            Self::Plain(inner) => inner.send_to(packet, destination).await,
+            Self::Relayed { inner, association } => {
+                prepend_header(&mut packet, destination);
+                inner.send_to(packet, association.relay_endpoint()).await
+            }
+        }
+    }
+
+    fn max_number_of_packets_to_send(&self) -> usize {
+        self.inner().max_number_of_packets_to_send()
+    }
+
+    async fn send_many_to(
+        &self,
+        send_buf: &mut Self::SendManyBuf,
+        packets: &mut Vec<(Packet, SocketAddr)>,
+    ) -> io::Result<()> {
+        if let Self::Relayed { association, .. } = self {
+            for (packet, destination) in packets.iter_mut() {
+                prepend_header(packet, *destination);
+                *destination = association.relay_endpoint();
+            }
+        }
+        self.inner().send_many_to(send_buf, packets).await
+    }
+
+    fn local_addr(&self) -> io::Result<Option<SocketAddr>> {
+        self.inner().local_addr()
+    }
+
+    #[cfg(target_os = "linux")]
+    fn set_fwmark(&self, mark: u32) -> io::Result<()> {
+        self.inner().set_fwmark(mark)
+    }
+}
+
+impl<S: UdpSend> MaybeSocks5Send<S> {
+    fn inner(&self) -> &S {
+        match self {
+            Self::Plain(inner) | Self::Relayed { inner, .. } => inner,
+        }
+    }
+}
+
+/// A [`UdpRecv`] that optionally decapsulates datagrams relayed by a SOCKS5 proxy.
+pub enum MaybeSocks5Recv<R: UdpRecv> {
+    Plain(R),
+    Relayed(R),
+}
+
+impl<R: UdpRecv> UdpRecv for MaybeSocks5Recv<R> {
+    type RecvManyBuf = R::RecvManyBuf;
+
+    async fn recv_from(&mut self, pool: &mut PacketBufPool) -> io::Result<(Packet, SocketAddr)> {
+        match self {
+            Self::Plain(inner) => inner.recv_from(pool).await,
+            Self::Relayed(inner) => loop {
+                let (mut packet, from) = inner.recv_from(pool).await?;
+                if let Some(origin) = strip_header(&mut packet, from) {
+                    return Ok((packet, origin));
+                }
+            },
+        }
+    }
+
+    async fn recv_many_from(
+        &mut self,
+        recv_buf: &mut Self::RecvManyBuf,
+        pool: &mut PacketBufPool,
+        packets: &mut Vec<(Packet, SocketAddr)>,
+    ) -> io::Result<()> {
+        match self {
+            Self::Plain(inner) => inner.recv_many_from(recv_buf, pool, packets).await,
+            Self::Relayed(inner) => {
+                // The trait contract appends to `packets`, so only touch what this call added.
+                let start = packets.len();
+                inner.recv_many_from(recv_buf, pool, packets).await?;
+
+                let mut index = start;
+                while index < packets.len() {
+                    let (packet, from) = &mut packets[index];
+                    match strip_header(packet, *from) {
+                        Some(origin) => {
+                            *from = origin;
+                            index += 1;
+                        }
+                        None => drop(packets.remove(index)),
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn enable_udp_gro(&self) -> io::Result<()> {
+        match self {
+            Self::Plain(inner) | Self::Relayed(inner) => inner.enable_udp_gro(),
+        }
+    }
+}
+
+/// Prepend the SOCKS5 header for `destination` to `packet`, shifting the payload to make room.
+///
+/// Buffers from GotaTun's packet pool have no headroom, so this costs one copy of the payload per
+/// datagram. An upstream API for reserving headroom in a [`Packet`] would remove it.
+fn prepend_header(packet: &mut Packet, destination: SocketAddr) {
+    let header_len = socks5::header_len(&destination);
+    let buffer = packet.buf_mut();
+
+    let payload_len = buffer.len();
+    buffer.resize(payload_len + header_len, 0);
+    buffer.copy_within(..payload_len, header_len);
+    socks5::write_udp_header(destination, buffer);
+}
+
+/// Strip the SOCKS5 header from a relayed datagram, returning the address it originated from.
+///
+/// Returns `None` for a datagram that is not a well-formed relayed datagram, which the caller
+/// should discard. `from` is only used for logging.
+fn strip_header(packet: &mut Packet, from: SocketAddr) -> Option<SocketAddr> {
+    let Some((origin, payload)) = socks5::decode_udp_datagram(packet) else {
+        log::debug!("Discarding malformed datagram from proxy at {from}");
+        return None;
+    };
+
+    // The payload is a suffix of the datagram, so this is where the header ends.
+    let payload_offset = packet.len() - payload.len();
+    packet.buf_mut().advance(payload_offset);
+
+    Some(origin)
+}
+
+/// An established UDP association, together with the bypass of its control connection.
+///
+/// The proxy tears the association down when the control connection closes, so the connection is
+/// held for as long as datagrams are relayed over it.
+pub struct Socks5Association {
+    association: Socks5UdpAssociation,
+    /// Keeps the control connection excluded from the tunnel for as long as it is open.
+    _bypass: BypassGuard,
+}
+
+impl Socks5Association {
+    fn relay_endpoint(&self) -> SocketAddr {
+        self.association.relay_endpoint()
+    }
+}
+
+/// A [`UdpTransportFactory`] that optionally relays another factory's socket through a SOCKS5
+/// proxy.
+pub struct MaybeSocks5TransportFactory<F> {
+    inner: F,
+    proxy: Option<Socks5Proxy>,
+    bypass: Arc<dyn SocketBypass>,
+}
+
+impl<F> MaybeSocks5TransportFactory<F> {
+    pub fn new(inner: F, proxy: Option<Socks5Proxy>, bypass: Arc<dyn SocketBypass>) -> Self {
+        Self {
+            inner,
+            proxy,
+            bypass,
+        }
+    }
+
+    /// Open the control connection and establish the UDP association.
+    ///
+    /// The control connection is excluded from the tunnel the same way the UDP socket is, so that
+    /// it does not try to route itself through the tunnel it is setting up. The exclusion is
+    /// applied before connecting, since the route is picked at that point.
+    async fn associate(&self, proxy: &Socks5Proxy) -> io::Result<Socks5Association> {
+        let proxy_addr = proxy.proxy_addr();
+        log::debug!("Associating with SOCKS5 proxy at {proxy_addr}");
+
+        let socket = match proxy_addr {
+            SocketAddr::V4(_) => TcpSocket::new_v4()?,
+            SocketAddr::V6(_) => TcpSocket::new_v6()?,
+        };
+        let BypassSocket {
+            socket,
+            guard: _bypass,
+        } = BypassSocket::new(Arc::clone(&self.bypass), socket)?;
+
+        let control = socket.connect(proxy_addr).await?;
+
+        let association = Socks5UdpAssociation::associate(control, proxy.auth())
+            .await
+            .map_err(io::Error::other)?;
+
+        Ok(Socks5Association {
+            association,
+            _bypass,
+        })
+    }
+}
+
+impl<F: UdpTransportFactory> UdpTransportFactory for MaybeSocks5TransportFactory<F> {
+    type Send = MaybeSocks5Send<F::Send>;
+    type Recv = MaybeSocks5Recv<F::Recv>;
+
+    async fn bind(
+        &mut self,
+        params: &UdpTransportFactoryParams,
+    ) -> io::Result<(Self::Send, Self::Recv)> {
+        let (send, recv) = self.inner.bind(params).await?;
+
+        let Some(proxy) = self.proxy.clone() else {
+            return Ok((MaybeSocks5Send::Plain(send), MaybeSocks5Recv::Plain(recv)));
+        };
+
+        let association = Arc::new(self.associate(&proxy).await?);
+        log::debug!(
+            "Relaying WireGuard through SOCKS5 proxy, via {}",
+            association.relay_endpoint()
+        );
+
+        Ok((
+            MaybeSocks5Send::Relayed {
+                inner: send,
+                association,
+            },
+            MaybeSocks5Recv::Relayed(recv),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Long enough to catch an off-by-one when the payload is shifted to make room.
+    const PAYLOAD_LEN: usize = 1400;
+
+    const IPV4_DESTINATION: &str = "192.0.2.1:51820";
+    const IPV6_DESTINATION: &str = "[2001:db8::1]:51820";
+
+    /// Build a packet from the pool, the way GotaTun hands them to the transport.
+    fn pooled_packet(payload: &[u8]) -> Packet {
+        let pool: PacketBufPool = PacketBufPool::new(1);
+        let mut packet = pool.get();
+
+        let buffer = packet.buf_mut();
+        buffer.clear();
+        buffer.extend_from_slice(payload);
+
+        packet
+    }
+
+    fn payload() -> Vec<u8> {
+        (0..PAYLOAD_LEN).map(|index| index as u8).collect()
+    }
+
+    /// Encapsulating must leave the payload byte-for-byte intact behind the header.
+    #[test]
+    fn prepended_header_precedes_an_intact_payload() {
+        for destination in [IPV4_DESTINATION, IPV6_DESTINATION] {
+            let destination: SocketAddr = destination.parse().unwrap();
+            let payload = payload();
+
+            let mut packet = pooled_packet(&payload);
+            prepend_header(&mut packet, destination);
+
+            let (parsed, encapsulated) = socks5::decode_udp_datagram(&packet).unwrap();
+            assert_eq!(parsed, destination);
+            assert_eq!(encapsulated, payload);
+        }
+    }
+
+    #[test]
+    fn stripping_undoes_prepending() {
+        for destination in [IPV4_DESTINATION, IPV6_DESTINATION] {
+            let destination: SocketAddr = destination.parse().unwrap();
+            let payload = payload();
+
+            let mut packet = pooled_packet(&payload);
+            prepend_header(&mut packet, destination);
+            let origin = strip_header(&mut packet, destination).unwrap();
+
+            assert_eq!(origin, destination);
+            assert_eq!(&packet[..], payload);
+        }
+    }
+
+    /// A datagram that is not a well-formed relayed datagram must be discarded, not misparsed.
+    #[test]
+    fn malformed_datagrams_are_discarded() {
+        let destination: SocketAddr = IPV4_DESTINATION.parse().unwrap();
+
+        let mut too_short = pooled_packet(&[0, 0]);
+        assert!(strip_header(&mut too_short, destination).is_none());
+
+        let mut fragmented = pooled_packet(&payload());
+        prepend_header(&mut fragmented, destination);
+        fragmented.buf_mut()[2] = 1;
+        assert!(strip_header(&mut fragmented, destination).is_none());
+    }
+}

--- a/talpid-wireguard/src/gotatun/socks5.rs
+++ b/talpid-wireguard/src/gotatun/socks5.rs
@@ -1,0 +1,462 @@
+//! A SOCKS5 transport for GotaTun's UDP sockets, using `UDP ASSOCIATE`.
+//!
+//! This is not obfuscation. It sits *underneath* the obfuscation layer, so that the bytes handed
+//! to the proxy are whatever the layer above produced. See [`super::obfuscation`].
+//!
+//! Every outgoing datagram gets a SOCKS5 header prepended and is redirected to the relay address
+//! the proxy handed out; incoming datagrams have their header stripped, and report the address the
+//! header says they came from, so that WireGuard's endpoint roaming keeps pointing at the real
+//! peer rather than at the proxy.
+
+use std::{io, net::SocketAddr, sync::Arc};
+
+use bytes::Buf;
+use gotatun::{
+    packet::{Packet, PacketBufPool},
+    udp::{UdpRecv, UdpSend, UdpTransportFactory, UdpTransportFactoryParams},
+};
+use talpid_types::net::proxy::Socks5Proxy;
+use tokio::net::TcpStream;
+use tunnel_obfuscation::socks5::{self, Socks5UdpAssociation};
+
+use crate::config::Config;
+
+#[cfg(target_os = "android")]
+use talpid_tunnel::tun_provider::Tun;
+
+/// A [`UdpSend`] that optionally relays datagrams through a SOCKS5 proxy.
+#[derive(Clone)]
+pub enum MaybeSocks5Send<S: UdpSend> {
+    Plain(S),
+    Relayed {
+        inner: S,
+        association: Arc<Socks5UdpAssociation>,
+    },
+}
+
+impl<S: UdpSend> UdpSend for MaybeSocks5Send<S> {
+    type SendManyBuf = S::SendManyBuf;
+
+    async fn send_to(&self, mut packet: Packet, destination: SocketAddr) -> io::Result<()> {
+        match self {
+            Self::Plain(inner) => inner.send_to(packet, destination).await,
+            Self::Relayed { inner, association } => {
+                prepend_header(&mut packet, destination);
+                inner.send_to(packet, association.relay_endpoint()).await
+            }
+        }
+    }
+
+    fn max_number_of_packets_to_send(&self) -> usize {
+        self.inner().max_number_of_packets_to_send()
+    }
+
+    async fn send_many_to(
+        &self,
+        send_buf: &mut Self::SendManyBuf,
+        packets: &mut Vec<(Packet, SocketAddr)>,
+    ) -> io::Result<()> {
+        if let Self::Relayed { association, .. } = self {
+            for (packet, destination) in packets.iter_mut() {
+                prepend_header(packet, *destination);
+                *destination = association.relay_endpoint();
+            }
+        }
+        self.inner().send_many_to(send_buf, packets).await
+    }
+
+    fn local_addr(&self) -> io::Result<Option<SocketAddr>> {
+        self.inner().local_addr()
+    }
+
+    #[cfg(target_os = "linux")]
+    fn set_fwmark(&self, mark: u32) -> io::Result<()> {
+        self.inner().set_fwmark(mark)
+    }
+}
+
+impl<S: UdpSend> MaybeSocks5Send<S> {
+    fn inner(&self) -> &S {
+        match self {
+            Self::Plain(inner) | Self::Relayed { inner, .. } => inner,
+        }
+    }
+}
+
+/// A [`UdpRecv`] that optionally decapsulates datagrams relayed by a SOCKS5 proxy.
+pub enum MaybeSocks5Recv<R: UdpRecv> {
+    Plain(R),
+    Relayed(R),
+    /// The address family that the proxy is not reachable over. Nothing is ever sent from it, so
+    /// nothing can arrive on it either.
+    Unused,
+}
+
+impl<R: UdpRecv> UdpRecv for MaybeSocks5Recv<R> {
+    type RecvManyBuf = R::RecvManyBuf;
+
+    async fn recv_from(&mut self, pool: &mut PacketBufPool) -> io::Result<(Packet, SocketAddr)> {
+        match self {
+            Self::Plain(inner) => inner.recv_from(pool).await,
+            Self::Relayed(inner) => loop {
+                let (mut packet, from) = inner.recv_from(pool).await?;
+                if let Some(origin) = strip_header(&mut packet, from) {
+                    return Ok((packet, origin));
+                }
+            },
+            Self::Unused => Err(unused_address_family()),
+        }
+    }
+
+    async fn recv_many_from(
+        &mut self,
+        recv_buf: &mut Self::RecvManyBuf,
+        pool: &mut PacketBufPool,
+        packets: &mut Vec<(Packet, SocketAddr)>,
+    ) -> io::Result<()> {
+        match self {
+            Self::Plain(inner) => inner.recv_many_from(recv_buf, pool, packets).await,
+            Self::Relayed(inner) => {
+                // The trait contract appends to `packets`, so only touch what this call added.
+                let start = packets.len();
+                inner.recv_many_from(recv_buf, pool, packets).await?;
+
+                let mut index = start;
+                while index < packets.len() {
+                    let (packet, from) = &mut packets[index];
+                    match strip_header(packet, *from) {
+                        Some(origin) => {
+                            *from = origin;
+                            index += 1;
+                        }
+                        None => drop(packets.remove(index)),
+                    }
+                }
+                Ok(())
+            }
+            Self::Unused => Err(unused_address_family()),
+        }
+    }
+
+    fn enable_udp_gro(&self) -> io::Result<()> {
+        match self {
+            Self::Plain(inner) | Self::Relayed(inner) => inner.enable_udp_gro(),
+            Self::Unused => Ok(()),
+        }
+    }
+}
+
+/// Mirrors how GotaTun itself reports a UDP socket that cannot be used.
+fn unused_address_family() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::Unsupported,
+        "The SOCKS5 proxy is not reachable over this address family",
+    )
+}
+
+/// Prepend the SOCKS5 header for `destination` to `packet`, shifting the payload to make room.
+///
+/// Buffers from GotaTun's packet pool have no headroom, so this costs one copy of the payload per
+/// datagram. An upstream API for reserving headroom in a [`Packet`] would remove it.
+fn prepend_header(packet: &mut Packet, destination: SocketAddr) {
+    let header_len = socks5::header_len(&destination);
+    let buffer = packet.buf_mut();
+
+    let payload_len = buffer.len();
+    buffer.resize(payload_len + header_len, 0);
+    buffer.copy_within(..payload_len, header_len);
+    socks5::write_udp_header(destination, buffer);
+}
+
+/// Strip the SOCKS5 header from a relayed datagram, returning the address it originated from.
+///
+/// Returns `None` for a datagram that is not a well-formed relayed datagram, which the caller
+/// should discard. `from` is only used for logging.
+fn strip_header(packet: &mut Packet, from: SocketAddr) -> Option<SocketAddr> {
+    let Some((origin, payload)) = socks5::decode_udp_datagram(packet) else {
+        log::debug!("Discarding malformed datagram from proxy at {from}");
+        return None;
+    };
+
+    // The payload is a suffix of the datagram, so this is where the header ends.
+    let payload_offset = packet.len() - payload.len();
+    packet.buf_mut().advance(payload_offset);
+
+    Some(origin)
+}
+
+/// A [`UdpTransportFactory`] that optionally relays another factory's sockets through a SOCKS5
+/// proxy.
+pub struct MaybeSocks5TransportFactory<F: UdpTransportFactory> {
+    inner: F,
+    proxy: Option<Socks5Proxy>,
+    #[cfg(target_os = "android")]
+    tun: Arc<Tun>,
+}
+
+impl<F: UdpTransportFactory> MaybeSocks5TransportFactory<F> {
+    /// Create a transport factory from the tunnel config.
+    pub fn from_config(
+        inner: F,
+        config: &Config,
+        #[cfg(target_os = "android")] tun: Arc<Tun>,
+    ) -> Self {
+        Self {
+            inner,
+            proxy: config.proxy.clone(),
+            #[cfg(target_os = "android")]
+            tun,
+        }
+    }
+
+    /// Open the control connection and establish the UDP association.
+    ///
+    /// The control connection is excluded from the tunnel the same way the UDP sockets are, so
+    /// that it does not try to route itself through the tunnel it is setting up.
+    async fn associate(
+        &self,
+        proxy: &Socks5Proxy,
+        #[cfg(target_os = "linux")] fwmark: Option<u32>,
+    ) -> io::Result<Socks5UdpAssociation> {
+        let proxy_addr = proxy.proxy_addr();
+        log::debug!("Associating with SOCKS5 proxy at {proxy_addr}");
+
+        let control = TcpStream::connect(proxy_addr).await?;
+
+        #[cfg(target_os = "linux")]
+        if let Some(fwmark) = fwmark {
+            socket2::SockRef::from(&control).set_mark(fwmark)?;
+        }
+        #[cfg(target_os = "android")]
+        {
+            use std::os::fd::AsFd;
+            self.tun
+                .bypass(&control.as_fd())
+                .map_err(io::Error::other)?;
+        }
+
+        Socks5UdpAssociation::associate(control, proxy.auth())
+            .await
+            .map_err(io::Error::other)
+    }
+}
+
+impl<F: UdpTransportFactory> UdpTransportFactory for MaybeSocks5TransportFactory<F> {
+    type SendV4 = MaybeSocks5Send<EitherSend<F::SendV4, F::SendV6>>;
+    type SendV6 = MaybeSocks5Send<EitherSend<F::SendV4, F::SendV6>>;
+    type RecvV4 = MaybeSocks5Recv<EitherRecv<F::RecvV4, F::RecvV6>>;
+    type RecvV6 = MaybeSocks5Recv<EitherRecv<F::RecvV4, F::RecvV6>>;
+
+    async fn bind(
+        &mut self,
+        params: &UdpTransportFactoryParams,
+    ) -> io::Result<((Self::SendV4, Self::RecvV4), (Self::SendV6, Self::RecvV6))> {
+        let ((send_v4, recv_v4), (send_v6, recv_v6)) = self.inner.bind(params).await?;
+
+        let Some(proxy) = self.proxy.clone() else {
+            return Ok((
+                (
+                    MaybeSocks5Send::Plain(EitherSend::V4(send_v4)),
+                    MaybeSocks5Recv::Plain(EitherRecv::V4(recv_v4)),
+                ),
+                (
+                    MaybeSocks5Send::Plain(EitherSend::V6(send_v6)),
+                    MaybeSocks5Recv::Plain(EitherRecv::V6(recv_v6)),
+                ),
+            ));
+        };
+
+        // All traffic goes to the proxy, so only the socket of the proxy's own address family is
+        // ever used. Hand the same sender to both slots, since GotaTun picks between them based
+        // on the peer endpoint, which has no relation to where the proxy lives.
+        let (send, recv) = match proxy.proxy_addr() {
+            SocketAddr::V4(_) => (EitherSend::V4(send_v4), EitherRecv::V4(recv_v4)),
+            SocketAddr::V6(_) => (EitherSend::V6(send_v6), EitherRecv::V6(recv_v6)),
+        };
+
+        let association = Arc::new(
+            self.associate(
+                &proxy,
+                #[cfg(target_os = "linux")]
+                params.fwmark,
+            )
+            .await?,
+        );
+        log::debug!(
+            "Relaying WireGuard through SOCKS5 proxy, via {}",
+            association.relay_endpoint()
+        );
+
+        let send = MaybeSocks5Send::Relayed {
+            inner: send,
+            association,
+        };
+        Ok((
+            (send.clone(), MaybeSocks5Recv::Relayed(recv)),
+            (send, MaybeSocks5Recv::Unused),
+        ))
+    }
+}
+
+/// A [`UdpSend`] that is one of two address families, chosen at runtime.
+///
+/// GotaTun's factory returns a separate sender per family, but a proxy is only reachable over one
+/// of them, so both slots must be able to hold either.
+#[derive(Clone)]
+pub enum EitherSend<V4: UdpSend, V6: UdpSend> {
+    V4(V4),
+    V6(V6),
+}
+
+impl<V4: UdpSend, V6: UdpSend> UdpSend for EitherSend<V4, V6> {
+    /// Both buffers are carried, since the variant is not known to the type system.
+    type SendManyBuf = (V4::SendManyBuf, V6::SendManyBuf);
+
+    async fn send_to(&self, packet: Packet, destination: SocketAddr) -> io::Result<()> {
+        match self {
+            Self::V4(inner) => inner.send_to(packet, destination).await,
+            Self::V6(inner) => inner.send_to(packet, destination).await,
+        }
+    }
+
+    fn max_number_of_packets_to_send(&self) -> usize {
+        match self {
+            Self::V4(inner) => inner.max_number_of_packets_to_send(),
+            Self::V6(inner) => inner.max_number_of_packets_to_send(),
+        }
+    }
+
+    async fn send_many_to(
+        &self,
+        send_buf: &mut Self::SendManyBuf,
+        packets: &mut Vec<(Packet, SocketAddr)>,
+    ) -> io::Result<()> {
+        match self {
+            Self::V4(inner) => inner.send_many_to(&mut send_buf.0, packets).await,
+            Self::V6(inner) => inner.send_many_to(&mut send_buf.1, packets).await,
+        }
+    }
+
+    fn local_addr(&self) -> io::Result<Option<SocketAddr>> {
+        match self {
+            Self::V4(inner) => inner.local_addr(),
+            Self::V6(inner) => inner.local_addr(),
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn set_fwmark(&self, mark: u32) -> io::Result<()> {
+        match self {
+            Self::V4(inner) => inner.set_fwmark(mark),
+            Self::V6(inner) => inner.set_fwmark(mark),
+        }
+    }
+}
+
+/// The [`UdpRecv`] counterpart of [`EitherSend`].
+pub enum EitherRecv<V4: UdpRecv, V6: UdpRecv> {
+    V4(V4),
+    V6(V6),
+}
+
+impl<V4: UdpRecv, V6: UdpRecv> UdpRecv for EitherRecv<V4, V6> {
+    type RecvManyBuf = (V4::RecvManyBuf, V6::RecvManyBuf);
+
+    async fn recv_from(&mut self, pool: &mut PacketBufPool) -> io::Result<(Packet, SocketAddr)> {
+        match self {
+            Self::V4(inner) => inner.recv_from(pool).await,
+            Self::V6(inner) => inner.recv_from(pool).await,
+        }
+    }
+
+    async fn recv_many_from(
+        &mut self,
+        recv_buf: &mut Self::RecvManyBuf,
+        pool: &mut PacketBufPool,
+        packets: &mut Vec<(Packet, SocketAddr)>,
+    ) -> io::Result<()> {
+        match self {
+            Self::V4(inner) => inner.recv_many_from(&mut recv_buf.0, pool, packets).await,
+            Self::V6(inner) => inner.recv_many_from(&mut recv_buf.1, pool, packets).await,
+        }
+    }
+
+    fn enable_udp_gro(&self) -> io::Result<()> {
+        match self {
+            Self::V4(inner) => inner.enable_udp_gro(),
+            Self::V6(inner) => inner.enable_udp_gro(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Long enough to catch an off-by-one when the payload is shifted to make room.
+    const PAYLOAD_LEN: usize = 1400;
+
+    const IPV4_DESTINATION: &str = "192.0.2.1:51820";
+    const IPV6_DESTINATION: &str = "[2001:db8::1]:51820";
+
+    /// Build a packet from the pool, the way GotaTun hands them to the transport.
+    fn pooled_packet(payload: &[u8]) -> Packet {
+        let pool: PacketBufPool = PacketBufPool::new(1);
+        let mut packet = pool.get();
+
+        let buffer = packet.buf_mut();
+        buffer.clear();
+        buffer.extend_from_slice(payload);
+
+        packet
+    }
+
+    fn payload() -> Vec<u8> {
+        (0..PAYLOAD_LEN).map(|index| index as u8).collect()
+    }
+
+    /// Encapsulating must leave the payload byte-for-byte intact behind the header.
+    #[test]
+    fn prepended_header_precedes_an_intact_payload() {
+        for destination in [IPV4_DESTINATION, IPV6_DESTINATION] {
+            let destination: SocketAddr = destination.parse().unwrap();
+            let payload = payload();
+
+            let mut packet = pooled_packet(&payload);
+            prepend_header(&mut packet, destination);
+
+            let (parsed, encapsulated) = socks5::decode_udp_datagram(&packet).unwrap();
+            assert_eq!(parsed, destination);
+            assert_eq!(encapsulated, payload);
+        }
+    }
+
+    #[test]
+    fn stripping_undoes_prepending() {
+        for destination in [IPV4_DESTINATION, IPV6_DESTINATION] {
+            let destination: SocketAddr = destination.parse().unwrap();
+            let payload = payload();
+
+            let mut packet = pooled_packet(&payload);
+            prepend_header(&mut packet, destination);
+            let origin = strip_header(&mut packet, destination).unwrap();
+
+            assert_eq!(origin, destination);
+            assert_eq!(&packet[..], payload);
+        }
+    }
+
+    /// A datagram that is not a well-formed relayed datagram must be discarded, not misparsed.
+    #[test]
+    fn malformed_datagrams_are_discarded() {
+        let destination: SocketAddr = IPV4_DESTINATION.parse().unwrap();
+
+        let mut too_short = pooled_packet(&[0, 0]);
+        assert!(strip_header(&mut too_short, destination).is_none());
+
+        let mut fragmented = pooled_packet(&payload());
+        prepend_header(&mut fragmented, destination);
+        fragmented.buf_mut()[2] = 1;
+        assert!(strip_header(&mut fragmented, destination).is_none());
+    }
+}

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -153,12 +153,12 @@ impl WireguardMonitor {
         args: TunnelArgs<'_>,
         _log_path: Option<&Path>,
     ) -> Result<WireguardMonitor> {
-        let is_single_lwo = params
+        let is_inline_obfuscation = params
             .obfuscation
             .as_ref()
-            .is_some_and(obfuscation::is_single_lwo);
+            .is_some_and(obfuscation::is_inline_obfuscation);
         let userspace_wireguard =
-            *FORCE_USERSPACE_WIREGUARD || params.use_userspace_wg() || is_single_lwo;
+            *FORCE_USERSPACE_WIREGUARD || params.use_userspace_wg() || is_inline_obfuscation;
         let route_mtu = args
             .runtime
             .block_on(get_route_mtu(params, &args.route_manager));
@@ -186,13 +186,13 @@ impl WireguardMonitor {
                 userspace_wireguard,
             ))?;
         // Adjust tunnel MTU again for obfuscation packet overhead
-        if params.options.mtu.is_none()
-            && let Some(obfuscator) = obfuscator.as_ref()
-        {
-            config.mtu = clamp_tunnel_mtu(
-                params,
-                config.mtu.saturating_sub(obfuscator.packet_overhead()),
-            );
+        if params.options.mtu.is_none() {
+            let obfuscation_overhead = obfuscator
+                .as_ref()
+                .map(ObfuscatorHandle::packet_overhead)
+                .unwrap_or(0);
+            let overhead = obfuscation_overhead.saturating_add(config.socks5_packet_overhead());
+            config.mtu = clamp_tunnel_mtu(params, config.mtu.saturating_sub(overhead));
         }
 
         #[cfg(target_os = "windows")]
@@ -433,13 +433,13 @@ impl WireguardMonitor {
                 args.tun_provider.clone(),
             ))?;
         // Adjust MTU again for obfuscation packet overhead
-        if params.options.mtu.is_none()
-            && let Some(obfuscator) = obfuscator.as_ref()
-        {
-            config.mtu = clamp_tunnel_mtu(
-                params,
-                config.mtu.saturating_sub(obfuscator.packet_overhead()),
-            );
+        if params.options.mtu.is_none() {
+            let obfuscation_overhead = obfuscator
+                .as_ref()
+                .map(ObfuscatorHandle::packet_overhead)
+                .unwrap_or(0);
+            let overhead = obfuscation_overhead.saturating_add(config.socks5_packet_overhead());
+            config.mtu = clamp_tunnel_mtu(params, config.mtu.saturating_sub(overhead));
         }
 
         let should_negotiate_ephemeral_peer = config.quantum_resistant || config.daita;

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -6,7 +6,7 @@ use self::config::Config;
 #[cfg(windows)]
 use futures::channel::mpsc;
 use futures::future::Future;
-use obfuscation::ObfuscatorHandle;
+use obfuscation::{ObfuscationSettings, ObfuscatorHandle};
 #[cfg(all(not(target_os = "android"), not(target_os = "linux")))]
 use std::collections::HashSet;
 #[cfg(windows)]
@@ -181,7 +181,10 @@ impl WireguardMonitor {
         args: TunnelArgs<'_>,
         _log_path: Option<&Path>,
     ) -> Result<WireguardMonitor> {
-        let require_userspace_wireguard = params.use_userspace_wg() || *FORCE_USERSPACE_WIREGUARD;
+        // The SOCKS5 transport sits in GotaTun's UDP stack, so relaying through a proxy is only
+        // possible with userspace WireGuard.
+        let require_userspace_wireguard =
+            params.use_userspace_wg() || params.proxy.is_some() || *FORCE_USERSPACE_WIREGUARD;
         let userspace_obfuscation = obfuscation::userspace_transport_available(params)
             && !*FORCE_LOCAL_SOCKET_OBFUSCATION
             && !*FORCE_KERNEL_WIREGUARD;
@@ -1093,20 +1096,23 @@ fn get_obfuscator(
     close_obfs_sender: &sync_mpsc::Sender<CloseMsg>,
     bypass: &Arc<dyn SocketBypass>,
 ) -> Result<Option<ObfuscatorHandle>> {
-    let Some(obfuscation_settings) = config.obfuscation_settings() else {
+    let obfuscation_settings = config.obfuscation_settings();
+
+    // Both the obfuscation and the SOCKS5 encapsulation add bytes to every packet -- the former
+    // whether it is applied inline or behind a local socket -- so make room for them before
+    // deciding which of the two obfuscation modes to set up.
+    if params.options.mtu.is_none() {
+        let obfuscation_overhead = obfuscation_settings
+            .as_ref()
+            .map(ObfuscationSettings::packet_overhead)
+            .unwrap_or(0);
+        let overhead = obfuscation_overhead.saturating_add(config.socks5_packet_overhead());
+        config.mtu = clamp_tunnel_mtu(params, config.mtu.saturating_sub(overhead));
+    }
+
+    let Some(obfuscation_settings) = obfuscation_settings else {
         return Ok(None);
     };
-
-    // The obfuscation adds this to every packet whether it is applied inline or behind a local
-    // socket, so make room for it before deciding which of the two to set up.
-    if params.options.mtu.is_none() {
-        config.mtu = clamp_tunnel_mtu(
-            params,
-            config
-                .mtu
-                .saturating_sub(obfuscation_settings.packet_overhead()),
-        );
-    }
 
     if userspace_obfuscation {
         log::debug!("Using inline obfuscation");

--- a/talpid-wireguard/src/obfuscation.rs
+++ b/talpid-wireguard/src/obfuscation.rs
@@ -55,6 +55,15 @@ impl ObfuscationSettings {
             }
         }
     }
+
+    /// See [`tunnel_obfuscation::Settings::stacks_on_provided_socket`].
+    pub fn stacks_on_provided_socket(&self) -> bool {
+        match self {
+            ObfuscationSettings::Single(settings) => settings.stacks_on_provided_socket(),
+            // Each transport it races has a socket of its own.
+            ObfuscationSettings::Multiplexer(_) => false,
+        }
+    }
 }
 
 /// Begin running obfuscation machine, if configured. This function will patch `config`'s endpoint

--- a/talpid-wireguard/src/obfuscation.rs
+++ b/talpid-wireguard/src/obfuscation.rs
@@ -40,10 +40,10 @@ pub async fn apply_obfuscation_config(
         return Ok(None);
     };
 
-    // When GotaTun is in use and LWO is configured, obfuscation is applied inline by
-    // MaybeObfuscatingTransportFactory.
-    if is_gotatun && is_single_lwo(obfuscator_config) {
-        log::debug!("GotaTun + LWO: skipping proxy, obfuscation will be applied inline");
+    // When GotaTun is in use, some obfuscation is applied inline by
+    // MaybeObfuscatingTransportFactory instead of by a local proxy socket.
+    if is_gotatun && is_inline_obfuscation(obfuscator_config) {
+        log::debug!("GotaTun: skipping proxy, obfuscation will be applied inline");
         return Ok(None);
     }
 
@@ -92,8 +92,13 @@ pub async fn apply_obfuscation_config(
     }))
 }
 
-/// Returns `true` when the obfuscation config is a single LWO method.
-pub fn is_single_lwo(obfuscators: &Obfuscators) -> bool {
+/// Whether this obfuscation is applied inline in the GotaTun UDP transport, rather than by a
+/// local proxy socket.
+///
+/// Inline obfuscation transforms datagrams in place, so it can be stacked on top of another
+/// transport such as a SOCKS5 proxy. Proxy socket obfuscation cannot, since WireGuard then only
+/// ever talks to a loopback address.
+pub fn is_inline_obfuscation(obfuscators: &Obfuscators) -> bool {
     matches!(
         obfuscators,
         Obfuscators::Single(ObfuscatorConfig::Lwo { .. })

--- a/talpid-wireguard/src/wireguard_nt/mod.rs
+++ b/talpid-wireguard/src/wireguard_nt/mod.rs
@@ -1040,6 +1040,7 @@ mod tests {
         ipv6_gateway: None,
         mtu: 0,
         obfuscator_config: None,
+        proxy: None,
         quantum_resistant: false,
         daita: false,
     });

--- a/talpid-wireguard/src/wireguard_nt/mod.rs
+++ b/talpid-wireguard/src/wireguard_nt/mod.rs
@@ -1234,6 +1234,7 @@ mod tests {
         mtu: 0,
         obfuscator_config: None,
         obfuscation_mtu: 0,
+        proxy: None,
         quantum_resistant: false,
         daita: false,
     });

--- a/tunnel-obfuscation/Cargo.toml
+++ b/tunnel-obfuscation/Cargo.toml
@@ -33,6 +33,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "macros", "net", "rt-multi-thread", "sync"] }
 tokio-util = { workspace = true, features = ["rt"] }
 udp-over-tcp = { workspace = true }
+zerocopy = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 criterion = { version = "0.7.0", features = ["async_tokio", "html_reports"] }

--- a/tunnel-obfuscation/Cargo.toml
+++ b/tunnel-obfuscation/Cargo.toml
@@ -32,9 +32,11 @@ tokio = { workspace = true, features = [
 ] }
 tokio-util = { workspace = true, features = ["rt"] }
 udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "00c8482f303aa23a69cfe9ee10903582cba3eb1e" }
+zerocopy = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 criterion = { version = "0.7.0", features = ["async_tokio", "html_reports"] }
+fast-socks5 = "1.0.0"
 tokio = { workspace = true, features = ["test-util"] }
 
 [lints]

--- a/tunnel-obfuscation/src/lib.rs
+++ b/tunnel-obfuscation/src/lib.rs
@@ -8,6 +8,7 @@ pub mod multiplexer;
 pub mod quic;
 pub mod shadowsocks;
 pub(crate) mod socket;
+pub mod socks5;
 pub mod udp2tcp;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/tunnel-obfuscation/src/lib.rs
+++ b/tunnel-obfuscation/src/lib.rs
@@ -81,6 +81,21 @@ impl Settings {
             Settings::Lwo(s) => s.packet_overhead(),
         }
     }
+
+    /// Whether this obfuscation transforms datagrams on a socket provided by the caller, rather
+    /// than opening its own connection to the obfuscation server.
+    ///
+    /// Only these can be layered on top of another transport, such as a SOCKS5 proxy.
+    pub fn stacks_on_provided_socket(&self) -> bool {
+        match self {
+            // A pure in-place transform of each datagram.
+            Settings::Lwo(_) => true,
+            // Connects to the obfuscation server over TCP.
+            Settings::Udp2Tcp(_) => false,
+            // Bind their own UDP socket in `create_transport`.
+            Settings::Shadowsocks(_) | Settings::Quic(_) => false,
+        }
+    }
 }
 
 /// Create an [ObfuscatedTransport] that obfuscates and deobfuscates packets in place where the

--- a/tunnel-obfuscation/src/lib.rs
+++ b/tunnel-obfuscation/src/lib.rs
@@ -10,6 +10,7 @@ pub mod multiplexer;
 pub mod quic;
 pub mod shadowsocks;
 pub mod socket;
+pub mod socks5;
 pub mod transport;
 pub mod udp2tcp;
 pub(crate) mod wireguard;

--- a/tunnel-obfuscation/src/socks5.rs
+++ b/tunnel-obfuscation/src/socks5.rs
@@ -1,0 +1,657 @@
+//! Barebones SOCKS5 client supporting UDP ASSOCIATE only (RFC 1928).
+//!
+//! This performs the SOCKS5 control handshake over TCP, requests a UDP association, and exposes
+//! the resulting UDP relay endpoint. It also provides pure encode/decode of the SOCKS5 UDP request
+//! header used to frame datagrams sent to and received from the relay.
+
+use std::{
+    io,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
+};
+
+use talpid_types::net::proxy::SocksAuth;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpStream,
+};
+use zerocopy::{
+    FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned, byteorder::network_endian::U16,
+};
+
+/// SOCKS protocol version (5).
+const SOCKS_VERSION: u8 = 0x05;
+/// Username/password authentication subnegotiation version (RFC 1929).
+const AUTH_VERSION: u8 = 0x01;
+/// "No authentication required" method.
+const METHOD_NO_AUTH: u8 = 0x00;
+/// Username/password authentication method (RFC 1929).
+const METHOD_USERNAME_PASSWORD: u8 = 0x02;
+/// "No acceptable methods" method.
+const METHOD_UNACCEPTABLE: u8 = 0xff;
+/// UDP ASSOCIATE command.
+const CMD_UDP_ASSOCIATE: u8 = 0x03;
+/// Reserved field value.
+const RSV: u8 = 0x00;
+/// "Succeeded" reply code, used both for requests and for authentication.
+const REP_SUCCESS: u8 = 0x00;
+/// A datagram that is not part of a fragment sequence. We never fragment.
+const FRAG_STANDALONE: u8 = 0x00;
+
+/// Address type: IPv4.
+const ATYP_IPV4: u8 = 0x01;
+/// Address type: domain name (unsupported).
+const ATYP_DOMAIN: u8 = 0x03;
+/// Address type: IPv6.
+const ATYP_IPV6: u8 = 0x04;
+
+/// `[VER][CMD][RSV]`, the part of a request that precedes the address.
+const REQUEST_PREFIX_LEN: usize = 3;
+
+/// The largest `ATYP + ADDR + PORT` encoding, which is the IPv6 one.
+const MAX_ADDR_LEN: usize = 1 + size_of::<Ipv6Endpoint>();
+
+/// The largest per-datagram header, which is the one for an IPv6 destination.
+///
+/// Prefer [`header_len`] when the destination is known.
+pub const MAX_HEADER_LEN: usize = size_of::<UdpHeader>() + size_of::<Ipv6Endpoint>();
+
+type Result<T> = std::result::Result<T, Error>;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// The SOCKS5 control connection failed during the handshake.
+    #[error("SOCKS5 control connection I/O failed")]
+    ControlIo(#[source] io::Error),
+
+    /// The server replied with an unexpected SOCKS version.
+    #[error("Unexpected SOCKS version: {0:#04x}")]
+    UnexpectedVersion(u8),
+
+    /// The server did not accept any of the methods we offered.
+    #[error("SOCKS5 proxy rejected our authentication methods")]
+    NoAcceptableAuthMethod,
+
+    /// The server selected a method we did not offer, or cannot perform.
+    #[error("SOCKS5 proxy selected an unsupported authentication method: {0:#04x}")]
+    UnsupportedAuthMethod(u8),
+
+    /// The server rejected our username and password.
+    #[error("SOCKS5 proxy rejected our credentials")]
+    AuthenticationFailed,
+
+    /// The server rejected the UDP ASSOCIATE request (`REP != 0`).
+    #[error("SOCKS5 request rejected (REP={0:#04x})")]
+    RequestRejected(u8),
+
+    /// The server replied with an address type we do not support.
+    #[error("Unsupported address type in SOCKS5 reply: {0:#04x}")]
+    UnsupportedReplyAddress(u8),
+}
+
+/// A SOCKS5 UDP association. Owns the TCP control connection that keeps the association alive;
+/// exposes the relay endpoint to send/receive UDP datagrams to.
+#[derive(Debug)]
+pub struct Socks5UdpAssociation {
+    // Kept alive; dropping it tears down the association.
+    //
+    // TODO: Reading from this would let us notice that the proxy has torn the association down,
+    // which currently manifests as datagrams being silently discarded.
+    _control: TcpStream,
+    relay_endpoint: SocketAddr,
+}
+
+impl Socks5UdpAssociation {
+    /// Perform the SOCKS5 handshake and UDP ASSOCIATE over `control`, returning the association
+    /// together with the relay endpoint.
+    ///
+    /// `control` must already be connected to the proxy. The caller owns socket setup, so that a
+    /// firewall mark or a tunnel bypass can be applied before the handshake.
+    ///
+    /// # Blocking
+    ///
+    /// Waits for the proxy to answer the method negotiation, the optional authentication, and the
+    /// associate request, so this blocks for as long as the proxy takes to respond to all three.
+    /// Apply a timeout if that is a concern.
+    pub async fn associate(mut control: TcpStream, auth: Option<&SocksAuth>) -> Result<Self> {
+        negotiate_auth(&mut control, auth).await?;
+
+        // Request: [VER][CMD=UDP ASSOCIATE][RSV][ATYP][DST.ADDR][DST.PORT].
+        // We send an unspecified DST matching the proxy's address family, telling the relay to
+        // accept from any client source. Our own source port is not known at this point, since the
+        // caller binds its UDP socket separately.
+        let peer_addr = control.peer_addr().map_err(Error::ControlIo)?;
+        let dst = match peer_addr {
+            SocketAddr::V4(_) => SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
+            SocketAddr::V6(_) => SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
+        };
+
+        let mut request = [0u8; REQUEST_PREFIX_LEN + MAX_ADDR_LEN];
+        request[..REQUEST_PREFIX_LEN].copy_from_slice(&[SOCKS_VERSION, CMD_UDP_ASSOCIATE, RSV]);
+        let addr_len = write_socks_addr(&mut request[REQUEST_PREFIX_LEN..], dst);
+        control
+            .write_all(&request[..REQUEST_PREFIX_LEN + addr_len])
+            .await
+            .map_err(Error::ControlIo)?;
+
+        // Reply: [VER][REP][RSV][ATYP][BND.ADDR][BND.PORT].
+        let relay_endpoint = read_reply(&mut control).await?;
+
+        // Proxies commonly reply with an unspecified address, meaning "the address you are already
+        // talking to me on". Relaying datagrams there would fail.
+        let relay_endpoint = if relay_endpoint.ip().is_unspecified() {
+            SocketAddr::new(peer_addr.ip(), relay_endpoint.port())
+        } else {
+            relay_endpoint
+        };
+
+        Ok(Socks5UdpAssociation {
+            _control: control,
+            relay_endpoint,
+        })
+    }
+
+    /// The UDP relay endpoint (BND.ADDR:BND.PORT) to send encapsulated datagrams to.
+    pub fn relay_endpoint(&self) -> SocketAddr {
+        self.relay_endpoint
+    }
+}
+
+/// The length of the header that [`write_udp_header`] produces for `dst`.
+pub const fn header_len(dst: &SocketAddr) -> usize {
+    let addr_len = match dst {
+        SocketAddr::V4(_) => size_of::<Ipv4Endpoint>(),
+        SocketAddr::V6(_) => size_of::<Ipv6Endpoint>(),
+    };
+    size_of::<UdpHeader>() + addr_len
+}
+
+/// Write the SOCKS5 UDP request header for a datagram destined for `dst` to the start of `out`.
+///
+/// This is the in-place counterpart of [`encode_udp_datagram`], for callers that prepend the
+/// header to a buffer already holding the payload, rather than building a new one.
+///
+/// # Panics
+///
+/// Panics if `out` is shorter than [`header_len`] for `dst`.
+pub fn write_udp_header(dst: SocketAddr, out: &mut [u8]) {
+    let len = header_len(&dst);
+    assert!(
+        out.len() >= len,
+        "buffer of {} bytes is too small for a {len} byte SOCKS5 header",
+        out.len(),
+    );
+
+    let (header_out, addr_out) = out.split_at_mut(size_of::<UdpHeader>());
+    let atyp = match dst {
+        SocketAddr::V4(dst) => write_endpoint(addr_out, Ipv4Endpoint::from(dst)),
+        SocketAddr::V6(dst) => write_endpoint(addr_out, Ipv6Endpoint::from(dst)),
+    };
+    UdpHeader {
+        rsv: [RSV; 2],
+        frag: FRAG_STANDALONE,
+        atyp,
+    }
+    .write_to_prefix(header_out)
+    .expect("the buffer is exactly the size of the header");
+}
+
+/// Encapsulate `payload` destined for `dst` into a SOCKS5 UDP request datagram, writing the framed
+/// bytes into `out` (cleared first). FRAG is always 0.
+pub fn encode_udp_datagram(dst: SocketAddr, payload: &[u8], out: &mut Vec<u8>) {
+    out.clear();
+    out.resize(header_len(&dst), 0);
+    write_udp_header(dst, out);
+    out.extend_from_slice(payload);
+}
+
+/// Parse a SOCKS5 UDP datagram received from the relay.
+///
+/// Returns the source address and a slice of the inner payload.
+///
+/// Returns `None` (datagram dropped) when:
+///   - the datagram is truncated/malformed, or
+///   - `FRAG != 0` (fragment).
+pub fn decode_udp_datagram(datagram: &[u8]) -> Option<(SocketAddr, &[u8])> {
+    let (header, rest) = UdpHeader::read_from_prefix(datagram).ok()?;
+
+    if header.frag != FRAG_STANDALONE {
+        let frag = header.frag;
+        log::trace!("Dropping fragmented SOCKS5 UDP datagram (FRAG={frag})");
+        // TODO: implement fragment reassembly instead of dropping fragments.
+        return None;
+    }
+
+    read_socks_addr(header.atyp, rest)
+}
+
+/// Negotiate an authentication method, and authenticate if the proxy asks us to.
+async fn negotiate_auth(control: &mut TcpStream, auth: Option<&SocksAuth>) -> Result<()> {
+    // Greeting: [VER][NMETHODS][METHODS..].
+    let greeting = match auth {
+        Some(_) => &[SOCKS_VERSION, 2, METHOD_NO_AUTH, METHOD_USERNAME_PASSWORD][..],
+        None => &[SOCKS_VERSION, 1, METHOD_NO_AUTH],
+    };
+    control
+        .write_all(greeting)
+        .await
+        .map_err(Error::ControlIo)?;
+
+    // Method selection reply: [VER][METHOD].
+    let mut reply = [0u8; 2];
+    control
+        .read_exact(&mut reply)
+        .await
+        .map_err(Error::ControlIo)?;
+    let [version, method] = reply;
+    if version != SOCKS_VERSION {
+        return Err(Error::UnexpectedVersion(version));
+    }
+
+    match (method, auth) {
+        (METHOD_NO_AUTH, _) => Ok(()),
+        (METHOD_UNACCEPTABLE, _) => Err(Error::NoAcceptableAuthMethod),
+        (METHOD_USERNAME_PASSWORD, Some(auth)) => authenticate(control, auth).await,
+        // Anything else, including a method we have no credentials for.
+        (method, _) => Err(Error::UnsupportedAuthMethod(method)),
+    }
+}
+
+/// Authenticate with a username and password, as specified by
+/// [RFC 1929](https://datatracker.ietf.org/doc/html/rfc1929).
+async fn authenticate(control: &mut TcpStream, auth: &SocksAuth) -> Result<()> {
+    let username = auth.username().as_bytes();
+    let password = auth.password().as_bytes();
+
+    // [VER][ULEN][UNAME][PLEN][PASSWD]. `SocksAuth` guarantees that both fit in a length byte.
+    let mut request = vec![AUTH_VERSION, username.len() as u8];
+    request.extend_from_slice(username);
+    request.push(password.len() as u8);
+    request.extend_from_slice(password);
+    control
+        .write_all(&request)
+        .await
+        .map_err(Error::ControlIo)?;
+
+    // [VER][STATUS].
+    let mut reply = [0u8; 2];
+    control
+        .read_exact(&mut reply)
+        .await
+        .map_err(Error::ControlIo)?;
+    let [_version, status] = reply;
+    if status != REP_SUCCESS {
+        return Err(Error::AuthenticationFailed);
+    }
+    Ok(())
+}
+
+/// Read and validate a SOCKS5 request reply, returning the bound (relay) endpoint.
+async fn read_reply(control: &mut TcpStream) -> Result<SocketAddr> {
+    // [VER][REP][RSV][ATYP].
+    let mut head = [0u8; 4];
+    control
+        .read_exact(&mut head)
+        .await
+        .map_err(Error::ControlIo)?;
+    let [version, reply, _rsv, atyp] = head;
+    if version != SOCKS_VERSION {
+        return Err(Error::UnexpectedVersion(version));
+    }
+    if reply != REP_SUCCESS {
+        return Err(Error::RequestRejected(reply));
+    }
+
+    match atyp {
+        ATYP_IPV4 => read_endpoint::<Ipv4Endpoint>(control).await,
+        ATYP_IPV6 => read_endpoint::<Ipv6Endpoint>(control).await,
+        // Domain names (0x03) are not supported; we only deal in IP endpoints.
+        atyp => Err(Error::UnsupportedReplyAddress(atyp)),
+    }
+}
+
+/// Read an address and port of a known type off the control connection.
+async fn read_endpoint<E: Endpoint>(control: &mut TcpStream) -> Result<SocketAddr> {
+    let mut endpoint = E::new_zeroed();
+    control
+        .read_exact(endpoint.as_mut_bytes())
+        .await
+        .map_err(Error::ControlIo)?;
+    Ok(endpoint.socket_addr())
+}
+
+/// Write an `ATYP`-prefixed address to the start of `out`, returning the number of bytes written.
+///
+/// # Panics
+///
+/// Panics if `out` is too small to hold the address.
+fn write_socks_addr(out: &mut [u8], addr: SocketAddr) -> usize {
+    let (atyp, addr_out) = out.split_at_mut(1);
+    atyp[0] = match addr {
+        SocketAddr::V4(addr) => write_endpoint(addr_out, Ipv4Endpoint::from(addr)),
+        SocketAddr::V6(addr) => write_endpoint(addr_out, Ipv6Endpoint::from(addr)),
+    };
+    1 + addr_len(&addr)
+}
+
+/// Parse an `ATYP`-prefixed address of type `atyp` from `data`, returning the address and the
+/// remaining bytes. Domain names (0x03) are unsupported and yield `None`.
+fn read_socks_addr(atyp: u8, data: &[u8]) -> Option<(SocketAddr, &[u8])> {
+    match atyp {
+        ATYP_IPV4 => read_endpoint_prefix::<Ipv4Endpoint>(data),
+        ATYP_IPV6 => read_endpoint_prefix::<Ipv6Endpoint>(data),
+        // Domain names are unsupported; we only ever deal in IP endpoints.
+        ATYP_DOMAIN => None,
+        // Unknown address types.
+        _ => None,
+    }
+}
+
+fn read_endpoint_prefix<E: Endpoint>(data: &[u8]) -> Option<(SocketAddr, &[u8])> {
+    let (endpoint, rest) = E::read_from_prefix(data).ok()?;
+    Some((endpoint.socket_addr(), rest))
+}
+
+/// Write an endpoint to the start of `out`, returning its `ATYP`.
+fn write_endpoint<E: Endpoint>(out: &mut [u8], endpoint: E) -> u8 {
+    endpoint
+        .write_to_prefix(out)
+        .expect("the caller ensures the buffer is large enough");
+    E::ATYP
+}
+
+fn addr_len(addr: &SocketAddr) -> usize {
+    match addr {
+        SocketAddr::V4(_) => size_of::<Ipv4Endpoint>(),
+        SocketAddr::V6(_) => size_of::<Ipv6Endpoint>(),
+    }
+}
+
+/// Leading fixed-layout prefix of a SOCKS5 UDP datagram: `[RSV(2)][FRAG(1)][ATYP(1)]`.
+#[derive(Debug, FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
+#[repr(C)]
+struct UdpHeader {
+    rsv: [u8; 2],
+    frag: u8,
+    atyp: u8,
+}
+
+/// An address followed by a big-endian port, as carried in SOCKS5 messages.
+trait Endpoint: FromBytes + IntoBytes + Immutable + KnownLayout + Unaligned + Sized {
+    /// The `ATYP` value identifying this kind of address.
+    const ATYP: u8;
+
+    fn socket_addr(&self) -> SocketAddr;
+}
+
+/// An IPv4 address followed by a big-endian port, as carried in SOCKS5 messages.
+#[derive(Debug, FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
+#[repr(C)]
+struct Ipv4Endpoint {
+    addr: [u8; 4],
+    port: U16,
+}
+
+impl Endpoint for Ipv4Endpoint {
+    const ATYP: u8 = ATYP_IPV4;
+
+    fn socket_addr(&self) -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::from(self.addr)), self.port.get())
+    }
+}
+
+impl From<SocketAddrV4> for Ipv4Endpoint {
+    fn from(addr: SocketAddrV4) -> Self {
+        Ipv4Endpoint {
+            addr: addr.ip().octets(),
+            port: addr.port().into(),
+        }
+    }
+}
+
+/// An IPv6 address followed by a big-endian port, as carried in SOCKS5 messages.
+#[derive(Debug, FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
+#[repr(C)]
+struct Ipv6Endpoint {
+    addr: [u8; 16],
+    port: U16,
+}
+
+impl Endpoint for Ipv6Endpoint {
+    const ATYP: u8 = ATYP_IPV6;
+
+    fn socket_addr(&self) -> SocketAddr {
+        SocketAddr::new(IpAddr::V6(Ipv6Addr::from(self.addr)), self.port.get())
+    }
+}
+
+impl From<SocketAddrV6> for Ipv6Endpoint {
+    fn from(addr: SocketAddrV6) -> Self {
+        Ipv6Endpoint {
+            addr: addr.ip().octets(),
+            port: addr.port().into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::net::TcpListener;
+
+    use super::*;
+
+    const IPV4_DESTINATION: &str = "192.0.2.10:4711";
+    const IPV6_DESTINATION: &str = "[2001:db8::1]:51820";
+
+    const RELAY: &str = "127.0.0.1:9999";
+
+    /// Serve one handshake from a hand-rolled server, asserting the exact bytes we send, and
+    /// return the association the client ended up with.
+    ///
+    /// `expected_methods` is the method list the greeting must offer, and `credentials` the
+    /// username and password the RFC 1929 exchange must carry, if any.
+    async fn handshake(
+        auth: Option<SocksAuth>,
+        expected_methods: &'static [u8],
+        credentials: Option<(&'static str, &'static str)>,
+    ) -> Result<Socks5UdpAssociation> {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = listener.local_addr().unwrap();
+        let relay: SocketAddr = RELAY.parse().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (mut conn, _) = listener.accept().await.unwrap();
+
+            // Greeting: [VER][NMETHODS][METHODS..].
+            let mut greeting = vec![0u8; 2 + expected_methods.len()];
+            conn.read_exact(&mut greeting).await.unwrap();
+            assert_eq!(greeting[0], SOCKS_VERSION);
+            assert_eq!(usize::from(greeting[1]), expected_methods.len());
+            assert_eq!(&greeting[2..], expected_methods);
+
+            let method = match credentials {
+                Some(_) => METHOD_USERNAME_PASSWORD,
+                None => METHOD_NO_AUTH,
+            };
+            conn.write_all(&[SOCKS_VERSION, method]).await.unwrap();
+
+            // [VER][ULEN][UNAME][PLEN][PASSWD].
+            if let Some((username, password)) = credentials {
+                let mut expected = vec![AUTH_VERSION, username.len() as u8];
+                expected.extend_from_slice(username.as_bytes());
+                expected.push(password.len() as u8);
+                expected.extend_from_slice(password.as_bytes());
+
+                let mut request = vec![0u8; expected.len()];
+                conn.read_exact(&mut request).await.unwrap();
+                assert_eq!(request, expected);
+
+                conn.write_all(&[AUTH_VERSION, REP_SUCCESS]).await.unwrap();
+            }
+
+            // Request: [VER][CMD=UDP ASSOCIATE][RSV][ATYP=IPv4][addr(4)][port(2)].
+            let mut request = [0u8; REQUEST_PREFIX_LEN + 1 + 4 + 2];
+            conn.read_exact(&mut request).await.unwrap();
+            assert_eq!(request[0], SOCKS_VERSION);
+            assert_eq!(request[1], CMD_UDP_ASSOCIATE);
+            assert_eq!(request[3], ATYP_IPV4);
+
+            // Reply: [VER][REP=0x00][RSV][ATYP=IPv4][BND.ADDR][BND.PORT].
+            let mut reply = vec![0u8; REQUEST_PREFIX_LEN + MAX_ADDR_LEN];
+            reply[..REQUEST_PREFIX_LEN].copy_from_slice(&[SOCKS_VERSION, REP_SUCCESS, RSV]);
+            let addr_len = write_socks_addr(&mut reply[REQUEST_PREFIX_LEN..], relay);
+            reply.truncate(REQUEST_PREFIX_LEN + addr_len);
+            conn.write_all(&reply).await.unwrap();
+
+            // Keep the control connection open until the client is done.
+            let mut scratch = [0u8; 1];
+            let _ = conn.read(&mut scratch).await;
+        });
+
+        let control = TcpStream::connect(proxy_addr).await.unwrap();
+        let association = Socks5UdpAssociation::associate(control, auth.as_ref()).await;
+        server.abort();
+
+        association
+    }
+
+    #[tokio::test]
+    async fn handshake_returns_relay_endpoint() {
+        let association = handshake(None, &[METHOD_NO_AUTH], None).await.unwrap();
+        assert_eq!(association.relay_endpoint(), RELAY.parse().unwrap());
+    }
+
+    /// Credentials must actually reach the proxy, rather than being silently dropped.
+    #[tokio::test]
+    async fn handshake_authenticates_with_credentials() {
+        let auth = SocksAuth::new("FooBar".to_owned(), "hunter2".to_owned()).unwrap();
+
+        let association = handshake(
+            Some(auth),
+            &[METHOD_NO_AUTH, METHOD_USERNAME_PASSWORD],
+            Some(("FooBar", "hunter2")),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(association.relay_endpoint(), RELAY.parse().unwrap());
+    }
+
+    #[test]
+    fn roundtrip_ipv4() {
+        let dst: SocketAddr = IPV4_DESTINATION.parse().unwrap();
+        let payload = b"hello wireguard";
+
+        let mut buf = Vec::new();
+        encode_udp_datagram(dst, payload, &mut buf);
+
+        let (src, decoded) = decode_udp_datagram(&buf).unwrap();
+        assert_eq!(src, dst);
+        assert_eq!(decoded, payload);
+    }
+
+    #[test]
+    fn roundtrip_ipv6() {
+        let dst: SocketAddr = IPV6_DESTINATION.parse().unwrap();
+        let payload = b"hello over ipv6";
+
+        let mut buf = Vec::new();
+        encode_udp_datagram(dst, payload, &mut buf);
+
+        let (src, decoded) = decode_udp_datagram(&buf).unwrap();
+        assert_eq!(src, dst);
+        assert_eq!(decoded, payload);
+    }
+
+    #[test]
+    fn encode_clears_output() {
+        let dst: SocketAddr = "192.0.2.10:80".parse().unwrap();
+        let mut buf = vec![0xff, 0xff, 0xff];
+        encode_udp_datagram(dst, b"x", &mut buf);
+        // The pre-existing junk must be gone (header begins with RSV=0x0000).
+        assert_eq!(&buf[0..3], &[0x00, 0x00, 0x00]);
+    }
+
+    #[test]
+    fn known_wire_bytes_ipv4() {
+        let dst: SocketAddr = "127.0.0.1:8080".parse().unwrap();
+        let mut buf = Vec::new();
+        encode_udp_datagram(dst, b"abc", &mut buf);
+
+        let expected = [
+            0x00, 0x00, // RSV
+            0x00, // FRAG
+            0x01, // ATYP = IPv4
+            127, 0, 0, 1, // DST.ADDR
+            0x1f, 0x90, // DST.PORT = 8080, big-endian
+            b'a', b'b', b'c', // DATA
+        ];
+        assert_eq!(buf, expected);
+    }
+
+    #[test]
+    fn known_wire_bytes_ipv6() {
+        let dst: SocketAddr = "[::1]:8080".parse().unwrap();
+        let mut buf = Vec::new();
+        encode_udp_datagram(dst, b"abc", &mut buf);
+
+        let expected = [
+            0x00, 0x00, // RSV
+            0x00, // FRAG
+            0x04, // ATYP = IPv6
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, // DST.ADDR
+            0x1f, 0x90, // DST.PORT = 8080, big-endian
+            b'a', b'b', b'c', // DATA
+        ];
+        assert_eq!(buf, expected);
+    }
+
+    /// The header sizes that the tunnel MTU calculation assumes.
+    #[test]
+    fn header_lengths() {
+        assert_eq!(header_len(&IPV4_DESTINATION.parse().unwrap()), 10);
+        assert_eq!(header_len(&IPV6_DESTINATION.parse().unwrap()), 22);
+        assert_eq!(MAX_HEADER_LEN, 22);
+    }
+
+    #[test]
+    fn fragment_is_dropped() {
+        let dst: SocketAddr = IPV4_DESTINATION.parse().unwrap();
+        let mut buf = Vec::new();
+        encode_udp_datagram(dst, b"data", &mut buf);
+        // Set FRAG (byte index 2) to a non-zero value.
+        buf[2] = 0x01;
+        assert!(decode_udp_datagram(&buf).is_none());
+    }
+
+    /// No prefix of a valid datagram may be mistaken for a complete one.
+    #[test]
+    fn truncated_datagrams_are_dropped() {
+        let dst: SocketAddr = IPV6_DESTINATION.parse().unwrap();
+        let mut buf = Vec::new();
+        encode_udp_datagram(dst, b"data", &mut buf);
+
+        for len in 0..header_len(&dst) {
+            assert!(
+                decode_udp_datagram(&buf[..len]).is_none(),
+                "expected a {len} byte datagram to be dropped as truncated"
+            );
+        }
+    }
+
+    #[test]
+    fn unsupported_domain_atyp_is_dropped() {
+        let datagram = [
+            0x00,
+            0x00,        // RSV
+            0x00,        // FRAG
+            ATYP_DOMAIN, // ATYP = domain name (unsupported)
+            0x03,
+            b'a',
+            b'b',
+            b'c', // length-prefixed domain
+            0x00,
+            0x50, // port
+        ];
+        assert!(decode_udp_datagram(&datagram).is_none());
+    }
+}

--- a/tunnel-obfuscation/tests/socks5.rs
+++ b/tunnel-obfuscation/tests/socks5.rs
@@ -1,0 +1,392 @@
+//! End-to-end tests for the SOCKS5 `UDP ASSOCIATE` client, driven against a real SOCKS5 server.
+//!
+//! The server below implements just enough of RFC 1928 to answer an associate request and relay
+//! datagrams for it. It is spelled out byte by byte rather than built on [`socks5`], so that a
+//! mistake in the wire format cannot cancel itself out against the client under test.
+
+use std::{
+    io,
+    net::{Ipv4Addr, SocketAddr},
+    time::Duration,
+};
+
+use talpid_types::net::proxy::SocksAuth;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream, UdpSocket},
+    time::timeout,
+};
+use tunnel_obfuscation::socks5::{self, Socks5UdpAssociation};
+
+const PAYLOAD: &[u8] = b"a wireguard packet, as far as the proxy is concerned";
+
+const USERNAME: &str = "mullvad";
+const PASSWORD: &str = "hunter2";
+
+/// SOCKS protocol version (5).
+const SOCKS_VERSION: u8 = 0x05;
+/// Username/password authentication subnegotiation version (RFC 1929).
+const AUTH_VERSION: u8 = 0x01;
+/// "No authentication required" method.
+const METHOD_NO_AUTH: u8 = 0x00;
+/// Username/password authentication method (RFC 1929).
+const METHOD_USERNAME_PASSWORD: u8 = 0x02;
+/// UDP ASSOCIATE command.
+const CMD_UDP_ASSOCIATE: u8 = 0x03;
+/// Reserved field value.
+const RSV: u8 = 0x00;
+/// "Succeeded" reply code, used both for requests and for authentication.
+const REP_SUCCESS: u8 = 0x00;
+/// A datagram that is not part of a fragment sequence.
+const FRAG_STANDALONE: u8 = 0x00;
+/// Address type: IPv4.
+const ATYP_IPV4: u8 = 0x01;
+
+/// How the test proxy behaves.
+#[derive(Clone, Copy, Default)]
+struct ProxyConfig {
+    /// Demand username/password authentication rather than accepting the no-auth method.
+    require_auth: bool,
+    /// Answer with an unspecified BND.ADDR, meaning "the address you are already talking to me
+    /// on". Real proxies commonly reply this way.
+    unspecified_bind_addr: bool,
+}
+
+/// Spawn a SOCKS5 server on localhost that only handles `UDP ASSOCIATE`, returning its address.
+///
+/// The server task is detached and lives until the test process exits.
+async fn spawn_proxy(config: ProxyConfig) -> io::Result<SocketAddr> {
+    let listener = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await?;
+    let proxy_addr = listener.local_addr()?;
+
+    tokio::spawn(async move {
+        while let Ok((control, _)) = listener.accept().await {
+            tokio::spawn(async move {
+                if let Err(error) = serve(control, config).await {
+                    eprintln!("SOCKS5 client failed: {error}");
+                }
+            });
+        }
+    });
+
+    Ok(proxy_addr)
+}
+
+/// Handshake with one client, then relay its datagrams until the process exits.
+async fn serve(mut control: TcpStream, config: ProxyConfig) -> io::Result<()> {
+    negotiate_auth(&mut control, config.require_auth).await?;
+    let relay = accept_udp_associate(&mut control, config.unspecified_bind_addr).await?;
+
+    // Dropping the control connection is what tears an association down, so hold it open for as
+    // long as datagrams are relayed.
+    let _control = control;
+    relay_datagrams(relay).await
+}
+
+/// Read the method selection greeting and select a method, authenticating if one is demanded.
+async fn negotiate_auth(control: &mut TcpStream, require_auth: bool) -> io::Result<()> {
+    // Greeting: [VER][NMETHODS][METHODS..].
+    let mut greeting = [0u8; 2];
+    control.read_exact(&mut greeting).await?;
+    let [version, method_count] = greeting;
+    assert_eq!(version, SOCKS_VERSION, "unexpected version in the greeting");
+
+    let mut methods = vec![0u8; usize::from(method_count)];
+    control.read_exact(&mut methods).await?;
+
+    if !require_auth {
+        assert!(
+            methods.contains(&METHOD_NO_AUTH),
+            "the client did not offer the no-auth method"
+        );
+        return control.write_all(&[SOCKS_VERSION, METHOD_NO_AUTH]).await;
+    }
+
+    assert!(
+        methods.contains(&METHOD_USERNAME_PASSWORD),
+        "the client did not offer username/password authentication"
+    );
+    control
+        .write_all(&[SOCKS_VERSION, METHOD_USERNAME_PASSWORD])
+        .await?;
+
+    // [VER][ULEN][UNAME][PLEN][PASSWD], per RFC 1929.
+    let mut version = [0u8; 1];
+    control.read_exact(&mut version).await?;
+    assert_eq!(version[0], AUTH_VERSION, "unexpected auth version");
+
+    let username = read_length_prefixed(control).await?;
+    let password = read_length_prefixed(control).await?;
+    assert_eq!(username, USERNAME.as_bytes(), "wrong username");
+    assert_eq!(password, PASSWORD.as_bytes(), "wrong password");
+
+    // [VER][STATUS].
+    control.write_all(&[AUTH_VERSION, REP_SUCCESS]).await
+}
+
+/// Read a length byte followed by that many bytes.
+async fn read_length_prefixed(control: &mut TcpStream) -> io::Result<Vec<u8>> {
+    let mut len = [0u8; 1];
+    control.read_exact(&mut len).await?;
+
+    let mut bytes = vec![0u8; usize::from(len[0])];
+    control.read_exact(&mut bytes).await?;
+    Ok(bytes)
+}
+
+/// Read the `UDP ASSOCIATE` request, bind a relay socket for it, and reply with the socket's
+/// address.
+async fn accept_udp_associate(
+    control: &mut TcpStream,
+    unspecified_bind_addr: bool,
+) -> io::Result<UdpSocket> {
+    // Request: [VER][CMD][RSV][ATYP][DST.ADDR][DST.PORT].
+    let mut request = [0u8; 4];
+    control.read_exact(&mut request).await?;
+    let [version, command, reserved, address_type] = request;
+    assert_eq!(version, SOCKS_VERSION, "unexpected version in the request");
+    assert_eq!(command, CMD_UDP_ASSOCIATE, "expected a UDP ASSOCIATE");
+    assert_eq!(reserved, RSV, "RSV must be zero");
+    assert_eq!(address_type, ATYP_IPV4, "expected an IPv4 DST.ADDR");
+
+    // DST tells a proxy which source to accept relayed datagrams from. This one relays for
+    // whoever shows up first instead, so it is only read to keep the stream in sync.
+    let mut destination = [0u8; 6];
+    control.read_exact(&mut destination).await?;
+
+    let relay = UdpSocket::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await?;
+    let bind_addr = match unspecified_bind_addr {
+        true => Ipv4Addr::UNSPECIFIED,
+        false => Ipv4Addr::LOCALHOST,
+    };
+
+    // Reply: [VER][REP][RSV][ATYP][BND.ADDR][BND.PORT].
+    let mut reply = vec![SOCKS_VERSION, REP_SUCCESS, RSV, ATYP_IPV4];
+    reply.extend_from_slice(&bind_addr.octets());
+    reply.extend_from_slice(&relay.local_addr()?.port().to_be_bytes());
+    control.write_all(&reply).await?;
+
+    Ok(relay)
+}
+
+/// Relay datagrams between the client and whatever destinations it addresses.
+async fn relay_datagrams(relay: UdpSocket) -> io::Result<()> {
+    let outbound = UdpSocket::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await?;
+    let mut client = None;
+
+    let mut from_client = vec![0u8; usize::from(u16::MAX)];
+    let mut from_destination = vec![0u8; usize::from(u16::MAX)];
+
+    loop {
+        tokio::select! {
+            result = relay.recv_from(&mut from_client) => {
+                let (len, sender) = result?;
+                client = Some(sender);
+
+                let (destination, payload) = decapsulate(&from_client[..len]);
+                outbound.send_to(payload, destination).await?;
+            }
+            result = outbound.recv_from(&mut from_destination) => {
+                let (len, origin) = result?;
+                let Some(client) = client else { continue };
+
+                let datagram = encapsulate(origin, &from_destination[..len]);
+                relay.send_to(&datagram, client).await?;
+            }
+        }
+    }
+}
+
+/// Split a datagram from the client into the destination it names and the payload behind it.
+fn decapsulate(datagram: &[u8]) -> (SocketAddr, &[u8]) {
+    // [RSV][RSV][FRAG][ATYP][DST.ADDR][DST.PORT][DATA], for an IPv4 DST.ADDR.
+    let [rsv_high, rsv_low, fragment, address_type, a, b, c, d, port_high, port_low, payload @ ..] =
+        datagram
+    else {
+        panic!("truncated datagram from the client");
+    };
+    assert_eq!([*rsv_high, *rsv_low], [RSV, RSV], "RSV must be zero");
+    assert_eq!(*fragment, FRAG_STANDALONE, "the client must not fragment");
+    assert_eq!(*address_type, ATYP_IPV4, "expected an IPv4 destination");
+
+    let destination = SocketAddr::from((
+        Ipv4Addr::new(*a, *b, *c, *d),
+        u16::from_be_bytes([*port_high, *port_low]),
+    ));
+
+    (destination, payload)
+}
+
+/// Frame `payload` as having arrived from `origin`, the way a proxy hands it back to the client.
+fn encapsulate(origin: SocketAddr, payload: &[u8]) -> Vec<u8> {
+    let SocketAddr::V4(origin) = origin else {
+        panic!("the test destinations are all IPv4");
+    };
+
+    let mut datagram = vec![RSV, RSV, FRAG_STANDALONE, ATYP_IPV4];
+    datagram.extend_from_slice(&origin.ip().octets());
+    datagram.extend_from_slice(&origin.port().to_be_bytes());
+    datagram.extend_from_slice(payload);
+    datagram
+}
+
+/// Spawn a UDP server that echoes every datagram back to its sender, returning its address.
+async fn spawn_echo_server() -> io::Result<SocketAddr> {
+    let socket = UdpSocket::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await?;
+    let echo_addr = socket.local_addr()?;
+
+    tokio::spawn(async move {
+        let mut buffer = vec![0u8; usize::from(u16::MAX)];
+        while let Ok((len, from)) = socket.recv_from(&mut buffer).await {
+            let _ = socket.send_to(&buffer[..len], from).await;
+        }
+    });
+
+    Ok(echo_addr)
+}
+
+/// How long to wait for the proxy to relay a reply.
+///
+/// Everything here runs on localhost, so exceeding this means the datagram was never relayed
+/// back. A malformed one makes the proxy reject it, which would otherwise hang the test forever
+/// rather than fail it.
+const RELAY_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Relay a datagram to `destination` through `relay_addr`, and return the reply along with the
+/// address the reply claims to have come from.
+///
+/// # Blocking
+///
+/// Waits for the reply to come back, for at most [`RELAY_TIMEOUT`].
+async fn relay_datagram(
+    socket: &UdpSocket,
+    relay_addr: SocketAddr,
+    destination: SocketAddr,
+    payload: &[u8],
+) -> io::Result<(SocketAddr, Vec<u8>)> {
+    let mut datagram = Vec::new();
+    socks5::encode_udp_datagram(destination, payload, &mut datagram);
+    socket.send_to(&datagram, relay_addr).await?;
+
+    let mut buffer = vec![0u8; usize::from(u16::MAX)];
+    let (len, _from) = timeout(RELAY_TIMEOUT, socket.recv_from(&mut buffer))
+        .await
+        .map_err(|_| io::Error::other("the proxy never relayed the datagram back"))??;
+
+    let (origin, echoed) = socks5::decode_udp_datagram(&buffer[..len])
+        .ok_or_else(|| io::Error::other("the proxy relayed a malformed datagram"))?;
+
+    Ok((origin, echoed.to_vec()))
+}
+
+/// Bind the UDP socket that a client sends encapsulated datagrams from.
+async fn bind_client_socket() -> UdpSocket {
+    UdpSocket::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn datagram_round_trips_through_the_proxy() {
+    let proxy_addr = spawn_proxy(ProxyConfig::default()).await.unwrap();
+    let echo_addr = spawn_echo_server().await.unwrap();
+
+    let control = TcpStream::connect(proxy_addr).await.unwrap();
+    let association = Socks5UdpAssociation::associate(control, None)
+        .await
+        .unwrap();
+
+    let socket = bind_client_socket().await;
+    let (origin, echoed) = relay_datagram(&socket, association.relay_endpoint(), echo_addr, PAYLOAD)
+        .await
+        .unwrap();
+
+    assert_eq!(origin, echo_addr);
+    assert_eq!(echoed, PAYLOAD);
+}
+
+/// The association must survive more than a single datagram, since a tunnel relies on it for its
+/// entire lifetime.
+#[tokio::test]
+async fn association_relays_repeatedly() {
+    const DATAGRAMS: usize = 10;
+
+    let proxy_addr = spawn_proxy(ProxyConfig::default()).await.unwrap();
+    let echo_addr = spawn_echo_server().await.unwrap();
+
+    let control = TcpStream::connect(proxy_addr).await.unwrap();
+    let association = Socks5UdpAssociation::associate(control, None)
+        .await
+        .unwrap();
+
+    let socket = bind_client_socket().await;
+
+    for i in 0..DATAGRAMS {
+        let payload = format!("datagram {i}");
+        let (origin, echoed) = relay_datagram(
+            &socket,
+            association.relay_endpoint(),
+            echo_addr,
+            payload.as_bytes(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(origin, echo_addr);
+        assert_eq!(echoed, payload.as_bytes());
+    }
+}
+
+/// A proxy that answers with an unspecified BND.ADDR means "the address you are already talking to
+/// me on", so the relay endpoint must come out usable rather than pointing at `0.0.0.0`.
+#[tokio::test]
+async fn unspecified_bind_address_resolves_to_the_proxy() {
+    let config = ProxyConfig {
+        unspecified_bind_addr: true,
+        ..ProxyConfig::default()
+    };
+    let proxy_addr = spawn_proxy(config).await.unwrap();
+    let echo_addr = spawn_echo_server().await.unwrap();
+
+    let control = TcpStream::connect(proxy_addr).await.unwrap();
+    let association = Socks5UdpAssociation::associate(control, None)
+        .await
+        .unwrap();
+
+    let relay_addr = association.relay_endpoint();
+    assert_eq!(relay_addr.ip(), proxy_addr.ip());
+
+    let socket = bind_client_socket().await;
+    let (origin, echoed) = relay_datagram(&socket, relay_addr, echo_addr, PAYLOAD)
+        .await
+        .unwrap();
+
+    assert_eq!(origin, echo_addr);
+    assert_eq!(echoed, PAYLOAD);
+}
+
+/// A proxy that demands credentials must be answered with the RFC 1929 subnegotiation before the
+/// associate request is sent.
+#[tokio::test]
+async fn association_authenticates_with_username_and_password() {
+    let config = ProxyConfig {
+        require_auth: true,
+        ..ProxyConfig::default()
+    };
+    let proxy_addr = spawn_proxy(config).await.unwrap();
+    let echo_addr = spawn_echo_server().await.unwrap();
+
+    let auth = SocksAuth::new(USERNAME.to_owned(), PASSWORD.to_owned()).unwrap();
+    let control = TcpStream::connect(proxy_addr).await.unwrap();
+    let association = Socks5UdpAssociation::associate(control, Some(&auth))
+        .await
+        .unwrap();
+
+    let socket = bind_client_socket().await;
+    let (origin, echoed) = relay_datagram(&socket, association.relay_endpoint(), echo_addr, PAYLOAD)
+        .await
+        .unwrap();
+
+    assert_eq!(origin, echo_addr);
+    assert_eq!(echoed, PAYLOAD);
+}

--- a/tunnel-obfuscation/tests/socks5.rs
+++ b/tunnel-obfuscation/tests/socks5.rs
@@ -1,0 +1,149 @@
+//! End-to-end tests for the SOCKS5 `UDP ASSOCIATE` client, driven against a real SOCKS5 server.
+
+use std::{
+    io,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+};
+
+use fast_socks5::{
+    Socks5Command,
+    server::{Socks5ServerProtocol, run_udp_proxy},
+};
+use tokio::net::{TcpListener, TcpStream, UdpSocket};
+use tunnel_obfuscation::socks5::{self, Socks5UdpAssociation};
+
+const PAYLOAD: &[u8] = b"a wireguard packet, as far as the proxy is concerned";
+
+/// Spawn a SOCKS5 server on localhost that only handles `UDP ASSOCIATE`, returning its address.
+///
+/// The server task is detached and lives until the test process exits.
+async fn spawn_proxy() -> io::Result<SocketAddr> {
+    let listener = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await?;
+    let proxy_addr = listener.local_addr()?;
+
+    tokio::spawn(async move {
+        while let Ok((socket, _)) = listener.accept().await {
+            tokio::spawn(async move {
+                if let Err(error) = serve(socket).await {
+                    eprintln!("SOCKS5 client failed: {error}");
+                }
+            });
+        }
+    });
+
+    Ok(proxy_addr)
+}
+
+async fn serve(socket: TcpStream) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let localhost = IpAddr::from(Ipv4Addr::LOCALHOST);
+
+    let (protocol, command, target) = Socks5ServerProtocol::accept_no_auth(socket)
+        .await?
+        .read_command()
+        .await?;
+    assert_eq!(command, Socks5Command::UDPAssociate);
+
+    run_udp_proxy(
+        protocol,
+        &target,
+        Some(localhost),
+        localhost,
+        Some(localhost),
+    )
+    .await?;
+    Ok(())
+}
+
+/// Spawn a UDP server that echoes every datagram back to its sender, returning its address.
+async fn spawn_echo_server() -> io::Result<SocketAddr> {
+    let socket = UdpSocket::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await?;
+    let echo_addr = socket.local_addr()?;
+
+    tokio::spawn(async move {
+        let mut buffer = [0u8; u16::MAX as usize];
+        while let Ok((len, from)) = socket.recv_from(&mut buffer).await {
+            let _ = socket.send_to(&buffer[..len], from).await;
+        }
+    });
+
+    Ok(echo_addr)
+}
+
+/// Relay a datagram to `destination` through `relay_addr`, and return the reply along with the
+/// address the reply claims to have come from.
+async fn relay_datagram(
+    socket: &UdpSocket,
+    relay_addr: SocketAddr,
+    destination: SocketAddr,
+    payload: &[u8],
+) -> io::Result<(SocketAddr, Vec<u8>)> {
+    let mut datagram = Vec::new();
+    socks5::encode_udp_datagram(destination, payload, &mut datagram);
+    socket.send_to(&datagram, relay_addr).await?;
+
+    let mut buffer = [0u8; u16::MAX as usize];
+    let (len, _from) = socket.recv_from(&mut buffer).await?;
+    let (origin, echoed) = socks5::decode_udp_datagram(&buffer[..len])
+        .ok_or_else(|| io::Error::other("the proxy relayed a malformed datagram"))?;
+
+    Ok((origin, echoed.to_vec()))
+}
+
+#[tokio::test]
+async fn datagram_round_trips_through_the_proxy() {
+    let proxy_addr = spawn_proxy().await.unwrap();
+    let echo_addr = spawn_echo_server().await.unwrap();
+
+    let control = TcpStream::connect(proxy_addr).await.unwrap();
+    let association = Socks5UdpAssociation::associate(control, None)
+        .await
+        .unwrap();
+
+    // The relay address must be usable as-is, even if the proxy replied with an unspecified one.
+    let relay_addr = association.relay_endpoint();
+    assert!(!relay_addr.ip().is_unspecified());
+
+    let socket = UdpSocket::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+        .await
+        .unwrap();
+    let (origin, echoed) = relay_datagram(&socket, relay_addr, echo_addr, PAYLOAD)
+        .await
+        .unwrap();
+
+    assert_eq!(origin, echo_addr);
+    assert_eq!(echoed, PAYLOAD);
+}
+
+/// The association must survive more than a single datagram, since a tunnel relies on it for its
+/// entire lifetime.
+#[tokio::test]
+async fn association_relays_repeatedly() {
+    const DATAGRAMS: usize = 10;
+
+    let proxy_addr = spawn_proxy().await.unwrap();
+    let echo_addr = spawn_echo_server().await.unwrap();
+
+    let control = TcpStream::connect(proxy_addr).await.unwrap();
+    let association = Socks5UdpAssociation::associate(control, None)
+        .await
+        .unwrap();
+
+    let socket = UdpSocket::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+        .await
+        .unwrap();
+
+    for i in 0..DATAGRAMS {
+        let payload = format!("datagram {i}");
+        let (origin, echoed) = relay_datagram(
+            &socket,
+            association.relay_endpoint(),
+            echo_addr,
+            payload.as_bytes(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(origin, echo_addr);
+        assert_eq!(echoed, payload.as_bytes());
+    }
+}


### PR DESCRIPTION
This makes it possible to proxy relay traffic via a SOCKS5 server (UDP ASSOCIATE). Like the API access method, this can be used to proxy via tools that provide a SOCKS5 interface.

It's added on top of obfuscation/anti-censorship methods, but currently only if they have a userspace implementation (only LWO so far).

### Out of scope/todo

* Only works with *userspace* obfuscation methods (LWO, or plain WG).
* CLI only.
* Specific errors are not propagated to frontends.
* Remote setting is broken without `mullvad-exclude`. Currently it pokes a hole for the control server, but not the UDP associate connection.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10847)
<!-- Reviewable:end -->
