### PR TITLE
Update UI E2E tests to handle Multihop tristate mode

### DIFF
--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/multihop-settings/multihop-settings.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/multihop-settings/multihop-settings.spec.ts
@@ -28,16 +28,34 @@ test.describe('Multihop settings', () => {
   });
 
   test.afterEach(async () => {
-    await routes.multihopSettings.setEnableMultihopSwitch(false);
-    const multihopSwitch = routes.multihopSettings.getEnableMultihopSwitch();
-
-    await expect(multihopSwitch).not.toBeChecked();
+    await routes.multihopSettings.selectMultihopMode('When needed');
   });
 
-  test('Should enable multihop when clicking switch', async () => {
-    await routes.multihopSettings.setEnableMultihopSwitch(true);
-    const multihopSwitch = routes.multihopSettings.getEnableMultihopSwitch();
+  test('Should have selected "When needed" multihop mode by default', async () => {
+    const multihopModeItem = routes.multihopSettings.getMultihopModeItem('When needed');
+    await expect(multihopModeItem).toHaveAttribute('aria-selected', 'true');
+  });
 
-    await expect(multihopSwitch).toBeChecked();
+  test('Should select "When needed" from non-default multihop mode', async () => {
+    const multihopModeItemNever = routes.multihopSettings.getMultihopModeItem('Never');
+    await multihopModeItemNever.click();
+    await expect(multihopModeItemNever).toHaveAttribute('aria-selected', 'true');
+
+    const multihopModeItemWhenNeeded = routes.multihopSettings.getMultihopModeItem('When needed');
+    await multihopModeItemWhenNeeded.click();
+    await expect(multihopModeItemWhenNeeded).toHaveAttribute('aria-selected', 'true');
+    await expect(multihopModeItemNever).toHaveAttribute('aria-selected', 'false');
+  });
+
+  test('Should select "Always" multihop mode', async () => {
+    const multihopModeItem = routes.multihopSettings.getMultihopModeItem('Always');
+    await multihopModeItem.click();
+    await expect(multihopModeItem).toHaveAttribute('aria-selected', 'true');
+  });
+
+  test('Should select "Never" multihop mode', async () => {
+    const multihopModeItem = routes.multihopSettings.getMultihopModeItem('Never');
+    await multihopModeItem.click();
+    await expect(multihopModeItem).toHaveAttribute('aria-selected', 'true');
   });
 });

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/tunnel-state.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/tunnel-state.spec.ts
@@ -171,11 +171,11 @@ test.describe('Tunnel state and settings', () => {
   });
 
   test('App should show multihop', async () => {
-    await exec('mullvad relay set multihop on');
+    await exec('mullvad relay set multihop always');
     await expectConnected(page);
     const relay = routes.main.getRelayHostname();
     await expect(relay).toHaveText(new RegExp('^' + escapeRegExp(`${HOSTNAME} via`), 'i'));
-    await exec('mullvad relay set multihop off');
+    await exec('mullvad relay set multihop auto');
     await page.getByText('Disconnect').click();
   });
 

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/multihop-settings/multihop-settings-route-object-model.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/multihop-settings/multihop-settings-route-object-model.ts
@@ -14,16 +14,16 @@ export class MultihopSettingsRouteObjectModel {
     this.selectors = createSelectors(page);
   }
 
-  getEnableMultihopSwitch() {
-    return this.selectors.enableMultihopSwitch();
+  getMultihopModeItems() {
+    return this.selectors.multihopModeItems();
   }
 
-  async setEnableMultihopSwitch(enable: boolean) {
-    const enableMultihopSwitch = this.selectors.enableMultihopSwitch();
-    const checked = await enableMultihopSwitch.isChecked();
+  getMultihopModeItem(label: string) {
+    return this.selectors.multihopModeItem(this.getMultihopModeItems(), label);
+  }
 
-    if ((enable && !checked) || (!enable && checked)) {
-      await enableMultihopSwitch.click();
-    }
+  async selectMultihopMode(label: string) {
+    const multihopModeItem = this.getMultihopModeItem(label);
+    await multihopModeItem.click();
   }
 }

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/multihop-settings/selectors.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/multihop-settings/selectors.ts
@@ -1,5 +1,12 @@
-import { Page } from 'playwright';
+import { Locator, Page } from 'playwright';
 
 export const createSelectors = (page: Page) => ({
-  enableMultihopSwitch: () => page.getByRole('switch', { name: 'Enable' }),
+  multihopModeItems: () =>
+    page.getByRole('listbox', {
+      name: 'Mode',
+    }),
+  multihopModeItem: (itemsLocator: Locator, name: string) =>
+    itemsLocator.getByRole('option', {
+      name,
+    }),
 });


### PR DESCRIPTION
This PR will:

- Update the "Multihop settings" E2E test to test the new Multihop tristate mode
- Update the "Tunnel state" E2E test to use the new Multihop tristate mode values

E2E test run: https://github.com/mullvad/mullvadvpn-app/actions/runs/31087639048
Only the tests which were previously failing were included in the run:
  - `test_multihop_ui`
  - `test_ui_tunnel_settings`
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10870)
<!-- Reviewable:end -->
