### PR TITLE
Hide filter pills on when needed multihop

### DIFF
--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationContext.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationContext.swift
@@ -13,6 +13,10 @@ struct LocationContext {
         selectedLocation is AutomaticLocationNode
     }
 
+    var isFilterOverridden: Bool {
+        isAutomaticLocation && filter.contains(where: { $0.isOverriddenByAutomaticLocation })
+    }
+
     init(
         recents: [LocationNode] = [],
         locations: [LocationNode] = [],

--- a/ios/MullvadVPN/View controllers/SelectLocation/Views/ActiveFilterView.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/Views/ActiveFilterView.swift
@@ -17,8 +17,8 @@ struct ActiveFilterView: View {
     }
     var body: some View {
         VStack(alignment: .leading, spacing: sortedFilters.isEmpty ? 8 : 16) {
-            ScrollView(.horizontal) {
-                if !activeFilter.isEmpty {
+            if !sortedFilters.isEmpty {
+                ScrollView(.horizontal) {
                     HStack {
                         ForEach(sortedFilters, id: \.hashValue) { filter in
                             Button {
@@ -51,9 +51,10 @@ struct ActiveFilterView: View {
                         }
                     }
                     .padding(.horizontal, 16)
+
                 }
+                .scrollIndicators(.never)
             }
-            .scrollIndicators(.never)
 
             if shouldShowAutomaticFilterOverrideNotice {
                 HStack(spacing: 4) {

--- a/ios/MullvadVPN/View controllers/SelectLocation/Views/MultihopWhenNeededInfoView.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/Views/MultihopWhenNeededInfoView.swift
@@ -41,6 +41,7 @@ struct MultihopWhenNeededInfoView<ViewModel: SelectLocationViewModel>: View {
                         })
                 ])
         )
+        .padding(.top, 24.0)
         .mullvadAlert(item: $multihopWarningAlert)
     }
 

--- a/ios/MullvadVPN/View controllers/SelectLocation/Views/SelectLocationView.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/Views/SelectLocationView.swift
@@ -256,12 +256,10 @@ struct SelectLocationView<ViewModel>: View where ViewModel: SelectLocationViewMo
 
     private func activeFilterView(locationContext: LocationContext, transition: AnyTransition) -> some View {
         ActiveFilterView(
-            activeFilter: locationContext.filter,
+            activeFilter: viewModel.visibleFilterChips,
             labelStyle: .general,
             automaticLocationIsActive: locationContext.isAutomaticLocation,
-            shouldShowAutomaticFilterOverrideNotice:
-                locationContext.isAutomaticLocation
-                && locationContext.filter.contains(where: { $0.isOverriddenByAutomaticLocation })
+            shouldShowAutomaticFilterOverrideNotice: locationContext.isFilterOverridden
         ) { filter in
             viewModel.onFilterTapped(filter)
         } onRemove: { filter in


### PR DESCRIPTION
This PR fixes a regression that caused the filter pills to be shown while the app was doing multihop for unsupported settings.

the below video is for before the regression, the app should correspond to it:

https://github.com/user-attachments/assets/245b1ca0-a014-48b2-a50c-6305038bb4cf

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10875)
<!-- Reviewable:end -->
