### PR TITLE
Android: sort location lists using locale-aware collation

### DIFF
--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -30,6 +30,9 @@ Line wrap the file at 100 chars.                                              Th
 - Route 10.124.0.0/23 inside the tunnel when Local network sharing is turned on. This is to enable
   the use SOCKS5 proxies on other relays together with Local network sharing.
 
+### Fixed
+- Fix relay list and custom lists not being sorted using locale-aware collation.
+
 
 ## [android/2026.8] - 2026-07-15
 ### Fixed

--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -30,6 +30,9 @@ Line wrap the file at 100 chars.                                              Th
 - Remove the initial privacy consent screen. The app now shows the Login Screen on first start.
   The privacy policy can still be reached from Settings.
 
+### Fixed
+- Fix relay list and custom lists not being sorted using locale-aware collation.
+
 
 ## [android/2026.9-beta2] - 2026-09-09
 ### Fixed

--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -31,7 +31,7 @@ Line wrap the file at 100 chars.                                              Th
   The privacy policy can still be reached from Settings.
 
 ### Fixed
-- Fix relay list and custom lists not being sorted using locale-aware collation.
+- Fix relay list and custom lists sorting by respecting locales.
 
 
 ## [android/2026.9-beta2] - 2026-09-09

--- a/android/lib/common/src/main/kotlin/net/mullvad/mullvadvpn/lib/common/util/relaylist/RelayListExtensions.kt
+++ b/android/lib/common/src/main/kotlin/net/mullvad/mullvadvpn/lib/common/util/relaylist/RelayListExtensions.kt
@@ -1,5 +1,6 @@
 package net.mullvad.mullvadvpn.lib.common.util.relaylist
 
+import java.text.Collator
 import net.mullvad.mullvadvpn.lib.model.GeoLocationId
 import net.mullvad.mullvadvpn.lib.model.RelayItem
 import net.mullvad.mullvadvpn.lib.model.RelayItemId
@@ -122,5 +123,6 @@ fun List<RelayItem.Location.Country>.getRelayItemsByCodes(
     this.filter { codes.contains(it.id) } +
         this.flatMap { it.descendants() }.filter { codes.contains(it.id) }
 
+// Sort using the default locale's collation rules rather than raw Unicode value comparison.
 fun <T : RelayItem> List<T>.sortedByName() =
-    this.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name })
+    this.sortedWith(compareBy(Collator.getInstance()) { it.name })

--- a/android/lib/common/src/main/kotlin/net/mullvad/mullvadvpn/lib/common/util/relaylist/RelayListExtensions.kt
+++ b/android/lib/common/src/main/kotlin/net/mullvad/mullvadvpn/lib/common/util/relaylist/RelayListExtensions.kt
@@ -1,5 +1,6 @@
 package net.mullvad.mullvadvpn.lib.common.util.relaylist
 
+import java.text.Collator
 import net.mullvad.mullvadvpn.lib.model.GeoLocationId
 import net.mullvad.mullvadvpn.lib.model.RelayItem
 
@@ -50,5 +51,6 @@ fun List<RelayItem.Location.Country>.getRelayItemsByCodes(
     this.filter { codes.contains(it.id) } +
         this.flatMap { it.descendants() }.filter { codes.contains(it.id) }
 
+// Sort using the default locale's collation rules rather than raw Unicode value comparison.
 fun <T : RelayItem> List<T>.sortedByName() =
-    this.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name })
+    this.sortedWith(compareBy(Collator.getInstance()) { it.name })

--- a/android/lib/common/src/main/kotlin/net/mullvad/mullvadvpn/lib/common/util/relaylist/RelayListExtensions.kt
+++ b/android/lib/common/src/main/kotlin/net/mullvad/mullvadvpn/lib/common/util/relaylist/RelayListExtensions.kt
@@ -123,6 +123,5 @@ fun List<RelayItem.Location.Country>.getRelayItemsByCodes(
     this.filter { codes.contains(it.id) } +
         this.flatMap { it.descendants() }.filter { codes.contains(it.id) }
 
-// Sort using the default locale's collation rules rather than raw Unicode value comparison.
 fun <T : RelayItem> List<T>.sortedByName() =
     this.sortedWith(compareBy(Collator.getInstance()) { it.name })

--- a/android/lib/common/src/main/kotlin/net/mullvad/mullvadvpn/lib/common/util/relaylist/RelayListExtensions.kt
+++ b/android/lib/common/src/main/kotlin/net/mullvad/mullvadvpn/lib/common/util/relaylist/RelayListExtensions.kt
@@ -1,6 +1,6 @@
 package net.mullvad.mullvadvpn.lib.common.util.relaylist
 
-import java.text.Collator
+import android.icu.text.Collator
 import net.mullvad.mullvadvpn.lib.model.GeoLocationId
 import net.mullvad.mullvadvpn.lib.model.RelayItem
 import net.mullvad.mullvadvpn.lib.model.RelayItemId

--- a/android/lib/repository/src/main/kotlin/net/mullvad/mullvadvpn/lib/repository/CustomListsRepository.kt
+++ b/android/lib/repository/src/main/kotlin/net/mullvad/mullvadvpn/lib/repository/CustomListsRepository.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.raise.ensureNotNull
 import co.touchlab.kermit.Logger
+import java.text.Collator
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -76,6 +77,7 @@ class CustomListsRepository(
         }
     }
 
+    // Sort using the default locale's collation rules rather than raw Unicode value comparison.
     private fun List<CustomList>.sortedByName() =
-        this.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name.value })
+        this.sortedWith(compareBy(Collator.getInstance()) { it.name.value })
 }

--- a/android/lib/repository/src/main/kotlin/net/mullvad/mullvadvpn/lib/repository/CustomListsRepository.kt
+++ b/android/lib/repository/src/main/kotlin/net/mullvad/mullvadvpn/lib/repository/CustomListsRepository.kt
@@ -77,7 +77,6 @@ class CustomListsRepository(
         }
     }
 
-    // Sort using the default locale's collation rules rather than raw Unicode value comparison.
     private fun List<CustomList>.sortedByName() =
         this.sortedWith(compareBy(Collator.getInstance()) { it.name.value })
 }

--- a/android/lib/repository/src/main/kotlin/net/mullvad/mullvadvpn/lib/repository/CustomListsRepository.kt
+++ b/android/lib/repository/src/main/kotlin/net/mullvad/mullvadvpn/lib/repository/CustomListsRepository.kt
@@ -4,7 +4,7 @@ import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.raise.ensureNotNull
 import co.touchlab.kermit.Logger
-import java.text.Collator
+import android.icu.text.Collator
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers

--- a/android/lib/repository/src/main/kotlin/net/mullvad/mullvadvpn/lib/repository/CustomListsRepository.kt
+++ b/android/lib/repository/src/main/kotlin/net/mullvad/mullvadvpn/lib/repository/CustomListsRepository.kt
@@ -1,10 +1,10 @@
 package net.mullvad.mullvadvpn.lib.repository
 
+import android.icu.text.Collator
 import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.raise.ensureNotNull
 import co.touchlab.kermit.Logger
-import android.icu.text.Collator
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers

--- a/android/lib/repository/src/test/kotlin/net/mullvad/mullvadvpn/lib/repository/CustomListsRepositoryTest.kt
+++ b/android/lib/repository/src/test/kotlin/net/mullvad/mullvadvpn/lib/repository/CustomListsRepositoryTest.kt
@@ -7,6 +7,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import java.util.Locale
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -20,6 +21,7 @@ import net.mullvad.mullvadvpn.lib.model.GeoLocationId
 import net.mullvad.mullvadvpn.lib.model.GetCustomListError
 import net.mullvad.mullvadvpn.lib.model.NameAlreadyExists
 import net.mullvad.mullvadvpn.lib.model.Settings
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -28,11 +30,13 @@ import org.junit.jupiter.api.Test
 class CustomListsRepositoryTest {
     private val mockManagementService: ManagementService = mockk()
     private lateinit var customListsRepository: CustomListsRepository
+    private lateinit var defaultLocale: Locale
 
     private val settingsFlow: MutableStateFlow<Settings> = MutableStateFlow(mockk(relaxed = true))
 
     @BeforeEach
     fun setup() {
+        defaultLocale = Locale.getDefault()
         mockkStatic(RELAY_LIST_EXTENSIONS)
         every { mockManagementService.settings } returns settingsFlow
         customListsRepository =
@@ -40,6 +44,11 @@ class CustomListsRepositoryTest {
                 managementService = mockManagementService,
                 dispatcher = UnconfinedTestDispatcher(),
             )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Locale.setDefault(defaultLocale)
     }
 
     @Test
@@ -261,6 +270,45 @@ class CustomListsRepositoryTest {
             CustomList(
                 id = customListId3,
                 name = CustomListName.fromString("M List"),
+                locations = emptyList(),
+            )
+        val mockSettings: Settings = mockk()
+        every { mockSettings.customLists } returns listOf(customList1, customList2, customList3)
+        settingsFlow.value = mockSettings
+
+        // Act
+        val result = customListsRepository.customLists.value
+
+        // Assert
+        val expectedOrder = listOf(customList2, customList3, customList1)
+        assertEquals(expectedOrder, result)
+    }
+
+    @Test
+    fun `custom lists should be sorted using the locale's collation`() = runTest {
+        // Arrange
+        // 'Á' (U+00C1) outranks 'Z' (U+005A) by Unicode value, so comparing names by Unicode
+        // value would place "Ávila" after "Zurich".
+        Locale.setDefault(Locale.forLanguageTag("pt"))
+        val customListId1 = CustomListId("1")
+        val customListId2 = CustomListId("2")
+        val customListId3 = CustomListId("3")
+        val customList1 =
+            CustomList(
+                id = customListId1,
+                name = CustomListName.fromString("Zurich"),
+                locations = emptyList(),
+            )
+        val customList2 =
+            CustomList(
+                id = customListId2,
+                name = CustomListName.fromString("Ávila"),
+                locations = emptyList(),
+            )
+        val customList3 =
+            CustomList(
+                id = customListId3,
+                name = CustomListName.fromString("Berlin"),
                 locations = emptyList(),
             )
         val mockSettings: Settings = mockk()

--- a/android/lib/repository/src/test/kotlin/net/mullvad/mullvadvpn/lib/repository/RelayListRepositoryTest.kt
+++ b/android/lib/repository/src/test/kotlin/net/mullvad/mullvadvpn/lib/repository/RelayListRepositoryTest.kt
@@ -1,0 +1,109 @@
+package net.mullvad.mullvadvpn.lib.repository
+
+import app.cash.turbine.test
+import io.mockk.every
+import io.mockk.mockk
+import java.util.Locale
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import net.mullvad.mullvadvpn.lib.grpc.ManagementService
+import net.mullvad.mullvadvpn.lib.model.GeoLocationId
+import net.mullvad.mullvadvpn.lib.model.LatLong
+import net.mullvad.mullvadvpn.lib.model.RelayItem
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@ExperimentalCoroutinesApi
+class RelayListRepositoryTest {
+    private val mockManagementService: ManagementService = mockk()
+    private val mockTranslationRepository: RelayLocationTranslationRepository = mockk()
+
+    private lateinit var relayListRepository: RelayListRepository
+    private lateinit var defaultLocale: Locale
+
+    private val countriesFlow = MutableStateFlow<List<RelayItem.Location.Country>>(emptyList())
+    private val translationsFlow = MutableStateFlow<Translations>(emptyMap())
+
+    @BeforeEach
+    fun setup() {
+        defaultLocale = Locale.getDefault()
+        every { mockManagementService.relayCountries } returns countriesFlow
+        // Unused by these tests, but read by other RelayListRepository properties on construction.
+        every { mockManagementService.wireguardEndpointData } returns emptyFlow()
+        every { mockManagementService.settings } returns emptyFlow()
+        every { mockTranslationRepository.translations } returns translationsFlow
+        relayListRepository =
+            RelayListRepository(
+                managementService = mockManagementService,
+                translationRepository = mockTranslationRepository,
+                dispatcher = UnconfinedTestDispatcher(),
+            )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Locale.setDefault(defaultLocale)
+    }
+
+    @Test
+    fun `countries should be sorted using the locale's collation`() = runTest {
+        // Arrange
+        // 'Á' (U+00C1) outranks 'Z' (U+005A) by Unicode value, so comparing names by Unicode
+        // value would place the accented countries after "Zimbabwe".
+        Locale.setDefault(Locale.forLanguageTag("pt"))
+        val countries = listOf(country("Zimbabwe"), country("Áustria"), country("Albânia"))
+        countriesFlow.value = countries
+        translationsFlow.value = countries.identityTranslations()
+
+        // Act, Assert
+        relayListRepository.relayList.test {
+            assertEquals(listOf("Albânia", "Áustria", "Zimbabwe"), awaitItem().map { it.name })
+        }
+    }
+
+    @Test
+    fun `cities should be sorted using the locale's collation`() = runTest {
+        // Arrange
+        Locale.setDefault(Locale.forLanguageTag("pt"))
+        val countries = listOf(country("Espanha", listOf("Zaragoza", "Ávila", "Barcelona")))
+        countriesFlow.value = countries
+        translationsFlow.value = countries.identityTranslations()
+
+        // Act, Assert
+        relayListRepository.relayList.test {
+            assertEquals(
+                listOf("Ávila", "Barcelona", "Zaragoza"),
+                awaitItem().single().cities.map { it.name },
+            )
+        }
+    }
+
+    private fun country(name: String, cityNames: List<String> = emptyList()) =
+        RelayItem.Location.Country(
+            id = GeoLocationId.Country(name),
+            name = name,
+            cities = cityNames.map { city(it, countryName = name) },
+        )
+
+    private fun city(name: String, countryName: String) =
+        RelayItem.Location.City(
+            id = GeoLocationId.City(GeoLocationId.Country(countryName), name),
+            name = name,
+            latLong = LatLong(0f, 0f),
+            relays = emptyList(),
+            countryName = countryName,
+        )
+
+    // Relays are only sorted once their names have been translated, so map every name to itself to
+    // keep the names unchanged while still exercising the translated-and-sorted path.
+    private fun List<RelayItem.Location.Country>.identityTranslations(): Translations =
+        flatMap { country ->
+            listOf(country.name) + country.cities.map { it.name }
+        }
+        .associateWith { it }
+}

--- a/android/lib/repository/src/test/kotlin/net/mullvad/mullvadvpn/lib/repository/RelayListRepositoryTest.kt
+++ b/android/lib/repository/src/test/kotlin/net/mullvad/mullvadvpn/lib/repository/RelayListRepositoryTest.kt
@@ -1,0 +1,107 @@
+package net.mullvad.mullvadvpn.lib.repository
+
+import app.cash.turbine.test
+import io.mockk.every
+import io.mockk.mockk
+import java.util.Locale
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import net.mullvad.mullvadvpn.lib.grpc.ManagementService
+import net.mullvad.mullvadvpn.lib.model.GeoLocationId
+import net.mullvad.mullvadvpn.lib.model.LatLong
+import net.mullvad.mullvadvpn.lib.model.RelayItem
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@ExperimentalCoroutinesApi
+class RelayListRepositoryTest {
+    private val mockManagementService: ManagementService = mockk()
+    private val mockTranslationRepository: RelayLocationTranslationRepository = mockk()
+
+    private lateinit var relayListRepository: RelayListRepository
+    private lateinit var defaultLocale: Locale
+
+    private val countriesFlow = MutableStateFlow<List<RelayItem.Location.Country>>(emptyList())
+    private val translationsFlow = MutableStateFlow<Translations>(emptyMap())
+
+    @BeforeEach
+    fun setup() {
+        defaultLocale = Locale.getDefault()
+        every { mockManagementService.relayCountries } returns countriesFlow
+        // Unused by these tests, but read by other RelayListRepository properties on construction.
+        every { mockManagementService.wireguardEndpointData } returns emptyFlow()
+        every { mockManagementService.settings } returns emptyFlow()
+        every { mockTranslationRepository.translations } returns translationsFlow
+        relayListRepository =
+            RelayListRepository(
+                managementService = mockManagementService,
+                translationRepository = mockTranslationRepository,
+                dispatcher = UnconfinedTestDispatcher(),
+            )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Locale.setDefault(defaultLocale)
+    }
+
+    @Test
+    fun `countries should be sorted using the locale's collation`() = runTest {
+        // Arrange
+        // 'Á' (U+00C1) outranks 'Z' (U+005A) by Unicode value, so comparing names by Unicode
+        // value would place the accented countries after "Zimbabwe".
+        Locale.setDefault(Locale.forLanguageTag("pt"))
+        val countries = listOf(country("Zimbabwe"), country("Áustria"), country("Albânia"))
+        countriesFlow.value = countries
+        translationsFlow.value = countries.identityTranslations()
+
+        // Act, Assert
+        relayListRepository.relayList.test {
+            assertEquals(listOf("Albânia", "Áustria", "Zimbabwe"), awaitItem().map { it.name })
+        }
+    }
+
+    @Test
+    fun `cities should be sorted using the locale's collation`() = runTest {
+        // Arrange
+        Locale.setDefault(Locale.forLanguageTag("pt"))
+        val countries = listOf(country("Espanha", listOf("Zaragoza", "Ávila", "Barcelona")))
+        countriesFlow.value = countries
+        translationsFlow.value = countries.identityTranslations()
+
+        // Act, Assert
+        relayListRepository.relayList.test {
+            assertEquals(
+                listOf("Ávila", "Barcelona", "Zaragoza"),
+                awaitItem().single().cities.map { it.name },
+            )
+        }
+    }
+
+    private fun country(name: String, cityNames: List<String> = emptyList()) =
+        RelayItem.Location.Country(
+            id = GeoLocationId.Country(name),
+            name = name,
+            cities = cityNames.map { city(it, countryName = name) },
+        )
+
+    private fun city(name: String, countryName: String) =
+        RelayItem.Location.City(
+            id = GeoLocationId.City(GeoLocationId.Country(countryName), name),
+            name = name,
+            latLong = LatLong(0f, 0f),
+            relays = emptyList(),
+            countryName = countryName,
+        )
+
+    // Relays are only sorted once their names have been translated, so map every name to itself to
+    // keep the names unchanged while still exercising the translated-and-sorted path.
+    private fun List<RelayItem.Location.Country>.identityTranslations(): Translations =
+        flatMap { country -> listOf(country.name) + country.cities.map { it.name } }
+            .associateWith { it }
+}


### PR DESCRIPTION
This is the Android counterpart to the iOS fix #10799: while reviewing that change, I realized that the relay list sorting on Android was also not locale-aware. The same went for the sorting of custom relay lists.

Both were sorted with `String.CASE_INSENSITIVE_ORDER`, which folds case but compares characters by their Unicode value. Concretely, translated location names (pt-PT) such as "Áustria" and "África do Sul" sorted after "Zimbabwe", since 'Á' (U+00C1) outranks 'Z' (U+005A).

Sort with a `java.text.Collator` instead. The desktop app already does this via `localeCompare`. The ordering is locale-specific by design: "Å" sorts among the A's in English but after "Z" in Swedish.

## Relay list before

Version 2026.8, European Portuguese locale.

<img width="300" alt="Screenshot_20260807-143610~2" src="https://github.com/user-attachments/assets/2ad4086e-c379-4563-bf7e-acb1b9e1c82f" />

## Relay list after

Commit 71f14129e0, same locale.

<img width="300" alt="Screenshot_20260807-145149~2" src="https://github.com/user-attachments/assets/17e0a8c4-0da4-4e38-b100-0532f3063cbd" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10878)
<!-- Reviewable:end -->
