### PR TITLE
Replace NSOperation-based initialisation tasks in AppDelegate with modern Swift structured concurrency

### DIFF
--- a/ios/MullvadSettings/MigrationManager.swift
+++ b/ios/MullvadSettings/MigrationManager.swift
@@ -80,6 +80,16 @@ public struct MigrationManager {
         }
     }
 
+//    public func migrateSettings(store: SettingsStore) async -> SettingsMigrationResult {
+//        await withCheckedContinuation { continuation in
+//            Task {@MainActor in
+//                migrateSettings(store: store) { result in
+//                    continuation.resume(returning: result)
+//                }
+//            }
+//        }
+//    }
+
     private func upgradeSettingsToLatestVersion(
         store: SettingsStore,
         migrationCompleted: @escaping @Sendable (SettingsMigrationResult) -> Void

--- a/ios/MullvadSettings/MigrationManager.swift
+++ b/ios/MullvadSettings/MigrationManager.swift
@@ -80,16 +80,6 @@ public struct MigrationManager {
         }
     }
 
-//    public func migrateSettings(store: SettingsStore) async -> SettingsMigrationResult {
-//        await withCheckedContinuation { continuation in
-//            Task {@MainActor in
-//                migrateSettings(store: store) { result in
-//                    continuation.resume(returning: result)
-//                }
-//            }
-//        }
-//    }
-
     private func upgradeSettingsToLatestVersion(
         store: SettingsStore,
         migrationCompleted: @escaping @Sendable (SettingsMigrationResult) -> Void

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -208,7 +208,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             tunnelSettingsUpdater: tunnelSettingsUpdater
         )
         addApplicationNotifications(application: application)
-        startInitialization(application: application)
+        Task {
+            await startInitialization(application: application)
+        }
 
         // Pre-warm @Observable infrastructure for LocationNode to avoid first-render lag
         // in SelectLocationView. SwiftUI's observation system has initialization overhead
@@ -514,15 +516,24 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         UNUserNotificationCenter.current().delegate = self
     }
 
-    private func startInitialization(application: UIApplication) {
+    private func startInitialization(application: UIApplication) async {
+        // the new structured code: things here run first, before we run the legacy operations.
+        // in the fullness of time, this section will grow and the latter will shrink to nothing
+        
+        // next: make a TaskGroup containing this and wipeSettings, and await that in one go
+        
+        await doLoadTunnelStore()
+        
+        // legacy concurrency code follows. We comment out the operations that have been converted.
+        
         let defaultLocationOperation = getDefaultLocationOperation()
-        let loadTunnelStoreOperation = getLoadTunnelStoreOperation()
+//        let loadTunnelStoreOperation = getLoadTunnelStoreOperation()
         let initTunnelManagerOperation = getInitTunnelManagerOperation()
         let deprecatedSettingsResolverOperation = getDeprecatedSettingsResolverOperation()
 
         var operations: [Operation] = [
             defaultLocationOperation,
-            loadTunnelStoreOperation,
+//            loadTunnelStoreOperation,
         ]
 
         let wipeSettingsOperation = getWipeSettingsOperation()
@@ -532,7 +543,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         defaultLocationOperation.addDependency(wipeSettingsOperation)
         migrateSettingsOperation.addDependencies([
             wipeSettingsOperation,
-            loadTunnelStoreOperation,
+//            loadTunnelStoreOperation,
         ])
         deprecatedSettingsResolverOperation.addDependency(migrateSettingsOperation)
         initTunnelManagerOperation.addDependency(migrateSettingsOperation)
@@ -560,6 +571,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                     finish(nil)
                 }
             }
+        }
+    }
+    
+    private func doLoadTunnelStore() async {
+        do {
+            try await tunnelStore.loadPersistentTunnels()
+        } catch {
+            logger.error(
+                error: error,
+                message: "Failed to load persistent tunnels."
+            )
         }
     }
 
@@ -635,6 +657,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     /// (`SettingsManager.getShouldWipeSettings()`)
     /// If (1) is `false` and (2) is `true`, we know that the app has been freshly installed/reinstalled and is
     /// compatible, thus triggering a settings wipe.
+    
+    /// CONCURRENCY PORTING NOTE: this does not seem to be asynchronous. It can call `deleteDevice`, but does not await the result. Why is it an AsyncBlockOperation?
     private func getWipeSettingsOperation() -> AsyncBlockOperation {
         AsyncBlockOperation { [settingsManager] in
             let appHasNeverBeenLaunched =

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -514,37 +514,25 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         UNUserNotificationCenter.current().delegate = self
     }
 
+    // MARK: Initialisation tasks, which are (mostly) performed asynchronously
+
     private func startInitialization(application: UIApplication) {
         // the new structured code: things here run first, before we run the legacy operations.
         // in the fullness of time, this section will grow and the latter will shrink to nothing
         Task {
             doWipeSettingsIfNeeded()
-            async let loadTunnelStore = doLoadTunnelStore()
-            async let getDefaultLocation = doGetDefaultLocation()
-            await [loadTunnelStore, getDefaultLocation]
+            async let loadTunnelStore: () = doLoadTunnelStore()
+            async let getDefaultLocation: () = doGetDefaultLocation()
+            // just doing `await [doLoadTunnelStore(), doGetDefaultLocation()]` would have
+            // executed these sequentially for some reason
+            _ = await [loadTunnelStore, getDefaultLocation]
             await doMigrateSettings(application: application)
-            async let initTunnelManager = doInitTunnelManager()
-            async let resolveDeprecatedSettings = doResolveDeprecatedSettings()
-            await [initTunnelManager, resolveDeprecatedSettings]
+            async let initTunnelManager: () = doInitTunnelManager()
+            async let resolveDeprecatedSettings: () = doResolveDeprecatedSettings()
+            _ = await [initTunnelManager, resolveDeprecatedSettings]
         }
     }
 
-    private func getLoadTunnelStoreOperation() -> AsyncBlockOperation {
-        AsyncBlockOperation(dispatchQueue: .main) { [self] finish in
-            MainActor.assumeIsolated {
-                tunnelStore.loadPersistentTunnels { [self] error in
-                    if let error {
-                        logger.error(
-                            error: error,
-                            message: "Failed to load persistent tunnels."
-                        )
-                    }
-                    finish(nil)
-                }
-            }
-        }
-    }
-    
     private func doLoadTunnelStore() async {
         do {
             try await tunnelStore.loadPersistentTunnels()
@@ -555,7 +543,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             )
         }
     }
-    
+
     private func doMigrateSettings(application: UIApplication) async {
         // this triggers an operation that needs to be carried out on the main queue, as
         // it uses NSFileCoordinator to maintain a lock shared between the app and extension
@@ -600,70 +588,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         }
     }
 
-    private func getMigrateSettingsOperation(application: UIApplication) -> AsyncBlockOperation {
-        AsyncBlockOperation(
-            dispatchQueue: .main,
-            block: { [self] (finish: @escaping @Sendable (Error?) -> Void) in
-                MainActor.assumeIsolated {
-                    migrationManager
-                        .migrateSettings(store: settingsManager.store) { [self] migrationResult in
-                            switch migrationResult {
-                            case .success:
-                                // Tell the tunnel to re-read tunnel configuration after migration.
-                                logger.debug("Successful migration from UI Process")
-                                tunnelManager.reconnectTunnel(selectNewRelay: true)
-                                fallthrough
-
-                            case .nothing:
-                                logger.debug("Attempted migration from UI Process, but found nothing to do")
-                                finish(nil)
-
-                            case let .failure(error):
-                                logger.error("Failed migration from UI Process: \(error)")
-                                MainActor.assumeIsolated {
-                                    let migrationUIHandler =
-                                        application.connectedScenes
-                                        .first { $0 is SettingsMigrationUIHandler } as? SettingsMigrationUIHandler
-
-                                    if let migrationUIHandler {
-                                        migrationUIHandler.showMigrationError(error) {
-                                            MainActor.assumeIsolated {
-                                                finish(error)
-                                            }
-                                        }
-                                    } else {
-                                        finish(error)
-                                    }
-                                }
-                            }
-                        }
-                }
-            }
-        )
-    }
-
-    private func getInitTunnelManagerOperation() -> AsyncBlockOperation {
-        // This operation is always treated as successful no matter what the configuration load yields.
-        // If the tunnel settings or device state can't be read, we simply pretend they are not there
-        // and leave user in logged out state. VPN config will be removed as well.
-        AsyncBlockOperation(dispatchQueue: .main) { [weak self] finish in
-            guard let self else {
-                finish(nil)
-                return
-            }
-            self.tunnelManager.loadConfiguration {
-                self.logger.debug("Finished initialization.")
-
-                NotificationManager.shared.updateNotifications()
-
-                Task {
-                    await self.storePaymentManager.start()
-                    finish(nil)
-                }
-            }
-        }
-    }
-    
     private func doInitTunnelManager() async {
         // This operation is always treated as successful no matter what the configuration load yields.
         // If the tunnel settings or device state can't be read, we simply pretend they are not there
@@ -683,7 +607,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     }
 
-    /// Returns an operation that acts on the following conditions:
     /// 1. If the app has never been launched, preload with default settings.
     /// - or -
     /// 1. Has the app been launched at least once after install? (`FirstTimeLaunch.hasFinished`)
@@ -691,46 +614,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     /// (`SettingsManager.getShouldWipeSettings()`)
     /// If (1) is `false` and (2) is `true`, we know that the app has been freshly installed/reinstalled and is
     /// compatible, thus triggering a settings wipe.
-    
-    /// CONCURRENCY PORTING NOTE: this does not seem to be asynchronous. It can call `deleteDevice`, but does not await the result. Why is it an AsyncBlockOperation?
-    private func getWipeSettingsOperation() -> AsyncBlockOperation {
-        AsyncBlockOperation { [settingsManager] in
-            let appHasNeverBeenLaunched =
-                !self.appPreferences.hasDoneFirstTimeLaunch && !settingsManager.getShouldWipeSettings()
-            let appWasLaunchedAfterReinstall =
-                !self.appPreferences.hasDoneFirstTimeLaunch && settingsManager.getShouldWipeSettings()
 
-            if appHasNeverBeenLaunched {
-                try? settingsManager.writeSettings(LatestTunnelSettings())
-            } else if appWasLaunchedAfterReinstall {
-                if let deviceState = try? settingsManager.readDeviceState(),
-                    let accountData = deviceState.accountData,
-                    let deviceData = deviceState.deviceData
-                {
-                    // this part is asynchronous, but we don't await the result
-                    _ = self.devicesProxy.deleteDevice(
-                        accountNumber: accountData.number,
-                        identifier: deviceData.identifier,
-                        retryStrategy: .noRetry
-                    ) { _ in
-                        // Do nothing.
-                    }
-                }
-
-                settingsManager.resetStore(policy: .all)
-                try? settingsManager.writeSettings(LatestTunnelSettings())
-
-                // Default access methods need to be repopulated again after settings wipe.
-                self.accessMethodRepository.addDefaultsMethods()
-                // At app startup, the relay cache tracker will get populated with a list of overriden IPs.
-                // The overriden IPs will get wiped, therefore, the cache needs to be pruned as well.
-                try? self.relayCacheTracker.refreshCachedRelays()
-            }
-
-            settingsManager.setShouldWipeSettings()
-        }
-    }
-    
+    /// this was an AsyncBlockOperation, though is not in itself asynchronous.(It can call `deleteDevice`, but does not await the result)
+    /// The reimplementation is entirely synchronous
     private func doWipeSettingsIfNeeded() {
         defer {
             settingsManager.setShouldWipeSettings()
@@ -767,42 +653,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         }
     }
 
-    private func getDefaultLocationOperation() -> AsyncBlockOperation {
-        AsyncBlockOperation {
-            guard !self.appPreferences.hasDoneFirstTimeLaunch else {
-                return
-            }
-            self.appPreferences.hasDoneFirstTimeLaunch = true
-
-            // No need to keep the handle since we're not waiting or cancelling the completion anyway.
-            _ = self.relayCacheTracker.updateRelays { _ in
-                Task {
-                    guard let cachedRelays = try? self.relayCacheTracker.getCachedRelays() else {
-                        return
-                    }
-
-                    let locationService = DefaultLocationService(
-                        urlSession: URLSession.shared, relayCache: cachedRelays)
-                    let locationIdentifier = try? await locationService.fetchCurrentLocationIdentifier()
-                    let userSelectedRelays: UserSelectedRelays =
-                        if let country = locationIdentifier?.country {
-                            UserSelectedRelays(locations: [.country(country)])
-                        } else {
-                            .default
-                        }
-
-                    let constraint = RelayConstraint.only(userSelectedRelays)
-
-                    if !self.appPreferences.hasDoneFirstTimeLogin {
-                        self.tunnelManager.updateSettings([
-                            .relayConstraints(RelayConstraints(entryLocations: constraint, exitLocations: constraint))
-                        ])
-                    }
-                }
-            }
-        }
-    }
-    
     private func doGetDefaultLocation() async {
         guard !self.appPreferences.hasDoneFirstTimeLaunch else {
             return
@@ -828,7 +678,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             ])
         }
     }
-    
+
     private func doResolveDeprecatedSettings() async {
         await withCheckedContinuation { continuation in
             DispatchQueue.main.async { [self] in
@@ -889,70 +739,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 }
             }
         }
-    }
-
-    private func getDeprecatedSettingsResolverOperation() -> AsyncBlockOperation {
-        AsyncBlockOperation(
-            dispatchQueue: .main,
-            block: { [self] (finish: @escaping @Sendable (Error?) -> Void) in
-
-                let resetVisibility: @Sendable () -> Void = {
-                    self.appPreferences.migratedSettingsState = MigratedSettingsState(
-                        preMigrationSettings: nil,
-                        lastInstalledVersion: Bundle.main.productVersion,
-                        lastMigratedVersion: MigratedVersion.current.rawValue,
-                        hasCompletedMigrationWizard: true,
-                        shouldShowMigratedSettingsMenuItem: false)
-                    self.migratedSettingsListener.onMigratedSettingsHandler?(.noChanges)
-                }
-
-                MainActor.assumeIsolated {
-                    let settingsResolver = DeprecatedSettingsResolver(
-                        cacheDirectory: containerURL,
-                        settingsManager: settingsManager,
-                        relaySelector: relaySelector,
-                        currentVersion: MigratedVersion(
-                            rawValue: appPreferences.migratedSettingsState.lastMigratedVersion)
-                            ?? MigratedVersion.current)
-
-                    let isAppUpdated =
-                        Bundle.main.productVersion != self.appPreferences.migratedSettingsState.lastInstalledVersion
-
-                    // Reset the migrated settings menu visibility after an app update.
-                    // The menu item should only remain visible within the same app version.
-                    appPreferences.migratedSettingsState.shouldShowMigratedSettingsMenuItem =
-                        !isAppUpdated && self.appPreferences.migratedSettingsState.shouldShowMigratedSettingsMenuItem
-
-                    settingsResolver.resolve(store: self.settingsManager.store) { [self] result in
-                        switch result {
-                        case let .migrated(old, new, changes):
-                            // Tell the tunnel to re-read tunnel configuration after migration.
-                            logger.debug("Successful resolving deprecated settings from UI Process")
-                            appPreferences.migratedSettingsState = MigratedSettingsState(
-                                preMigrationSettings: old,
-                                lastInstalledVersion: Bundle.main.productVersion,
-                                lastMigratedVersion: MigratedVersion.current.rawValue,
-                                hasCompletedMigrationWizard: changes.isEmpty,
-                                shouldShowMigratedSettingsMenuItem: !changes.isEmpty)
-                            migratedSettingsListener.onMigratedSettingsHandler?(
-                                changes.isEmpty ? .noChanges : .migrated)
-                            tunnelManager.updateSettings([.all(new)])
-                            finish(nil)
-
-                        case .nothing:
-                            logger.debug(
-                                "Attempted resolving deprecated settings from UI Process, but It's already up to date, so nothing to do"
-                            )
-                            migratedSettingsListener.onMigratedSettingsHandler?(.noChanges)
-                            finish(nil)
-                        case let .failure(error):
-                            logger.error("Failed resolving deprecated settings from UI Process: \(error)")
-                            resetVisibility()
-                            finish(error)
-                        }
-                    }
-                }
-            })
     }
 
     // MARK: - UNUserNotificationCenterDelegate

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -514,120 +514,93 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         UNUserNotificationCenter.current().delegate = self
     }
 
+    // MARK: Initialisation tasks, which are (mostly) performed asynchronously
+
     private func startInitialization(application: UIApplication) {
-        let defaultLocationOperation = getDefaultLocationOperation()
-        let loadTunnelStoreOperation = getLoadTunnelStoreOperation()
-        let initTunnelManagerOperation = getInitTunnelManagerOperation()
-        let deprecatedSettingsResolverOperation = getDeprecatedSettingsResolverOperation()
-
-        var operations: [Operation] = [
-            defaultLocationOperation,
-            loadTunnelStoreOperation,
-        ]
-
-        let wipeSettingsOperation = getWipeSettingsOperation()
-        let migrateSettingsOperation = getMigrateSettingsOperation(application: application)
-
-        // Dependencies
-        defaultLocationOperation.addDependency(wipeSettingsOperation)
-        migrateSettingsOperation.addDependencies([
-            wipeSettingsOperation,
-            loadTunnelStoreOperation,
-        ])
-        deprecatedSettingsResolverOperation.addDependency(migrateSettingsOperation)
-        initTunnelManagerOperation.addDependency(migrateSettingsOperation)
-
-        operations.append(contentsOf: [
-            wipeSettingsOperation,
-            migrateSettingsOperation,
-            deprecatedSettingsResolverOperation,
-            initTunnelManagerOperation,
-        ])
-
-        operationQueue.addOperations(operations, waitUntilFinished: false)
+        // the new structured code: things here run first, before we run the legacy operations.
+        // in the fullness of time, this section will grow and the latter will shrink to nothing
+        Task {
+            doWipeSettingsIfNeeded()
+            async let loadTunnelStore: () = doLoadTunnelStore()
+            async let getDefaultLocation: () = doGetDefaultLocation()
+            _ = await [loadTunnelStore, getDefaultLocation]
+            await doMigrateSettings(application: application)
+            await doResolveDeprecatedSettings()
+            await doInitTunnelManager()
+            await storePaymentManager.start()
+        }
     }
 
-    private func getLoadTunnelStoreOperation() -> AsyncBlockOperation {
-        AsyncBlockOperation(dispatchQueue: .main) { [self] finish in
-            MainActor.assumeIsolated {
-                tunnelStore.loadPersistentTunnels { [self] error in
-                    if let error {
-                        logger.error(
-                            error: error,
-                            message: "Failed to load persistent tunnels."
-                        )
+    private func doLoadTunnelStore() async {
+        do {
+            try await tunnelStore.loadPersistentTunnels()
+        } catch {
+            logger.error(
+                error: error,
+                message: "Failed to load persistent tunnels."
+            )
+        }
+    }
+
+    private func doMigrateSettings(application: UIApplication) async {
+        // this triggers an operation that needs to be carried out on the main queue, as
+        // it uses NSFileCoordinator to maintain a lock shared between the app and extension
+        // it consumes any error states produced in the process
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                self.migrationManager
+                    .migrateSettings(store: self.settingsManager.store) { [self] migrationResult in
+                        switch migrationResult {
+                        case .success:
+                            // Tell the tunnel to re-read tunnel configuration after migration.
+                            logger.debug("Successful migration from UI Process")
+                            tunnelManager.reconnectTunnel(selectNewRelay: true)
+                            fallthrough
+
+                        case .nothing:
+                            logger.debug("Attempted migration from UI Process, but found nothing to do")
+                            continuation.resume(returning: ())
+
+                        case let .failure(error):
+                            logger.error("Failed migration from UI Process: \(error)")
+                            // SAFETY NOTE: We can assume this to be running on the same thread that
+                            // `MigrationManager.migrateSettings` was called from, as the callback is
+                            // called through `NSFileCoordinator`, which runs synchronously on one thread
+                            // and is used for locking between processes using the filesystem.
+                            MainActor.assumeIsolated {
+                                let migrationUIHandler =
+                                    application.connectedScenes
+                                    .first { $0 is SettingsMigrationUIHandler } as? SettingsMigrationUIHandler
+
+                                if let migrationUIHandler {
+                                    migrationUIHandler.showMigrationError(error) {
+                                        continuation.resume(returning: ())
+                                    }
+                                } else {
+                                    continuation.resume(returning: ())
+                                }
+                            }
+                        }
                     }
-                    finish(nil)
-                }
             }
         }
     }
 
-    private func getMigrateSettingsOperation(application: UIApplication) -> AsyncBlockOperation {
-        AsyncBlockOperation(
-            dispatchQueue: .main,
-            block: { [self] (finish: @escaping @Sendable (Error?) -> Void) in
-                MainActor.assumeIsolated {
-                    migrationManager
-                        .migrateSettings(store: settingsManager.store) { [self] migrationResult in
-                            switch migrationResult {
-                            case .success:
-                                // Tell the tunnel to re-read tunnel configuration after migration.
-                                logger.debug("Successful migration from UI Process")
-                                tunnelManager.reconnectTunnel(selectNewRelay: true)
-                                fallthrough
-
-                            case .nothing:
-                                logger.debug("Attempted migration from UI Process, but found nothing to do")
-                                finish(nil)
-
-                            case let .failure(error):
-                                logger.error("Failed migration from UI Process: \(error)")
-                                MainActor.assumeIsolated {
-                                    let migrationUIHandler =
-                                        application.connectedScenes
-                                        .first { $0 is SettingsMigrationUIHandler } as? SettingsMigrationUIHandler
-
-                                    if let migrationUIHandler {
-                                        migrationUIHandler.showMigrationError(error) {
-                                            MainActor.assumeIsolated {
-                                                finish(error)
-                                            }
-                                        }
-                                    } else {
-                                        finish(error)
-                                    }
-                                }
-                            }
-                        }
-                }
-            }
-        )
-    }
-
-    private func getInitTunnelManagerOperation() -> AsyncBlockOperation {
+    private func doInitTunnelManager() async {
         // This operation is always treated as successful no matter what the configuration load yields.
         // If the tunnel settings or device state can't be read, we simply pretend they are not there
         // and leave user in logged out state. VPN config will be removed as well.
-        AsyncBlockOperation(dispatchQueue: .main) { [weak self] finish in
-            guard let self else {
-                finish(nil)
-                return
-            }
+        await withCheckedContinuation { continuation in
             self.tunnelManager.loadConfiguration {
                 self.logger.debug("Finished initialization.")
 
                 NotificationManager.shared.updateNotifications()
 
-                Task {
-                    await self.storePaymentManager.start()
-                    finish(nil)
-                }
+                continuation.resume(returning: ())
             }
         }
     }
 
-    /// Returns an operation that acts on the following conditions:
     /// 1. If the app has never been launched, preload with default settings.
     /// - or -
     /// 1. Has the app been launched at least once after install? (`FirstTimeLaunch.hasFinished`)
@@ -635,84 +608,71 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     /// (`SettingsManager.getShouldWipeSettings()`)
     /// If (1) is `false` and (2) is `true`, we know that the app has been freshly installed/reinstalled and is
     /// compatible, thus triggering a settings wipe.
-    private func getWipeSettingsOperation() -> AsyncBlockOperation {
-        AsyncBlockOperation { [settingsManager] in
-            let appHasNeverBeenLaunched =
-                !self.appPreferences.hasDoneFirstTimeLaunch && !settingsManager.getShouldWipeSettings()
-            let appWasLaunchedAfterReinstall =
-                !self.appPreferences.hasDoneFirstTimeLaunch && settingsManager.getShouldWipeSettings()
-
-            if appHasNeverBeenLaunched {
-                try? settingsManager.writeSettings(LatestTunnelSettings())
-            } else if appWasLaunchedAfterReinstall {
-                if let deviceState = try? settingsManager.readDeviceState(),
-                    let accountData = deviceState.accountData,
-                    let deviceData = deviceState.deviceData
-                {
-                    _ = self.devicesProxy.deleteDevice(
-                        accountNumber: accountData.number,
-                        identifier: deviceData.identifier,
-                        retryStrategy: .noRetry
-                    ) { _ in
-                        // Do nothing.
-                    }
-                }
-
-                settingsManager.resetStore(policy: .all)
-                try? settingsManager.writeSettings(LatestTunnelSettings())
-
-                // Default access methods need to be repopulated again after settings wipe.
-                self.accessMethodRepository.addDefaultsMethods()
-                // At app startup, the relay cache tracker will get populated with a list of overriden IPs.
-                // The overriden IPs will get wiped, therefore, the cache needs to be pruned as well.
-                try? self.relayCacheTracker.refreshCachedRelays()
-            }
-
+    private func doWipeSettingsIfNeeded() {
+        defer {
             settingsManager.setShouldWipeSettings()
         }
-    }
+        guard !self.appPreferences.hasDoneFirstTimeLaunch else { return }
 
-    private func getDefaultLocationOperation() -> AsyncBlockOperation {
-        AsyncBlockOperation {
-            guard !self.appPreferences.hasDoneFirstTimeLaunch else {
-                return
-            }
-            self.appPreferences.hasDoneFirstTimeLaunch = true
-
-            // No need to keep the handle since we're not waiting or cancelling the completion anyway.
-            _ = self.relayCacheTracker.updateRelays { _ in
-                Task {
-                    guard let cachedRelays = try? self.relayCacheTracker.getCachedRelays() else {
-                        return
-                    }
-
-                    let locationService = DefaultLocationService(
-                        urlSession: URLSession.shared, relayCache: cachedRelays)
-                    let locationIdentifier = try? await locationService.fetchCurrentLocationIdentifier()
-                    let userSelectedRelays: UserSelectedRelays =
-                        if let country = locationIdentifier?.country {
-                            UserSelectedRelays(locations: [.country(country)])
-                        } else {
-                            .default
-                        }
-
-                    let constraint = RelayConstraint.only(userSelectedRelays)
-
-                    if !self.appPreferences.hasDoneFirstTimeLogin {
-                        self.tunnelManager.updateSettings([
-                            .relayConstraints(RelayConstraints(entryLocations: constraint, exitLocations: constraint))
-                        ])
-                    }
+        if !settingsManager.getShouldWipeSettings() {
+            // the app has never been launched
+            try? settingsManager.writeSettings(LatestTunnelSettings())
+        } else {
+            // the app has been launched after a reinstall
+            if let deviceState = try? settingsManager.readDeviceState(),
+                let accountData = deviceState.accountData,
+                let deviceData = deviceState.deviceData
+            {
+                // this part is asynchronous, but we don't await the result
+                _ = self.devicesProxy.deleteDevice(
+                    accountNumber: accountData.number,
+                    identifier: deviceData.identifier,
+                    retryStrategy: .noRetry
+                ) { _ in
+                    // Do nothing.
                 }
             }
+
+            settingsManager.resetStore(policy: .all)
+            try? settingsManager.writeSettings(LatestTunnelSettings())
+
+            // Default access methods need to be repopulated again after settings wipe.
+            self.accessMethodRepository.addDefaultsMethods()
+            // At app startup, the relay cache tracker will get populated with a list of overriden IPs.
+            // The overriden IPs will get wiped, therefore, the cache needs to be pruned as well.
+            try? self.relayCacheTracker.refreshCachedRelays()
         }
     }
 
-    private func getDeprecatedSettingsResolverOperation() -> AsyncBlockOperation {
-        AsyncBlockOperation(
-            dispatchQueue: .main,
-            block: { [self] (finish: @escaping @Sendable (Error?) -> Void) in
+    private func doGetDefaultLocation() async {
+        guard !self.appPreferences.hasDoneFirstTimeLaunch else {
+            return
+        }
+        self.appPreferences.hasDoneFirstTimeLaunch = true
+        _ = try? await relayCacheTracker.updateRelays()
+        guard let cachedRelays = try? relayCacheTracker.getCachedRelays() else { return }
+        let locationService = DefaultLocationService(
+            urlSession: URLSession.shared, relayCache: cachedRelays)
+        let locationIdentifier = try? await locationService.fetchCurrentLocationIdentifier()
+        let userSelectedRelays: UserSelectedRelays =
+            if let country = locationIdentifier?.country {
+                UserSelectedRelays(locations: [.country(country)])
+            } else {
+                .default
+            }
 
+        let constraint = RelayConstraint.only(userSelectedRelays)
+
+        if !self.appPreferences.hasDoneFirstTimeLogin {
+            self.tunnelManager.updateSettings([
+                .relayConstraints(RelayConstraints(entryLocations: constraint, exitLocations: constraint))
+            ])
+        }
+    }
+
+    private func doResolveDeprecatedSettings() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async { [self] in
                 let resetVisibility: @Sendable () -> Void = {
                     self.appPreferences.migratedSettingsState = MigratedSettingsState(
                         preMigrationSettings: nil,
@@ -722,7 +682,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                         shouldShowMigratedSettingsMenuItem: false)
                     self.migratedSettingsListener.onMigratedSettingsHandler?(.noChanges)
                 }
-
                 MainActor.assumeIsolated {
                     let settingsResolver = DeprecatedSettingsResolver(
                         cacheDirectory: containerURL,
@@ -757,22 +716,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                             migratedSettingsListener.onMigratedSettingsHandler?(
                                 changes.isEmpty ? .noChanges : .migrated)
                             tunnelManager.updateSettings([.all(new)])
-                            finish(nil)
+                            continuation.resume(returning: ())
 
                         case .nothing:
                             logger.debug(
                                 "Attempted resolving deprecated settings from UI Process, but It's already up to date, so nothing to do"
                             )
                             migratedSettingsListener.onMigratedSettingsHandler?(.noChanges)
-                            finish(nil)
+                            continuation.resume(returning: ())
                         case let .failure(error):
                             logger.error("Failed resolving deprecated settings from UI Process: \(error)")
                             resetVisibility()
-                            finish(error)
+                            continuation.resume(returning: ())
                         }
                     }
                 }
-            })
+            }
+        }
     }
 
     // MARK: - UNUserNotificationCenterDelegate

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -521,18 +521,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         // in the fullness of time, this section will grow and the latter will shrink to nothing
         
         // next: make a TaskGroup containing this and wipeSettings, and await that in one go
-        
+        `
         await doLoadTunnelStore()
+        doWipeSettingsIfNeeded()
+        await doGetDefaultLocation()
         
         // legacy concurrency code follows. We comment out the operations that have been converted.
         
-        let defaultLocationOperation = getDefaultLocationOperation()
+//        let defaultLocationOperation = getDefaultLocationOperation()
 //        let loadTunnelStoreOperation = getLoadTunnelStoreOperation()
         let initTunnelManagerOperation = getInitTunnelManagerOperation()
         let deprecatedSettingsResolverOperation = getDeprecatedSettingsResolverOperation()
 
         var operations: [Operation] = [
-            defaultLocationOperation,
+//            defaultLocationOperation,
 //            loadTunnelStoreOperation,
         ]
 
@@ -540,11 +542,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         let migrateSettingsOperation = getMigrateSettingsOperation(application: application)
 
         // Dependencies
-        defaultLocationOperation.addDependency(wipeSettingsOperation)
-        migrateSettingsOperation.addDependencies([
-            wipeSettingsOperation,
+//        defaultLocationOperation.addDependency(wipeSettingsOperation)
+//        migrateSettingsOperation.addDependencies([
+//            wipeSettingsOperation,
 //            loadTunnelStoreOperation,
-        ])
+//        ])
         deprecatedSettingsResolverOperation.addDependency(migrateSettingsOperation)
         initTunnelManagerOperation.addDependency(migrateSettingsOperation)
 
@@ -673,6 +675,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                     let accountData = deviceState.accountData,
                     let deviceData = deviceState.deviceData
                 {
+                    // this part is asynchronous, but we don't await the result
                     _ = self.devicesProxy.deleteDevice(
                         accountNumber: accountData.number,
                         identifier: deviceData.identifier,
@@ -694,6 +697,43 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
             settingsManager.setShouldWipeSettings()
         }
+    }
+    
+    private func doWipeSettingsIfNeeded() {
+        let appHasNeverBeenLaunched =
+            !self.appPreferences.hasDoneFirstTimeLaunch && !settingsManager.getShouldWipeSettings()
+        let appWasLaunchedAfterReinstall =
+            !self.appPreferences.hasDoneFirstTimeLaunch && settingsManager.getShouldWipeSettings()
+
+        if appHasNeverBeenLaunched {
+            try? settingsManager.writeSettings(LatestTunnelSettings())
+        } else if appWasLaunchedAfterReinstall {
+            if let deviceState = try? settingsManager.readDeviceState(),
+                let accountData = deviceState.accountData,
+                let deviceData = deviceState.deviceData
+            {
+                // this part is asynchronous, but we don't await the result
+                _ = self.devicesProxy.deleteDevice(
+                    accountNumber: accountData.number,
+                    identifier: deviceData.identifier,
+                    retryStrategy: .noRetry
+                ) { _ in
+                    // Do nothing.
+                }
+            }
+
+            settingsManager.resetStore(policy: .all)
+            try? settingsManager.writeSettings(LatestTunnelSettings())
+
+            // Default access methods need to be repopulated again after settings wipe.
+            self.accessMethodRepository.addDefaultsMethods()
+            // At app startup, the relay cache tracker will get populated with a list of overriden IPs.
+            // The overriden IPs will get wiped, therefore, the cache needs to be pruned as well.
+            try? self.relayCacheTracker.refreshCachedRelays()
+        }
+
+        settingsManager.setShouldWipeSettings()
+
     }
 
     private func getDefaultLocationOperation() -> AsyncBlockOperation {
@@ -729,6 +769,32 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                     }
                 }
             }
+        }
+    }
+    
+    private func doGetDefaultLocation() async {
+        guard !self.appPreferences.hasDoneFirstTimeLaunch else {
+            return
+        }
+        self.appPreferences.hasDoneFirstTimeLaunch = true
+        _ = try? await relayCacheTracker.updateRelays()
+        guard let cachedRelays = try? relayCacheTracker.getCachedRelays() else { return }
+        let locationService = DefaultLocationService(
+            urlSession: URLSession.shared, relayCache: cachedRelays)
+        let locationIdentifier = try? await locationService.fetchCurrentLocationIdentifier()
+        let userSelectedRelays: UserSelectedRelays =
+            if let country = locationIdentifier?.country {
+                UserSelectedRelays(locations: [.country(country)])
+            } else {
+                .default
+            }
+
+        let constraint = RelayConstraint.only(userSelectedRelays)
+
+        if !self.appPreferences.hasDoneFirstTimeLogin {
+            self.tunnelManager.updateSettings([
+                .relayConstraints(RelayConstraints(entryLocations: constraint, exitLocations: constraint))
+            ])
         }
     }
 

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -527,9 +527,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             // executed these sequentially for some reason
             _ = await [loadTunnelStore, getDefaultLocation]
             await doMigrateSettings(application: application)
-            async let initTunnelManager: () = doInitTunnelManager()
-            async let resolveDeprecatedSettings: () = doResolveDeprecatedSettings()
-            _ = await [initTunnelManager, resolveDeprecatedSettings]
+            await doResolveDeprecatedSettings()
+            await doInitTunnelManager()
             await self.storePaymentManager.start()
         }
     }

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -566,16 +566,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
                         case let .failure(error):
                             logger.error("Failed migration from UI Process: \(error)")
-                            let migrationUIHandler =
-                                application.connectedScenes
-                                .first { $0 is SettingsMigrationUIHandler } as? SettingsMigrationUIHandler
+                            MainActor.assumeIsolated {
+                                let migrationUIHandler =
+                                    application.connectedScenes
+                                    .first { $0 is SettingsMigrationUIHandler } as? SettingsMigrationUIHandler
 
-                            if let migrationUIHandler {
-                                migrationUIHandler.showMigrationError(error) {
+                                if let migrationUIHandler {
+                                    migrationUIHandler.showMigrationError(error) {
+                                        continuation.resume(returning: ())
+                                    }
+                                } else {
                                     continuation.resume(returning: ())
                                 }
-                            } else {
-                                continuation.resume(returning: ())
                             }
                         }
                     }

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -208,9 +208,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             tunnelSettingsUpdater: tunnelSettingsUpdater
         )
         addApplicationNotifications(application: application)
-        Task {
-            await startInitialization(application: application)
-        }
+        startInitialization(application: application)
 
         // Pre-warm @Observable infrastructure for LocationNode to avoid first-render lag
         // in SelectLocationView. SwiftUI's observation system has initialization overhead
@@ -516,15 +514,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         UNUserNotificationCenter.current().delegate = self
     }
 
-    private func startInitialization(application: UIApplication) async {
+    private func startInitialization(application: UIApplication) {
         // the new structured code: things here run first, before we run the legacy operations.
         // in the fullness of time, this section will grow and the latter will shrink to nothing
-        
-        // next: make a TaskGroup containing this and wipeSettings, and await that in one go
-        
-        await doLoadTunnelStore()
-        doWipeSettingsIfNeeded()
-        await doGetDefaultLocation()
+        Task {
+            doWipeSettingsIfNeeded()
+            async let loadTunnelStore = doLoadTunnelStore()
+            async let getDefaultLocation = doGetDefaultLocation()
+            await [loadTunnelStore, getDefaultLocation]
+            await MainActor.run {
+                
+            }
+        }
         
         // legacy concurrency code follows. We comment out the operations that have been converted.
         

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -566,6 +566,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
                         case let .failure(error):
                             logger.error("Failed migration from UI Process: \(error)")
+                            // SAFETY NOTE: We can assume this to be running on the same thread that
+                            // `MigrationManager.migrateSettings` was called from, as the callback is
+                            // called through `NSFileCoordinator`, which runs synchronously on one thread
+                            // and is used for locking between processes using the filesystem.
                             MainActor.assumeIsolated {
                                 let migrationUIHandler =
                                     application.connectedScenes

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -530,6 +530,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             async let initTunnelManager: () = doInitTunnelManager()
             async let resolveDeprecatedSettings: () = doResolveDeprecatedSettings()
             _ = await [initTunnelManager, resolveDeprecatedSettings]
+            await self.storePaymentManager.start()
         }
     }
 
@@ -598,13 +599,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
                 NotificationManager.shared.updateNotifications()
 
-                Task {
-                    await self.storePaymentManager.start()
-                    continuation.resume(returning: ())
-                }
+                continuation.resume(returning: ())
             }
         }
-
     }
 
     /// 1. If the app has never been launched, preload with default settings.

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -523,8 +523,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             doWipeSettingsIfNeeded()
             async let loadTunnelStore: () = doLoadTunnelStore()
             async let getDefaultLocation: () = doGetDefaultLocation()
-            // just doing `await [doLoadTunnelStore(), doGetDefaultLocation()]` would have
-            // executed these sequentially for some reason
             _ = await [loadTunnelStore, getDefaultLocation]
             await doMigrateSettings(application: application)
             await doResolveDeprecatedSettings()

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -551,40 +551,34 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         // it consumes any error states produced in the process
         await withCheckedContinuation { continuation in
             DispatchQueue.main.async {
-                MainActor.assumeIsolated {
-                    self.migrationManager
-                        .migrateSettings(store: self.settingsManager.store) { [self] migrationResult in
-                            switch migrationResult {
-                            case .success:
-                                // Tell the tunnel to re-read tunnel configuration after migration.
-                                logger.debug("Successful migration from UI Process")
-                                tunnelManager.reconnectTunnel(selectNewRelay: true)
-                                fallthrough
+                self.migrationManager
+                    .migrateSettings(store: self.settingsManager.store) { [self] migrationResult in
+                        switch migrationResult {
+                        case .success:
+                            // Tell the tunnel to re-read tunnel configuration after migration.
+                            logger.debug("Successful migration from UI Process")
+                            tunnelManager.reconnectTunnel(selectNewRelay: true)
+                            fallthrough
 
-                            case .nothing:
-                                logger.debug("Attempted migration from UI Process, but found nothing to do")
-                                continuation.resume(returning: ())
+                        case .nothing:
+                            logger.debug("Attempted migration from UI Process, but found nothing to do")
+                            continuation.resume(returning: ())
 
-                            case let .failure(error):
-                                logger.error("Failed migration from UI Process: \(error)")
-                                MainActor.assumeIsolated {
-                                    let migrationUIHandler =
-                                        application.connectedScenes
-                                        .first { $0 is SettingsMigrationUIHandler } as? SettingsMigrationUIHandler
+                        case let .failure(error):
+                            logger.error("Failed migration from UI Process: \(error)")
+                            let migrationUIHandler =
+                                application.connectedScenes
+                                .first { $0 is SettingsMigrationUIHandler } as? SettingsMigrationUIHandler
 
-                                    if let migrationUIHandler {
-                                        migrationUIHandler.showMigrationError(error) {
-                                            MainActor.assumeIsolated {
-                                                continuation.resume(returning: ())
-                                            }
-                                        }
-                                    } else {
-                                        continuation.resume(returning: ())
-                                    }
+                            if let migrationUIHandler {
+                                migrationUIHandler.showMigrationError(error) {
+                                    continuation.resume(returning: ())
                                 }
+                            } else {
+                                continuation.resume(returning: ())
                             }
                         }
-                }
+                    }
             }
         }
     }
@@ -611,9 +605,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     /// (`SettingsManager.getShouldWipeSettings()`)
     /// If (1) is `false` and (2) is `true`, we know that the app has been freshly installed/reinstalled and is
     /// compatible, thus triggering a settings wipe.
-
-    /// this was an AsyncBlockOperation, though is not in itself asynchronous.(It can call `deleteDevice`, but does not await the result)
-    /// The reimplementation is entirely synchronous
     private func doWipeSettingsIfNeeded() {
         defer {
             settingsManager.setShouldWipeSettings()

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -522,43 +522,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             async let loadTunnelStore = doLoadTunnelStore()
             async let getDefaultLocation = doGetDefaultLocation()
             await [loadTunnelStore, getDefaultLocation]
-            await MainActor.run {
-                
-            }
+            await doMigrateSettings(application: application)
+            async let initTunnelManager = doInitTunnelManager()
+            async let resolveDeprecatedSettings = doResolveDeprecatedSettings()
+            await [initTunnelManager, resolveDeprecatedSettings]
         }
-        
-        // legacy concurrency code follows. We comment out the operations that have been converted.
-        
-//        let defaultLocationOperation = getDefaultLocationOperation()
-//        let loadTunnelStoreOperation = getLoadTunnelStoreOperation()
-        let initTunnelManagerOperation = getInitTunnelManagerOperation()
-        let deprecatedSettingsResolverOperation = getDeprecatedSettingsResolverOperation()
-
-        var operations: [Operation] = [
-//            defaultLocationOperation,
-//            loadTunnelStoreOperation,
-        ]
-
-        let wipeSettingsOperation = getWipeSettingsOperation()
-        let migrateSettingsOperation = getMigrateSettingsOperation(application: application)
-
-        // Dependencies
-//        defaultLocationOperation.addDependency(wipeSettingsOperation)
-//        migrateSettingsOperation.addDependencies([
-//            wipeSettingsOperation,
-//            loadTunnelStoreOperation,
-//        ])
-        deprecatedSettingsResolverOperation.addDependency(migrateSettingsOperation)
-        initTunnelManagerOperation.addDependency(migrateSettingsOperation)
-
-        operations.append(contentsOf: [
-            wipeSettingsOperation,
-            migrateSettingsOperation,
-            deprecatedSettingsResolverOperation,
-            initTunnelManagerOperation,
-        ])
-
-        operationQueue.addOperations(operations, waitUntilFinished: false)
     }
 
     private func getLoadTunnelStoreOperation() -> AsyncBlockOperation {
@@ -585,6 +553,50 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 error: error,
                 message: "Failed to load persistent tunnels."
             )
+        }
+    }
+    
+    private func doMigrateSettings(application: UIApplication) async {
+        // this triggers an operation that needs to be carried out on the main queue, as
+        // it uses NSFileCoordinator to maintain a lock shared between the app and extension
+        // it consumes any error states produced in the process
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                MainActor.assumeIsolated {
+                    self.migrationManager
+                        .migrateSettings(store: self.settingsManager.store) { [self] migrationResult in
+                            switch migrationResult {
+                            case .success:
+                                // Tell the tunnel to re-read tunnel configuration after migration.
+                                logger.debug("Successful migration from UI Process")
+                                tunnelManager.reconnectTunnel(selectNewRelay: true)
+                                fallthrough
+
+                            case .nothing:
+                                logger.debug("Attempted migration from UI Process, but found nothing to do")
+                                continuation.resume(returning: ())
+
+                            case let .failure(error):
+                                logger.error("Failed migration from UI Process: \(error)")
+                                MainActor.assumeIsolated {
+                                    let migrationUIHandler =
+                                        application.connectedScenes
+                                        .first { $0 is SettingsMigrationUIHandler } as? SettingsMigrationUIHandler
+
+                                    if let migrationUIHandler {
+                                        migrationUIHandler.showMigrationError(error) {
+                                            MainActor.assumeIsolated {
+                                                continuation.resume(returning: ())
+                                            }
+                                        }
+                                    } else {
+                                        continuation.resume(returning: ())
+                                    }
+                                }
+                            }
+                        }
+                }
+            }
         }
     }
 
@@ -650,6 +662,25 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 }
             }
         }
+    }
+    
+    private func doInitTunnelManager() async {
+        // This operation is always treated as successful no matter what the configuration load yields.
+        // If the tunnel settings or device state can't be read, we simply pretend they are not there
+        // and leave user in logged out state. VPN config will be removed as well.
+        await withCheckedContinuation { continuation in
+            self.tunnelManager.loadConfiguration {
+                self.logger.debug("Finished initialization.")
+
+                NotificationManager.shared.updateNotifications()
+
+                Task {
+                    await self.storePaymentManager.start()
+                    continuation.resume(returning: ())
+                }
+            }
+        }
+
     }
 
     /// Returns an operation that acts on the following conditions:
@@ -795,6 +826,68 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             self.tunnelManager.updateSettings([
                 .relayConstraints(RelayConstraints(entryLocations: constraint, exitLocations: constraint))
             ])
+        }
+    }
+    
+    private func doResolveDeprecatedSettings() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async { [self] in
+                let resetVisibility: @Sendable () -> Void = {
+                    self.appPreferences.migratedSettingsState = MigratedSettingsState(
+                        preMigrationSettings: nil,
+                        lastInstalledVersion: Bundle.main.productVersion,
+                        lastMigratedVersion: MigratedVersion.current.rawValue,
+                        hasCompletedMigrationWizard: true,
+                        shouldShowMigratedSettingsMenuItem: false)
+                    self.migratedSettingsListener.onMigratedSettingsHandler?(.noChanges)
+                }
+                MainActor.assumeIsolated {
+                    let settingsResolver = DeprecatedSettingsResolver(
+                        cacheDirectory: containerURL,
+                        settingsManager: settingsManager,
+                        relaySelector: relaySelector,
+                        currentVersion: MigratedVersion(
+                            rawValue: appPreferences.migratedSettingsState.lastMigratedVersion)
+                            ?? MigratedVersion.current)
+
+                    let isAppUpdated =
+                        Bundle.main.productVersion != self.appPreferences.migratedSettingsState.lastInstalledVersion
+
+                    // Reset the migrated settings menu visibility after an app update.
+                    // The menu item should only remain visible within the same app version.
+                    appPreferences.migratedSettingsState.shouldShowMigratedSettingsMenuItem =
+                        !isAppUpdated && self.appPreferences.migratedSettingsState.shouldShowMigratedSettingsMenuItem
+
+                    settingsResolver.resolve(store: self.settingsManager.store) { [self] result in
+                        switch result {
+                        case let .migrated(old, new, changes):
+                            // Tell the tunnel to re-read tunnel configuration after migration.
+                            logger.debug("Successful resolving deprecated settings from UI Process")
+                            appPreferences.migratedSettingsState = MigratedSettingsState(
+                                preMigrationSettings: old,
+                                lastInstalledVersion: Bundle.main.productVersion,
+                                lastMigratedVersion: MigratedVersion.current.rawValue,
+                                hasCompletedMigrationWizard: changes.isEmpty,
+                                shouldShowMigratedSettingsMenuItem: !changes.isEmpty)
+                            migratedSettingsListener.onMigratedSettingsHandler?(
+                                changes.isEmpty ? .noChanges : .migrated)
+                            tunnelManager.updateSettings([.all(new)])
+                            continuation.resume(returning: ())
+
+                        case .nothing:
+                            logger.debug(
+                                "Attempted resolving deprecated settings from UI Process, but It's already up to date, so nothing to do"
+                            )
+                            migratedSettingsListener.onMigratedSettingsHandler?(.noChanges)
+                            continuation.resume(returning: ())
+                        case let .failure(error):
+                            logger.error("Failed resolving deprecated settings from UI Process: \(error)")
+                            resetVisibility()
+                            continuation.resume(returning: ())
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -521,7 +521,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         // in the fullness of time, this section will grow and the latter will shrink to nothing
         
         // next: make a TaskGroup containing this and wipeSettings, and await that in one go
-        `
+        
         await doLoadTunnelStore()
         doWipeSettingsIfNeeded()
         await doGetDefaultLocation()
@@ -700,14 +700,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
     
     private func doWipeSettingsIfNeeded() {
-        let appHasNeverBeenLaunched =
-            !self.appPreferences.hasDoneFirstTimeLaunch && !settingsManager.getShouldWipeSettings()
-        let appWasLaunchedAfterReinstall =
-            !self.appPreferences.hasDoneFirstTimeLaunch && settingsManager.getShouldWipeSettings()
+        defer {
+            settingsManager.setShouldWipeSettings()
+        }
+        if self.appPreferences.hasDoneFirstTimeLaunch { return }
 
-        if appHasNeverBeenLaunched {
+        if !settingsManager.getShouldWipeSettings() {
+            // the app has never been launched
             try? settingsManager.writeSettings(LatestTunnelSettings())
-        } else if appWasLaunchedAfterReinstall {
+        } else {
+            // the app has been launched after a reinstall
             if let deviceState = try? settingsManager.readDeviceState(),
                 let accountData = deviceState.accountData,
                 let deviceData = deviceState.deviceData
@@ -731,9 +733,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             // The overriden IPs will get wiped, therefore, the cache needs to be pruned as well.
             try? self.relayCacheTracker.refreshCachedRelays()
         }
-
-        settingsManager.setShouldWipeSettings()
-
     }
 
     private func getDefaultLocationOperation() -> AsyncBlockOperation {

--- a/ios/MullvadVPN/RelayCacheTracker/RelayCacheTracker.swift
+++ b/ios/MullvadVPN/RelayCacheTracker/RelayCacheTracker.swift
@@ -185,6 +185,22 @@ final class RelayCacheTracker: RelayCacheTrackerProtocol, @unchecked Sendable {
     {
         performUpdate(shouldThrottle: false, completionHandler: completionHandler)
     }
+    
+    func updateRelays() async throws -> RelaysFetchResult {
+        try await withCheckedThrowingContinuation { continuation in
+            _ = self.updateRelays { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+    
+    func fetchRelays() async throws -> RelaysFetchResult {
+        try await withCheckedThrowingContinuation { continuation in
+            _ = self.fetchRelays { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
 
     func getCachedRelays() throws -> CachedRelays {
         relayCacheLock.lock()

--- a/ios/MullvadVPN/RelayCacheTracker/RelayCacheTracker.swift
+++ b/ios/MullvadVPN/RelayCacheTracker/RelayCacheTracker.swift
@@ -185,7 +185,7 @@ final class RelayCacheTracker: RelayCacheTrackerProtocol, @unchecked Sendable {
     {
         performUpdate(shouldThrottle: false, completionHandler: completionHandler)
     }
-    
+
     func updateRelays() async throws -> RelaysFetchResult {
         try await withCheckedThrowingContinuation { continuation in
             _ = self.updateRelays { result in
@@ -193,7 +193,7 @@ final class RelayCacheTracker: RelayCacheTrackerProtocol, @unchecked Sendable {
             }
         }
     }
-    
+
     func fetchRelays() async throws -> RelaysFetchResult {
         try await withCheckedThrowingContinuation { continuation in
             _ = self.fetchRelays { result in

--- a/ios/MullvadVPN/RelayCacheTracker/RelayCacheTracker.swift
+++ b/ios/MullvadVPN/RelayCacheTracker/RelayCacheTracker.swift
@@ -186,6 +186,22 @@ final class RelayCacheTracker: RelayCacheTrackerProtocol, @unchecked Sendable {
         performUpdate(shouldThrottle: false, completionHandler: completionHandler)
     }
 
+    func updateRelays() async throws -> RelaysFetchResult {
+        try await withCheckedThrowingContinuation { continuation in
+            _ = self.updateRelays { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+
+    func fetchRelays() async throws -> RelaysFetchResult {
+        try await withCheckedThrowingContinuation { continuation in
+            _ = self.fetchRelays { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+
     func getCachedRelays() throws -> CachedRelays {
         relayCacheLock.lock()
         defer { relayCacheLock.unlock() }

--- a/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProviderManager.swift
+++ b/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProviderManager.swift
@@ -115,6 +115,14 @@
 
             completionHandler(tunnelProviders, nil)
         }
+        
+        static func loadAllFromPreferences() async throws -> [SimulatorTunnelProviderManager] {
+            // locking does not work in async contexts
+            tunnels.map { tunnelInfo in
+                SimulatorTunnelProviderManager(tunnelInfo: tunnelInfo)
+            }
+
+        }
 
         override required init() {
             tunnelInfo = SimulatorTunnelInfo()

--- a/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProviderManager.swift
+++ b/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProviderManager.swift
@@ -115,7 +115,7 @@
 
             completionHandler(tunnelProviders, nil)
         }
-        
+
         static func loadAllFromPreferences() async throws -> [SimulatorTunnelProviderManager] {
             // locking does not work in async contexts
             tunnels.map { tunnelInfo in

--- a/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProviderManager.swift
+++ b/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProviderManager.swift
@@ -116,6 +116,13 @@
             completionHandler(tunnelProviders, nil)
         }
 
+        static func loadAllFromPreferences() async throws -> [SimulatorTunnelProviderManager] {
+            tunnels.map { tunnelInfo in
+                SimulatorTunnelProviderManager(tunnelInfo: tunnelInfo)
+            }
+
+        }
+
         override required init() {
             tunnelInfo = SimulatorTunnelInfo()
             super.init()

--- a/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProviderManager.swift
+++ b/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProviderManager.swift
@@ -117,7 +117,6 @@
         }
 
         static func loadAllFromPreferences() async throws -> [SimulatorTunnelProviderManager] {
-            // locking does not work in async contexts
             tunnels.map { tunnelInfo in
                 SimulatorTunnelProviderManager(tunnelInfo: tunnelInfo)
             }

--- a/ios/MullvadVPN/TunnelManager/TunnelStore.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelStore.swift
@@ -50,6 +50,29 @@ final class TunnelStore: TunnelStoreProtocol, TunnelStatusObserver, @unchecked S
 
         return persistentTunnels
     }
+    
+    private func setPersistentTunnelsFromManagers(_ managers: [NETunnelProviderManager]) {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+        
+        self.persistentTunnels.forEach { tunnel in
+            tunnel.removeObserver(self)
+        }
+        
+        self.persistentTunnels =
+            managers.map { manager in
+                let tunnel = Tunnel(tunnelProvider: manager, backgroundTaskProvider: self.application)
+                tunnel.addObserver(self)
+
+                self.logger.debug(
+                    "Loaded persistent tunnel: \(tunnel.logFormat()) with status: \(tunnel.status)."
+                )
+
+                return tunnel
+            }
+    }
 
     func loadPersistentTunnels(completion: @escaping @Sendable (Error?) -> Void) {
         TunnelProviderManagerType.loadAllFromPreferences { managers, error in
@@ -61,23 +84,15 @@ final class TunnelStore: TunnelStoreProtocol, TunnelStatusObserver, @unchecked S
             }
 
             guard error == nil else { return }
-
-            self.persistentTunnels.forEach { tunnel in
-                tunnel.removeObserver(self)
-            }
-
-            self.persistentTunnels =
-                managers?.map { manager in
-                    let tunnel = Tunnel(tunnelProvider: manager, backgroundTaskProvider: self.application)
-                    tunnel.addObserver(self)
-
-                    self.logger.debug(
-                        "Loaded persistent tunnel: \(tunnel.logFormat()) with status: \(tunnel.status)."
-                    )
-
-                    return tunnel
-                } ?? []
+            
+            self.setPersistentTunnelsFromManagers(managers ?? [])
         }
+    }
+    
+    // the above function rewritten to be async
+    func loadPersistentTunnels() async throws {
+        let managers = try await TunnelProviderManagerType.loadAllFromPreferences()
+        self.setPersistentTunnelsFromManagers(managers)
     }
 
     func createNewTunnel() -> TunnelType {

--- a/ios/MullvadVPN/TunnelManager/TunnelStore.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelStore.swift
@@ -51,7 +51,7 @@ final class TunnelStore: TunnelStoreProtocol, TunnelStatusObserver, @unchecked S
         return persistentTunnels
     }
     
-    private func setPersistentTunnelsFromManagers(_ managers: [NETunnelProviderManager]) {
+    private func setPersistentTunnelsFromManagers(_ managers: [TunnelProviderManagerType]) {
         self.lock.lock()
         defer {
             self.lock.unlock()

--- a/ios/MullvadVPN/TunnelManager/TunnelStore.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelStore.swift
@@ -50,17 +50,17 @@ final class TunnelStore: TunnelStoreProtocol, TunnelStatusObserver, @unchecked S
 
         return persistentTunnels
     }
-    
+
     private func setPersistentTunnelsFromManagers(_ managers: [TunnelProviderManagerType]) {
         self.lock.lock()
         defer {
             self.lock.unlock()
         }
-        
+
         self.persistentTunnels.forEach { tunnel in
             tunnel.removeObserver(self)
         }
-        
+
         self.persistentTunnels =
             managers.map { manager in
                 let tunnel = Tunnel(tunnelProvider: manager, backgroundTaskProvider: self.application)
@@ -84,11 +84,11 @@ final class TunnelStore: TunnelStoreProtocol, TunnelStatusObserver, @unchecked S
             }
 
             guard error == nil else { return }
-            
+
             self.setPersistentTunnelsFromManagers(managers ?? [])
         }
     }
-    
+
     // the above function rewritten to be async
     func loadPersistentTunnels() async throws {
         let managers = try await TunnelProviderManagerType.loadAllFromPreferences()

--- a/ios/MullvadVPN/TunnelManager/TunnelStore.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelStore.swift
@@ -74,22 +74,6 @@ final class TunnelStore: TunnelStoreProtocol, TunnelStatusObserver, @unchecked S
             }
     }
 
-    func loadPersistentTunnels(completion: @escaping @Sendable (Error?) -> Void) {
-        TunnelProviderManagerType.loadAllFromPreferences { managers, error in
-            self.lock.lock()
-            defer {
-                self.lock.unlock()
-
-                completion(error)
-            }
-
-            guard error == nil else { return }
-
-            self.setPersistentTunnelsFromManagers(managers ?? [])
-        }
-    }
-
-    // the above function rewritten to be async
     func loadPersistentTunnels() async throws {
         let managers = try await TunnelProviderManagerType.loadAllFromPreferences()
         self.setPersistentTunnelsFromManagers(managers)

--- a/ios/MullvadVPN/TunnelManager/TunnelStore.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelStore.swift
@@ -51,33 +51,32 @@ final class TunnelStore: TunnelStoreProtocol, TunnelStatusObserver, @unchecked S
         return persistentTunnels
     }
 
-    func loadPersistentTunnels(completion: @escaping @Sendable (Error?) -> Void) {
-        TunnelProviderManagerType.loadAllFromPreferences { managers, error in
-            self.lock.lock()
-            defer {
-                self.lock.unlock()
-
-                completion(error)
-            }
-
-            guard error == nil else { return }
-
-            self.persistentTunnels.forEach { tunnel in
-                tunnel.removeObserver(self)
-            }
-
-            self.persistentTunnels =
-                managers?.map { manager in
-                    let tunnel = Tunnel(tunnelProvider: manager, backgroundTaskProvider: self.application)
-                    tunnel.addObserver(self)
-
-                    self.logger.debug(
-                        "Loaded persistent tunnel: \(tunnel.logFormat()) with status: \(tunnel.status)."
-                    )
-
-                    return tunnel
-                } ?? []
+    private func setPersistentTunnelsFromManagers(_ managers: [TunnelProviderManagerType]) {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
         }
+
+        self.persistentTunnels.forEach { tunnel in
+            tunnel.removeObserver(self)
+        }
+
+        self.persistentTunnels =
+            managers.map { manager in
+                let tunnel = Tunnel(tunnelProvider: manager, backgroundTaskProvider: self.application)
+                tunnel.addObserver(self)
+
+                self.logger.debug(
+                    "Loaded persistent tunnel: \(tunnel.logFormat()) with status: \(tunnel.status)."
+                )
+
+                return tunnel
+            }
+    }
+
+    func loadPersistentTunnels() async throws {
+        let managers = try await TunnelProviderManagerType.loadAllFromPreferences()
+        self.setPersistentTunnelsFromManagers(managers)
     }
 
     func createNewTunnel() -> TunnelType {


### PR DESCRIPTION
This replaces the graph of tasks executed at app initialisation time, which were handled as `NSOperation`-based operations, with modern Swift asynchronous functions whose interdependency is established by the order in which they are `await`ed.  Additionally, some refactoring has been done: the wipe-settings task, which was never asynchronous, is performed synchronously at the start, and store manager initialisation is now its own thing rather than part of tunnel manager initialisation.

Note that two of the tasks invoke settings-modifying operations which can, depending on the phases of celestial objects and the whim of the gods, be started from either the app or the packet tunnel extension, and so use a FileCoordinator for locking, a pattern for which there is not currently an elegant modern-Swift solution. As such, these are fired off in an asynchronous operation on the main thread which does the relevant locking. It'll do in a screaming fit.

Another task (`doInitTunnelManager`) calls `tunnelManager.loadConfiguration`, which internally uses a `NSOperation`. Refactoring this is left to another task.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10852)
<!-- Reviewable:end -->
