### PR TITLE
Reset migrated settings visibility per app update ios

### DIFF
--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -738,7 +738,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                     // Reset the migrated settings menu visibility after an app update.
                     // The menu item should only remain visible within the same app version.
                     appPreferences.migratedSettingsState.shouldShowMigratedSettingsMenuItem =
-                        !isAppUpdated && self.appPreferences.migratedSettingsState.shouldShowMigratedSettingsMenuItem
+                        isAppUpdated
+                        ? false : self.appPreferences.migratedSettingsState.shouldShowMigratedSettingsMenuItem
+                    appPreferences.migratedSettingsState.hasCompletedMigrationWizard =
+                        isAppUpdated ? true : self.appPreferences.migratedSettingsState.hasCompletedMigrationWizard
 
                     settingsResolver.resolve(store: self.settingsManager.store) { [self] result in
                         switch result {


### PR DESCRIPTION
This PR resets a flag that slipped through the cracks during app upgrades.

**Reproduction steps:**

1. Install the app from **App Store**.
2. Change the settings to trigger the migrated settings for the next version. You can find the steps [here](https://www.figma.com/design/X0QJhxSUzCBQQBTLJ59oGi/Automatic-Multihop?node-id=6989-36046&t=6DLHc0OeCBUmqw6R-4)
3. Install any version from **TestFlight** that supports migrated settings.
4. Open the app. The yellow crumb should be visible.
5. While the yellow crumb is still visible, install the current build over the existing one.
6. Open the app again. The yellow crumb should be gone after the upgrade.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10855)
<!-- Reviewable:end -->
