### PR TITLE
Refactor `variant` and add  `color` prop to `Button` component

### DIFF
--- a/desktop/packages/mullvad-vpn/src/renderer/components/ExpiredAccountAddTime.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/ExpiredAccountAddTime.tsx
@@ -236,7 +236,7 @@ export function SetupFinished() {
                 </Button.Text>
                 <Button.Icon icon="external" />
               </Button>
-              <Button variant="success" onClick={finish}>
+              <Button color="success" onClick={finish}>
                 <Button.Text>
                   {
                     // TRANSLATORS: Button label for starting the app.

--- a/desktop/packages/mullvad-vpn/src/renderer/components/NotificationArea.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/NotificationArea.tsx
@@ -309,7 +309,7 @@ function NotificationActionWrapper({
       </Button.Text>
     </Button>
   ) : (
-    <Button variant="success" key="problem-report" onClick={goToProblemReport}>
+    <Button color="success" key="problem-report" onClick={goToProblemReport}>
       <Button.Text>
         {
           // TRANSLATORS: Button label to send a problem report.
@@ -327,8 +327,8 @@ function NotificationActionWrapper({
   ];
 
   if (action.troubleshoot?.buttons) {
-    const actionButtons = action.troubleshoot.buttons.map(({ variant, label, action }) => (
-      <Button key={label} variant={variant} onClick={action}>
+    const actionButtons = action.troubleshoot.buttons.map(({ color: variant, label, action }) => (
+      <Button key={label} color={variant} onClick={action}>
         <Button.Text>{label}</Button.Text>
       </Button>
     ));

--- a/desktop/packages/mullvad-vpn/src/renderer/components/ProxyForm.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/ProxyForm.tsx
@@ -170,7 +170,7 @@ export function ProxyFormButtons() {
   return (
     <Flex margin={{ horizontal: 'medium', top: 'large' }} justifyContent="space-between">
       {onDelete !== undefined ? (
-        <Button width="fit" variant="destructive" onClick={onDelete}>
+        <Button width="fit" color="destructive" onClick={onDelete}>
           <Button.Text>{messages.gettext('Delete')}</Button.Text>
         </Button>
       ) : (

--- a/desktop/packages/mullvad-vpn/src/renderer/components/RedeemVoucher.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/RedeemVoucher.tsx
@@ -212,7 +212,7 @@ export function RedeemVoucherSubmitButton() {
   const disabled = submitting || response?.type === 'success';
 
   return (
-    <Button variant="success" disabled={!valueValid || disabled} onClick={onSubmit}>
+    <Button color="success" disabled={!valueValid || disabled} onClick={onSubmit}>
       <Button.Text>
         {
           // TRANSLATORS: Button label for voucher redemption.
@@ -303,7 +303,7 @@ export function RedeemVoucherButton(props: RedeemVoucherButtonProps) {
 
   return (
     <>
-      <Button variant="success" onClick={onClick} {...props}>
+      <Button color="success" onClick={onClick} {...props}>
         <Button.Text>
           {
             // TRANSLATORS: Button label for redeeming a voucher.

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/account/AccountView.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/account/AccountView.tsx
@@ -79,7 +79,7 @@ export function AccountView() {
 
             <FlexColumn gap="medium">
               <Button
-                variant="success"
+                color="success"
                 disabled={isOffline}
                 onClick={buyMore}
                 aria-description={messages.pgettext('accessibility', 'Opens externally')}>
@@ -89,7 +89,7 @@ export function AccountView() {
 
               <RedeemVoucherButton />
 
-              <Button variant="destructive" onClick={doLogout}>
+              <Button color="destructive" onClick={doLogout}>
                 <Button.Text>
                   {
                     // TRANSLATORS: Button label for logging out.

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/api-access/ApiAccessView.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/api-access/ApiAccessView.tsx
@@ -392,7 +392,7 @@ function ApiAccessMethod(props: ApiAccessMethodProps) {
           </StatusDialog.Text>
         )}
         <StatusDialog.ButtonGroup>
-          <StatusDialog.Button onClick={confirmRemove} variant="destructive">
+          <StatusDialog.Button onClick={confirmRemove} color="destructive">
             <StatusDialog.Button.Text>{messages.gettext('Delete')}</StatusDialog.Button.Text>
           </StatusDialog.Button>
           <StatusDialog.CloseButton>

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/debug/DebugView.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/debug/DebugView.tsx
@@ -42,7 +42,7 @@ function ThrowErrorButton() {
   }, []);
 
   return (
-    <Button variant="destructive" onClick={handleClick}>
+    <Button color="destructive" onClick={handleClick}>
       <Button.Text>Throw error</Button.Text>
     </Button>
   );
@@ -54,7 +54,7 @@ function UnhandledRejectionButton() {
   }, []);
 
   return (
-    <Button variant="destructive" onClick={handleClick}>
+    <Button color="destructive" onClick={handleClick}>
       <Button.Text>Unhandled rejection</Button.Text>
     </Button>
   );
@@ -68,7 +68,7 @@ function ErrorDuringRender() {
   }
 
   return (
-    <Button variant="destructive" onClick={setError}>
+    <Button color="destructive" onClick={setError}>
       <Button.Text>Error next render</Button.Text>
     </Button>
   );

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/device-revoked/DeviceRevokedView.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/device-revoked/DeviceRevokedView.tsx
@@ -68,7 +68,7 @@ export function DeviceRevokedView() {
             </FlexColumn>
 
             <Button
-              variant={tunnelState.state === 'disconnected' ? 'primary' : 'destructive'}
+              variant={tunnelState.state === 'disconnected' ? 'neutral' : 'destructive'}
               onClick={leaveRevokedDevice}>
               <Button.Text>
                 {

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/device-revoked/DeviceRevokedView.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/device-revoked/DeviceRevokedView.tsx
@@ -68,7 +68,7 @@ export function DeviceRevokedView() {
             </FlexColumn>
 
             <Button
-              variant={tunnelState.state === 'disconnected' ? 'neutral' : 'destructive'}
+              color={tunnelState.state === 'disconnected' ? 'neutral' : 'destructive'}
               onClick={leaveRevokedDevice}>
               <Button.Text>
                 {

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/expired-account-error/ExpiredAccountErrorView.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/expired-account-error/ExpiredAccountErrorView.tsx
@@ -83,7 +83,7 @@ function ExpiredAccountErrorViewComponent() {
 
             <FlexColumn gap="medium">
               {recoveryAction === RecoveryAction.disconnect && (
-                <Button variant="destructive" disabled={disconnecting} onClick={disconnect}>
+                <Button color="destructive" disabled={disconnecting} onClick={disconnect}>
                   <Button.Text>
                     {
                       // TRANSLATORS: Button label for disconnecting from the VPN.
@@ -95,7 +95,7 @@ function ExpiredAccountErrorViewComponent() {
 
               <ExternalPaymentButton />
 
-              <Button variant="success" onClick={navigateToRedeemVoucher}>
+              <Button color="success" onClick={navigateToRedeemVoucher}>
                 <Button.Text>
                   {
                     // TRANSLATORS: Button label for navigating to the voucher redemption view.
@@ -205,7 +205,7 @@ function ExternalPaymentButton() {
 
   return (
     <Button
-      variant="success"
+      color="success"
       disabled={openingExternalPayment || recoveryAction === RecoveryAction.disconnect}
       onClick={openExternalPayment}
       aria-description={

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/filter/FilterView.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/filter/FilterView.tsx
@@ -44,7 +44,7 @@ function FilterViewImpl() {
               </View.Container>
             </NavigationScrollbars>
             <View.Container horizontalMargin="medium" padding={{ vertical: 'large' }}>
-              <Button variant="success" disabled={noSelectedProviders} onClick={handleApply}>
+              <Button color="success" disabled={noSelectedProviders} onClick={handleApply}>
                 <Button.Text>
                   {noSelectedProviders
                     ? messages.gettext('No matching servers found')

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/launch/components/troubleshooting-modal/TroubleshootingModal.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/launch/components/troubleshooting-modal/TroubleshootingModal.tsx
@@ -48,7 +48,7 @@ export function TroubleshootingModal({ open, onOpenChange }: TroubleshootingModa
         }
       </StatusDialog.Text>
       <StatusDialog.ButtonGroup>
-        <StatusDialog.Button onClick={openSendProblemReport} variant="success">
+        <StatusDialog.Button onClick={openSendProblemReport} color="success">
           <StatusDialog.Button.Text>
             {
               // TRANSLATORS: Button label for sending a problem report.

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/login/ClearAccountHistoryDialog.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/login/ClearAccountHistoryDialog.tsx
@@ -27,7 +27,7 @@ export default function ClearAccountHistoryDialog({ open, onOpenChange, onConfir
         }
       </StatusDialog.Text>
       <StatusDialog.ButtonGroup>
-        <StatusDialog.Button onClick={onConfirm} variant="destructive">
+        <StatusDialog.Button onClick={onConfirm} color="destructive">
           <StatusDialog.Button.Text>
             {
               // TRANSLATORS: Button label in confirmation dialog that confirms a remove action.

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/login/LoginView.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/login/LoginView.tsx
@@ -412,7 +412,7 @@ class Login extends React.Component<IProps, IState> {
               </StyledAccountInputGroup>
               <Button
                 type="submit"
-                variant="success"
+                color="success"
                 disabled={!allowLogin}
                 aria-label={
                   // TRANSLATORS: This is used by screenreaders to communicate the login button.
@@ -593,7 +593,7 @@ function BlockMessage() {
     <StyledBlockMessageContainer>
       <StyledBlockTitle>{messages.gettext('Blocking internet')}</StyledBlockTitle>
       <StyledBlockMessage>{message}</StyledBlockMessage>
-      <Button variant="destructive" onClick={unlock}>
+      <Button color="destructive" onClick={unlock}>
         <Button.Text>{buttonText}</Button.Text>
       </Button>
     </StyledBlockMessageContainer>

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/main/components/connection-panel/components/connect-button/ConnectButton.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/main/components/connection-panel/components/connect-button/ConnectButton.tsx
@@ -18,7 +18,7 @@ export function ConnectButton(props: ButtonProps) {
   }, [connectTunnel]);
 
   return (
-    <Button variant="success" onClick={onConnect} {...props}>
+    <Button color="success" onClick={onConnect} {...props}>
       <Button.Text>{messages.pgettext('tunnel-control', 'Connect')}</Button.Text>
     </Button>
   );

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/main/components/connection-panel/components/disconnect-button/DisconnectButton.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/main/components/connection-panel/components/disconnect-button/DisconnectButton.tsx
@@ -22,7 +22,7 @@ export function DisconnectButton() {
   const displayAsCancel = tunnelState !== 'connected';
 
   return (
-    <Button variant="destructive" onClick={onDisconnect}>
+    <Button color="destructive" onClick={onDisconnect}>
       <Button.Text>
         {displayAsCancel ? messages.gettext('Cancel') : messages.gettext('Disconnect')}
       </Button.Text>

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/problem-report/ProblemReportView.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/problem-report/ProblemReportView.tsx
@@ -192,7 +192,7 @@ function Form() {
           </Button.Text>
           <Button.Icon icon="external" />
         </Button>
-        <Button variant="success" disabled={!validate() || disableActions} onClick={onSend}>
+        <Button color="success" disabled={!validate() || disableActions} onClick={onSend}>
           <Button.Text>
             {
               // TRANSLATORS: Button label for sending the problem report.
@@ -278,7 +278,7 @@ function Failed() {
             }
           </Button.Text>
         </Button>
-        <Button variant="success" onClick={onSend}>
+        <Button color="success" onClick={onSend}>
           <Button.Text>
             {
               // TRANSLATORS: Button label for retrying problem report submission after a failure.
@@ -307,7 +307,7 @@ function NoEmailDialog() {
     <StatusDialog variant="warning" open={sendState === SendState.confirm}>
       <StatusDialog.Text>{message}</StatusDialog.Text>
       <StatusDialog.ButtonGroup>
-        <StatusDialog.Button onClick={onSend} variant="destructive">
+        <StatusDialog.Button onClick={onSend} color="destructive">
           <StatusDialog.Button.Text>
             {
               // TRANSLATORS: Button label for sending the problem report without an email address.
@@ -377,7 +377,7 @@ function OutdatedVersionWarningDialog() {
       <StatusDialog.Text>{message}</StatusDialog.Text>
       <StatusDialog.ButtonGroup>
         <StatusDialog.Button
-          variant="success"
+          color="success"
           disabled={disabled}
           onClick={upgradeAction}
           aria-description={messages.pgettext('accessibility', 'Opens externally')}>
@@ -389,7 +389,7 @@ function OutdatedVersionWarningDialog() {
           </StatusDialog.Button.Text>
           {isLinux && <StatusDialog.Button.Icon icon="external" />}
         </StatusDialog.Button>
-        <StatusDialog.CloseButton variant="destructive">
+        <StatusDialog.CloseButton color="destructive">
           <StatusDialog.CloseButton.Text>
             {
               // TRANSLATORS: Button label for continuing problem report submission with an outdated app version.

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/settings-import/SettingsImportView.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/settings-import/SettingsImportView.tsx
@@ -183,7 +183,7 @@ export function SettingsImportView() {
               </View.Container>
             </FlexColumn>
             <Button
-              variant="destructive"
+              color="destructive"
               onClick={handleClickClearAllOverrides}
               disabled={!activeOverrides}>
               <Button.Text>
@@ -204,7 +204,7 @@ export function SettingsImportView() {
                 )}
               </StatusDialog.Text>
               <StatusDialog.ButtonGroup>
-                <StatusDialog.Button onClick={confirmClear} variant="destructive">
+                <StatusDialog.Button onClick={confirmClear} color="destructive">
                   <StatusDialog.Button.Text>{messages.gettext('Clear')}</StatusDialog.Button.Text>
                 </StatusDialog.Button>
                 <StatusDialog.CloseButton>

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/settings/components/quit-button/QuitButton.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/settings/components/quit-button/QuitButton.tsx
@@ -14,7 +14,7 @@ export function QuitButton() {
   }, [quit]);
 
   return (
-    <Button variant="destructive" onClick={handleClick}>
+    <Button color="destructive" onClick={handleClick}>
       <Button.Text>
         {isConnected ? messages.gettext('Disconnect & quit') : messages.gettext('Quit')}
       </Button.Text>

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/too-many-devices/TooManyDevicesView.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/too-many-devices/TooManyDevicesView.tsx
@@ -71,7 +71,7 @@ export function TooManyDevicesView() {
 
             {devices !== undefined && (
               <View.Container flexDirection="column" horizontalMargin="medium" gap="medium">
-                <Button variant="success" onClick={continueLogin} disabled={continueButtonDisabled}>
+                <Button color="success" onClick={continueLogin} disabled={continueButtonDisabled}>
                   <Button.Text>
                     {
                       // TRANSLATORS: Button for continuing login process.

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/vpn-settings/components/custom-dns-settings/CustomDnsSettings.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/vpn-settings/components/custom-dns-settings/CustomDnsSettings.tsx
@@ -401,7 +401,7 @@ function ConfirmationDialog({ abort, confirm, open }: IConfirmationDialogProps) 
     <StatusDialog variant="caution" open={open} onOpenChange={handleOpenChange}>
       <StatusDialog.Text>{message}</StatusDialog.Text>
       <StatusDialog.ButtonGroup>
-        <StatusDialog.Button variant="destructive" onClick={confirm}>
+        <StatusDialog.Button color="destructive" onClick={confirm}>
           <StatusDialog.Button.Text>
             {
               // TRANSLATORS: Button label to add a private IP DNS server despite warning.

--- a/desktop/packages/mullvad-vpn/src/renderer/features/custom-lists/components/delete-custom-list-dialog/DeleteCustomListDialog.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/features/custom-lists/components/delete-custom-list-dialog/DeleteCustomListDialog.tsx
@@ -67,7 +67,7 @@ export function DeleteCustomListDialog({
             <Dialog.ButtonGroup>
               <Dialog.Button
                 key="save"
-                variant="destructive"
+                color="destructive"
                 onClick={handleConfirm}
                 disabled={loading || !open}>
                 <Dialog.Button.Text>{messages.gettext('Delete list')}</Dialog.Button.Text>

--- a/desktop/packages/mullvad-vpn/src/renderer/features/locations/components/disable-recents-dialog/DisableRecentsDialog.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/features/locations/components/disable-recents-dialog/DisableRecentsDialog.tsx
@@ -24,7 +24,7 @@ export function DisableRecentsDialog({ onOpenChange, ...props }: DisableRecentsD
         {messages.pgettext('locations-feature', 'Disabling recents will also clear history.')}
       </StatusDialog.Text>
       <StatusDialog.ButtonGroup>
-        <StatusDialog.Button variant="destructive" onClick={disableRecents}>
+        <StatusDialog.Button color="destructive" onClick={disableRecents}>
           <StatusDialog.Button.Text>{messages.gettext('Disable')}</StatusDialog.Button.Text>
         </StatusDialog.Button>
         <StatusDialog.Button key="cancel" onClick={handleCancel}>

--- a/desktop/packages/mullvad-vpn/src/renderer/features/tunnel/components/lockdown-mode-switch/LockdownModeSwitch.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/features/tunnel/components/lockdown-mode-switch/LockdownModeSwitch.tsx
@@ -47,7 +47,7 @@ function LockdownModeSwitch({ children, ...props }: LockdownModeSwitchProp) {
           )}
         </StatusDialog.Text>
         <StatusDialog.ButtonGroup>
-          <StatusDialog.Button variant="destructive" onClick={confirmLockdownMode}>
+          <StatusDialog.Button color="destructive" onClick={confirmLockdownMode}>
             <StatusDialog.Button.Text>{messages.gettext('Enable anyway')}</StatusDialog.Button.Text>
           </StatusDialog.Button>
           <StatusDialog.CloseButton>

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/button/Button.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/button/Button.tsx
@@ -6,15 +6,17 @@ import { TransientProps } from '../../types';
 import { ButtonProvider } from './ButtonContext';
 import { ButtonIcon, ButtonText, StyledButtonIcon, StyledButtonText } from './components';
 
+export type ButtonVariants = 'neutral' | 'success' | 'destructive';
+
 export type ButtonProps = React.ComponentPropsWithRef<'button'> & {
-  variant?: 'primary' | 'success' | 'destructive';
+  variant?: ButtonVariants;
   width?: 'fill' | 'fit';
 };
 
 const styles = {
   radius: Radius.radius4,
   variants: {
-    primary: {
+    neutral: {
       background: colors.blue,
       hover: colors.blue60,
       pressed: colors.blue40,
@@ -36,7 +38,7 @@ const styles = {
 };
 
 export const StyledButton = styled.button<TransientProps<Pick<ButtonProps, 'variant' | 'width'>>>`
-  ${({ $width = 'fill', $variant = 'primary' }) => {
+  ${({ $width = 'fill', $variant = 'neutral' }) => {
     const variant = styles.variants[$variant];
 
     return css`

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/button/Button.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/button/Button.tsx
@@ -7,29 +7,31 @@ import { ButtonProvider } from './ButtonContext';
 import { ButtonIcon, ButtonText, StyledButtonIcon, StyledButtonText } from './components';
 
 export type ButtonColors = 'neutral' | 'success' | 'destructive';
+export type ButtonVariants = 'primary' | 'secondary';
 
 export type ButtonProps = React.ComponentPropsWithRef<'button'> & {
   color?: ButtonColors;
+  variant?: ButtonVariants;
   width?: 'fill' | 'fit';
 };
 
 const styles = {
   radius: Radius.radius4,
-  colors: {
+  variants: {
     neutral: {
-      background: colors.blue,
+      color: colors.blue,
       hover: colors.blue60,
       pressed: colors.blue40,
       disabled: colors.blue40,
     },
     success: {
-      background: colors.green,
+      color: colors.green,
       hover: colors.green80,
       pressed: colors.green40,
       disabled: colors.green40,
     },
     destructive: {
-      background: colors.red,
+      color: colors.red,
       hover: colors.red80,
       pressed: colors.red40,
       disabled: colors.red40,
@@ -37,12 +39,15 @@ const styles = {
   },
 };
 
-export const StyledButton = styled.button<TransientProps<Pick<ButtonProps, 'color' | 'width'>>>`
-  ${({ $width = 'fill', $color = 'neutral' }) => {
-    const variant = styles.colors[$color];
+type StyledButtonProps = TransientProps<Required<Pick<ButtonProps, 'variant' | 'color' | 'width'>>>;
+
+export const StyledButton = styled.button<StyledButtonProps>`
+  ${({ $width, $color, $variant }) => {
+    const variant = styles.variants[$color];
+    const backgroundOrBorderColor = $variant === 'primary' ? 'background' : 'border-color';
 
     return css`
-      --background: ${variant.background};
+      --color: ${variant.color};
       --hover: ${variant.hover};
       --pressed: ${variant.pressed};
       --disabled: ${variant.disabled};
@@ -58,7 +63,19 @@ export const StyledButton = styled.button<TransientProps<Pick<ButtonProps, 'colo
       min-height: 32px;
       min-width: 60px;
       border-radius: var(--radius);
-      background: var(--background);
+
+      ${backgroundOrBorderColor}: var(--color);
+
+      // Add border if secondary appearance
+      ${() => {
+        if ($variant === 'secondary') {
+          return css`
+            border: 1px solid var(--color);
+            background: transparent;
+          `;
+        }
+        return null;
+      }}
 
       ${() => {
         if ($width === 'fill') {
@@ -75,21 +92,21 @@ export const StyledButton = styled.button<TransientProps<Pick<ButtonProps, 'colo
       }}
 
       @media (prefers-reduced-motion: no-preference) {
-        transition: background-color var(--transition-duration) ease;
+        transition: ${backgroundOrBorderColor} var(--transition-duration) ease;
       }
 
       &&:not(:disabled):hover {
         --transition-duration: 0s;
-        background: var(--hover);
+        ${backgroundOrBorderColor}: var(--hover);
       }
 
       &&:not(:disabled):active {
         --transition-duration: 0s;
-        background: var(--pressed);
+        ${backgroundOrBorderColor}: var(--pressed);
       }
 
       &:disabled {
-        background: var(--disabled);
+        ${backgroundOrBorderColor}: var(--disabled);
       }
 
       &:focus-visible {
@@ -127,10 +144,17 @@ export const StyledButton = styled.button<TransientProps<Pick<ButtonProps, 'colo
   }}
 `;
 
-function Button({ children, color, width, disabled = false, ...props }: ButtonProps) {
+function Button({
+  children,
+  disabled = false,
+  variant = 'primary',
+  color = 'neutral',
+  width = 'fill',
+  ...props
+}: ButtonProps) {
   return (
     <ButtonProvider disabled={disabled}>
-      <StyledButton disabled={disabled} $color={color} $width={width} {...props}>
+      <StyledButton disabled={disabled} $variant={variant} $color={color} $width={width} {...props}>
         {children}
       </StyledButton>
     </ButtonProvider>

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/button/Button.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/button/Button.tsx
@@ -6,16 +6,16 @@ import { TransientProps } from '../../types';
 import { ButtonProvider } from './ButtonContext';
 import { ButtonIcon, ButtonText, StyledButtonIcon, StyledButtonText } from './components';
 
-export type ButtonVariants = 'neutral' | 'success' | 'destructive';
+export type ButtonColors = 'neutral' | 'success' | 'destructive';
 
 export type ButtonProps = React.ComponentPropsWithRef<'button'> & {
-  variant?: ButtonVariants;
+  color?: ButtonColors;
   width?: 'fill' | 'fit';
 };
 
 const styles = {
   radius: Radius.radius4,
-  variants: {
+  colors: {
     neutral: {
       background: colors.blue,
       hover: colors.blue60,
@@ -37,9 +37,9 @@ const styles = {
   },
 };
 
-export const StyledButton = styled.button<TransientProps<Pick<ButtonProps, 'variant' | 'width'>>>`
-  ${({ $width = 'fill', $variant = 'neutral' }) => {
-    const variant = styles.variants[$variant];
+export const StyledButton = styled.button<TransientProps<Pick<ButtonProps, 'color' | 'width'>>>`
+  ${({ $width = 'fill', $color = 'neutral' }) => {
+    const variant = styles.colors[$color];
 
     return css`
       --background: ${variant.background};
@@ -127,10 +127,10 @@ export const StyledButton = styled.button<TransientProps<Pick<ButtonProps, 'vari
   }}
 `;
 
-function Button({ children, variant, width, disabled = false, ...props }: ButtonProps) {
+function Button({ children, color, width, disabled = false, ...props }: ButtonProps) {
   return (
     <ButtonProvider disabled={disabled}>
-      <StyledButton disabled={disabled} $variant={variant} $width={width} {...props}>
+      <StyledButton disabled={disabled} $color={color} $width={width} {...props}>
         {children}
       </StyledButton>
     </ButtonProvider>

--- a/desktop/packages/mullvad-vpn/src/shared/notifications/error.tsx
+++ b/desktop/packages/mullvad-vpn/src/shared/notifications/error.tsx
@@ -302,12 +302,12 @@ export class ErrorNotificationProvider
           {
             label: messages.pgettext('troubleshoot', 'Open system settings'),
             action: () => this.context.showFullDiskAccessSettings?.(),
-            variant: 'success',
+            color: 'success',
           },
           {
             label: messages.pgettext('troubleshoot', 'Disable split tunneling'),
             action: () => this.context.disableSplitTunneling?.(),
-            variant: 'destructive',
+            color: 'destructive',
           },
         ];
       }

--- a/desktop/packages/mullvad-vpn/src/shared/notifications/notification.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/notifications/notification.ts
@@ -1,6 +1,6 @@
 import { ExternalLinkProps } from '../../renderer/components/ExternalLink';
 import { InternalLinkProps } from '../../renderer/components/InternalLink';
-import { ButtonProps } from '../../renderer/lib/components';
+import { ButtonProps, type ButtonVariants } from '../../renderer/lib/components';
 import { RoutePath } from '../../shared/routes';
 import { Url } from '../constants';
 
@@ -30,7 +30,7 @@ export interface InAppNotificationTroubleshootInfo {
 export interface InAppNotificationTroubleshootButton {
   label: string;
   action: () => void;
-  variant?: 'primary' | 'success' | 'destructive';
+  variant?: ButtonVariants;
 }
 
 export type InAppNotificationAction =

--- a/desktop/packages/mullvad-vpn/src/shared/notifications/notification.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/notifications/notification.ts
@@ -1,6 +1,6 @@
 import { ExternalLinkProps } from '../../renderer/components/ExternalLink';
 import { InternalLinkProps } from '../../renderer/components/InternalLink';
-import { ButtonProps, type ButtonVariants } from '../../renderer/lib/components';
+import { type ButtonColors, ButtonProps } from '../../renderer/lib/components';
 import { RoutePath } from '../../shared/routes';
 import { Url } from '../constants';
 
@@ -30,7 +30,7 @@ export interface InAppNotificationTroubleshootInfo {
 export interface InAppNotificationTroubleshootButton {
   label: string;
   action: () => void;
-  variant?: ButtonVariants;
+  color?: ButtonColors;
 }
 
 export type InAppNotificationAction =


### PR DESCRIPTION
Renames current `variant` prop to `color` and adds a new prop called `variant` which changes whether the button has a solid or bordered look.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10865)
<!-- Reviewable:end -->
