### PR TITLE
Tolerate exited processes when clearing split tunneling cgroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ Line wrap the file at 100 chars.                                              Th
 - Fix infinite loop of account checks when account ran out of time.
 - Fix IPv6 obfuscation relay selection when the relay's WireGuard endpoint only has IPv4.
 
+#### Linux
+- Fix `mullvad split-tunnel clear` failing with "Error in split tunneling" when one of the excluded
+  processes had already exited.
+
 #### Windows
 - Preserve the app's own theme colors when Windows high contrast (forced-colors) mode is
   enabled in order to prevent toggle switches and other custom-styled controls from becoming

--- a/talpid-cgroup/src/lib.rs
+++ b/talpid-cgroup/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg(target_os = "linux")]
 use anyhow::{Context as _, anyhow};
+use nix::{libc::pid_t, unistd::Pid};
 use std::ffi::OsStr;
 use std::fs;
 use std::os::unix::ffi::OsStrExt;
@@ -18,8 +19,47 @@ pub const DEFAULT_NET_CLS_DIR: &str = "/sys/fs/cgroup/net_cls";
 
 /// Errors related to cgroups.
 #[derive(thiserror::Error, Debug)]
-#[error("CGroup error")]
-pub struct Error(#[from] anyhow::Error);
+pub enum Error {
+    /// The PID does not name a live process, so it cannot be moved between cgroups.
+    ///
+    /// Callers that are moving a process to a particular cgroup can usually treat this as
+    /// success, since a process that no longer exists is not in any cgroup.
+    #[error("No such process: {0}")]
+    NoSuchProcess(Pid),
+
+    /// Any other cgroup error.
+    #[error("CGroup error")]
+    Other(#[from] anyhow::Error),
+}
+
+/// Move `pids` into another cgroup by passing each of them to `add`.
+///
+/// PIDs that exit before they can be moved are ignored: a process that no longer exists is
+/// already out of the source cgroup, which is the state we are asked to produce. Any other
+/// failure is reported, but only after every remaining PID has been attempted — one failing PID
+/// must not strand the rest of them in the source cgroup.
+fn move_pids(pids: Vec<pid_t>, mut add: impl FnMut(Pid) -> Result<(), Error>) -> Result<(), Error> {
+    let mut last_error = None;
+
+    for pid in pids {
+        let pid = Pid::from_raw(pid);
+        match add(pid) {
+            Ok(()) => (),
+            Err(Error::NoSuchProcess(pid)) => {
+                log::debug!("Process {pid} exited before it could be moved out of the cgroup");
+            }
+            Err(error) => {
+                log::error!("Failed to move process {pid} out of the cgroup: {error:?}");
+                last_error = Some(error);
+            }
+        }
+    }
+
+    match last_error {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
+}
 
 /// Find the path of the cgroup v1 net_cls controller mount if it exists.
 ///
@@ -68,6 +108,102 @@ fn parse_mount_line(line: &[u8]) -> Option<PathBuf> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::cell::RefCell;
+
+    /// The error produced when a PID no longer names a live process.
+    fn no_such_process(pid: pid_t) -> Error {
+        Error::NoSuchProcess(Pid::from_raw(pid))
+    }
+
+    /// An error that is *not* a dead process, and so must be reported.
+    fn write_failed() -> Error {
+        Error::Other(anyhow!("Failed to add process to cgroup"))
+    }
+
+    /// Run [`move_pids`], recording which PIDs it attempted to move.
+    fn move_recording(
+        pids: Vec<pid_t>,
+        add: impl Fn(pid_t) -> Result<(), Error>,
+    ) -> (Result<(), Error>, Vec<pid_t>) {
+        let attempted = RefCell::new(vec![]);
+        let result = move_pids(pids, |pid| {
+            attempted.borrow_mut().push(pid.as_raw());
+            add(pid.as_raw())
+        });
+        (result, attempted.into_inner())
+    }
+
+    /// A PID that exits between being listed and being moved must not abort the operation.
+    ///
+    /// This is the regression test for `mullvad split-tunnel clear` failing with
+    /// `FailedPrecondition` when the cgroup contained a PID that was no longer live.
+    #[test]
+    fn dead_pid_does_not_abort_move() {
+        let (result, attempted) = move_recording(vec![1, 2, 3], |pid| {
+            if pid == 2 {
+                Err(no_such_process(pid))
+            } else {
+                Ok(())
+            }
+        });
+
+        assert!(result.is_ok(), "move should have succeeded, got {result:?}");
+        assert_eq!(
+            attempted,
+            vec![1, 2, 3],
+            "every PID should be attempted, including those after the dead PID"
+        );
+    }
+
+    /// A cgroup containing nothing but dead PIDs empties successfully.
+    #[test]
+    fn all_pids_dead_is_success() {
+        let (result, attempted) = move_recording(vec![1, 2], |pid| Err(no_such_process(pid)));
+
+        assert!(result.is_ok(), "move should have succeeded, got {result:?}");
+        assert_eq!(attempted, vec![1, 2]);
+    }
+
+    /// A genuine failure is still reported, but only after the other PIDs have been moved.
+    #[test]
+    fn real_error_is_reported_but_does_not_abort_move() {
+        let (result, attempted) = move_recording(vec![1, 2, 3], |pid| match pid {
+            1 => Err(write_failed()),
+            _ => Ok(()),
+        });
+
+        assert!(result.is_err(), "move should have reported the failure");
+        assert_eq!(
+            attempted,
+            vec![1, 2, 3],
+            "a failing PID should not strand the remaining PIDs in the cgroup"
+        );
+    }
+
+    /// A dead PID must not mask a real error from elsewhere in the list.
+    #[test]
+    fn dead_pid_does_not_mask_real_error() {
+        let (result, _) = move_recording(vec![1, 2], |pid| {
+            if pid == 1 {
+                Err(write_failed())
+            } else {
+                Err(no_such_process(pid))
+            }
+        });
+
+        assert!(
+            matches!(result, Err(Error::Other(_))),
+            "the real error should be reported, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn moving_an_empty_cgroup_is_success() {
+        let (result, attempted) = move_recording(vec![], |_| Ok(()));
+
+        assert!(result.is_ok(), "move should have succeeded, got {result:?}");
+        assert!(attempted.is_empty());
+    }
 
     #[test]
     fn test_find_net_cls_path() {

--- a/talpid-cgroup/src/v1.rs
+++ b/talpid-cgroup/src/v1.rs
@@ -110,10 +110,15 @@ impl CGroup1 {
         let pid_str = CStr::from_bytes_until_nul(&pid_buf).expect("buf contains null");
 
         // Write PID to `cgroup.procs`.
-        nix::unistd::write(&self.procs, pid_str.to_bytes())
-            .with_context(|| anyhow!("Failed to add process {pid} to cgroup"))?;
-
-        Ok(())
+        match nix::unistd::write(&self.procs, pid_str.to_bytes()) {
+            Ok(_) => Ok(()),
+            // The kernel rejects PIDs that don't name a live process. Report this separately, so
+            // that callers can tell it apart from a genuine failure to write.
+            Err(Errno::ESRCH) => Err(super::Error::NoSuchProcess(pid)),
+            Err(error) => Err(error)
+                .with_context(|| anyhow!("Failed to add process {pid} to cgroup"))
+                .map_err(super::Error::from),
+        }
     }
 
     /// List all PIDs in this cgroup.
@@ -135,6 +140,16 @@ impl CGroup1 {
             })
             .collect();
         Ok(pids)
+    }
+
+    /// Move every process in this cgroup into `dest`, emptying this cgroup.
+    ///
+    /// Processes that exit before they can be moved are ignored, since they are already out of
+    /// this cgroup. A process that cannot be moved for any other reason does not prevent the
+    /// remaining ones from being moved, but the error is returned once they have all been tried.
+    pub fn move_pids_to(&mut self, dest: &CGroup1) -> Result<(), super::Error> {
+        let pids = self.list_pids()?;
+        super::move_pids(pids, |pid| dest.add_pid(pid))
     }
 
     /// Set the classid for this net_cls cgroup.

--- a/talpid-cgroup/src/v2.rs
+++ b/talpid-cgroup/src/v2.rs
@@ -100,10 +100,15 @@ impl CGroup2 {
         let pid_str = CStr::from_bytes_until_nul(&pid_buf).expect("buf contains null");
 
         // Write PID to `cgroup.procs`.
-        nix::unistd::write(&self.procs, pid_str.to_bytes())
-            .with_context(|| anyhow!("Failed to add process {pid} to cgroup2"))?;
-
-        Ok(())
+        match nix::unistd::write(&self.procs, pid_str.to_bytes()) {
+            Ok(_) => Ok(()),
+            // The kernel rejects PIDs that don't name a live process. Report this separately, so
+            // that callers can tell it apart from a genuine failure to write.
+            Err(Errno::ESRCH) => Err(Error::NoSuchProcess(pid)),
+            Err(error) => Err(error)
+                .with_context(|| anyhow!("Failed to add process {pid} to cgroup2"))
+                .map_err(Error::from),
+        }
     }
 
     /// List all PIDs in this cgroup2.
@@ -125,6 +130,16 @@ impl CGroup2 {
             })
             .collect();
         Ok(pids)
+    }
+
+    /// Move every process in this cgroup2 into `dest`, emptying this cgroup2.
+    ///
+    /// Processes that exit before they can be moved are ignored, since they are already out of
+    /// this cgroup2. A process that cannot be moved for any other reason does not prevent the
+    /// remaining ones from being moved, but the error is returned once they have all been tried.
+    pub fn move_pids_to(&mut self, dest: &CGroup2) -> Result<(), Error> {
+        let pids = self.list_pids()?;
+        crate::move_pids(pids, |pid| dest.add_pid(pid))
     }
 
     /// Get the inode of the cgroup2

--- a/talpid-core/src/split_tunnel/linux/mod.rs
+++ b/talpid-core/src/split_tunnel/linux/mod.rs
@@ -217,12 +217,21 @@ impl Inner {
     }
 
     /// Removes all PIDs from the Cgroup.
+    ///
+    /// PIDs can only be removed from a cgroup by moving them to another one, so this moves them
+    /// all back to the root cgroup.
     fn clear(&mut self) -> Result<(), Error> {
-        for pid in self.list()? {
-            let pid = Pid::from_raw(pid);
-            self.remove(pid)?;
+        match self {
+            Inner::CGroup1(inner) => inner
+                .excluded_cgroup1
+                .move_pids_to(&inner.root_cgroup1)
+                .map_err(Error::from),
+            #[cfg(feature = "cgroup2")]
+            Inner::CGroup2(inner) => inner
+                .excluded_cgroup2
+                .move_pids_to(&inner.root_cgroup2)
+                .map_err(Error::from),
         }
-        Ok(())
     }
 
     /// Get a handle to the [CGroup2] used for split-tunneling, if any.


### PR DESCRIPTION
## What

Fixes `mullvad split-tunnel clear` failing on Linux when the split tunneling cgroup contains a PID
that no longer names a live process:

```
Error: gRPC call returned error

Caused by:
    status: FailedPrecondition, message: "Error in split tunneling", details: [], metadata: ...
```

`talpid_cgroup::Error` gains a typed `NoSuchProcess` variant, and the loop that empties the cgroup
moves into new `CGroup1::move_pids_to` / `CGroup2::move_pids_to` methods that tolerate PIDs which
have already exited.

## Why

PIDs cannot be removed from a cgroup, only moved to another one, so `clear` walked the membership
list and wrote each PID into the root cgroup. The kernel returns `ESRCH` for a PID that does not
name a live process, and the `?` inside that loop aborted the whole operation. A single dead PID
therefore both failed the command and left every remaining PID excluded from the tunnel — the
opposite of what was asked for, with no indication of how far it got.

This is a race even with no stale state: a process can exit between being listed and being moved.

## How

- `add_pid` (v1 and v2) maps `Errno::ESRCH` to `Error::NoSuchProcess(pid)` instead of burying it in
  an `anyhow` context. Every other errno keeps its original context message.
- A shared `move_pids` helper skips that error — a process that no longer exists is already out of
  the cgroup, which is the state `clear` is asked to produce — and reports any other failure only
  once every remaining PID has been attempted.
- `Inner::clear` in `talpid-core` delegates to `move_pids_to`, so it no longer pattern-matches on
  `talpid_cgroup`'s error internals.

`mullvad split-tunnel add` is deliberately left strict: it does not handle `NoSuchProcess`, so
naming a PID that does not exist still reports an error rather than silently doing nothing.

| | before | after |
|---|---|---|
| `clear` with dead PIDs in the list | error, remaining PIDs left excluded | succeeds, cgroup emptied |
| `clear` with a non-`ESRCH` failure | aborts at the first one | attempts all, then reports it |
| `add <dead-pid>` | error | error (unchanged) |

## How to test

Manually, on Linux with the daemon running:

```sh
mullvad-exclude sleep 5 &
mullvad split-tunnel list      # shows the PID
sleep 6                        # let it exit
mullvad split-tunnel clear     # failed before this change; now succeeds
```

Automated:

```sh
cargo test -p talpid-cgroup
```

Five tests cover the policy. To confirm they are load-bearing, replace the body of `move_pids`
with the original logic:

```rust
for pid in pids {
    add(Pid::from_raw(pid))?;
}
Ok(())
```

`dead_pid_does_not_abort_move`, `all_pids_dead_is_success` and
`real_error_is_reported_but_does_not_abort_move` then fail.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10886)
<!-- Reviewable:end -->
