### PR TITLE
Fix Accessibility for DAITA and IAN toggles

### DIFF
--- a/ios/MullvadVPN/Views/SegmentedListItem/SegmentedListItem.swift
+++ b/ios/MullvadVPN/Views/SegmentedListItem/SegmentedListItem.swift
@@ -25,7 +25,7 @@ struct SegmentedListItem<Leading: View>: View {
     /// A grouped content sub component. Adds sub items to the list. Typically used in multi-choice settings or expanded lists.
     let groupedContent: AnyView?
     var footer: MullvadInfoView?
-    var onSelect: (() -> Void)?
+    let onSelect: (() -> Void)?
 
     /// The optional `trailing`, `segment` and `groupedContent` view builders default to `EmptyView`, so callers
     /// only specify the slots they need. An omitted slot is detected via its `EmptyView` type and stored as `nil`
@@ -67,40 +67,46 @@ struct SegmentedListItem<Leading: View>: View {
 
     var body: some View {
         HStack(spacing: 2) {
+            let label = HStack(spacing: 8) {
+                leading()
+                Spacer()
+                trailing?.accessibilityIdentifier(self.accessibilityIdentifier)
+            }
+            .padding(.leading, 16)
+            .padding(.trailing, trailing == nil ? 16 : 0)
+            .background(Color.colorForIndentationLevel(level))
+            .sizeOfView {
+                segmentHeight = $0.height
+            }
+
             let button = Button {
                 withAnimation(.easeInOut(duration: 0.15)) {
                     onSelect?()
                 }
             } label: {
-                HStack(spacing: 8) {
-                    leading()
-                    Spacer()
-                    trailing
-                }
-                .padding(.leading, 16)
-                .padding(.trailing, trailing == nil ? 16 : 0)
-                .background(Color.colorForIndentationLevel(level))
-                .sizeOfView {
-                    segmentHeight = $0.height
-                }
+                label
             }
 
-            switch userInteraction {
-            case .enabled:
-                button
-                    .buttonStyle(PlainButtonStyle())
-                    .disabled(false)
-            case .enabledWithoutHighlight:
-                button
-                    .buttonStyle(StaticButtonStyle())
-                    .disabled(false)
-            case .inactive:
-                button
-                    .buttonStyle(InactiveButtonStyle())
-            case .disabled:
-                button
-                    .buttonStyle(PlainButtonStyle())
-                    .disabled(true)
+            if onSelect != nil {
+                switch userInteraction {
+                case .enabled:
+                    button
+                        .buttonStyle(PlainButtonStyle())
+                        .disabled(false)
+                case .enabledWithoutHighlight:
+                    button
+                        .buttonStyle(StaticButtonStyle())
+                        .disabled(false)
+                case .inactive:
+                    button
+                        .buttonStyle(InactiveButtonStyle())
+                case .disabled:
+                    button
+                        .buttonStyle(PlainButtonStyle())
+                        .disabled(true)
+                }
+            } else {
+                label
             }
 
             segment
@@ -111,9 +117,11 @@ struct SegmentedListItem<Leading: View>: View {
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityIdentifier(accessibilityIdentifier)
-        .accessibilityAction(named: Text("Select \(accessibilityLabel)")) {
-            withAnimation(.easeInOut(duration: 0.15)) {
-                onSelect?()
+        .if(onSelect != nil) {
+            $0.accessibilityAction(named: Text("Select \(accessibilityLabel)")) {
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    onSelect?()
+                }
             }
         }
         .clipShape(


### PR DESCRIPTION
It turned out that the problem was with SegmentedListItem's view hierarchy. This item by default made a `Button` view, within which it encased its contents, even when not provided with an `onSelect` action that would make the button useful. This interfered with accessibility if there was another button or toggle in the item (i.e., inside the unused button's label, and subordinate to this useless button).  This fix removes the Button unless there is an `onSelect` provided which makes it useful.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10860)
<!-- Reviewable:end -->
