### PR TITLE
FWT - only allow selected obfuscation endpoint when connected

### DIFF
--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -8,8 +8,9 @@ use futures::future::Fuse;
 use futures::{FutureExt, StreamExt};
 use talpid_routing::RouteManagerHandle;
 use talpid_tunnel::tun_provider::TunProvider;
-use talpid_tunnel::{EventHook, TunnelArgs, TunnelEvent, TunnelMetadata};
+use talpid_tunnel::{EventHook, SelectedObfuscation, TunnelArgs, TunnelEvent, TunnelMetadata};
 use talpid_types::ErrorExt;
+use talpid_types::net::obfuscation::Obfuscators;
 use talpid_types::net::{
     AllowedClients, AllowedEndpoint, AllowedTunnelTraffic, wireguard::TunnelParameters,
 };
@@ -596,14 +597,37 @@ impl ConnectingState {
                     ),
                 }
             }
-            Some((TunnelEvent::Up(metadata), _)) => NewState(ConnectedState::enter(
-                shared_values,
-                metadata,
-                self.tunnel_events,
-                self.tunnel_parameters,
-                self.tunnel_close_event,
-                self.tunnel_close_tx,
-            )),
+            Some((
+                TunnelEvent::Up {
+                    metadata,
+                    selected_obfuscation,
+                },
+                _,
+            )) => {
+                let mut tunnel_parameters = self.tunnel_parameters;
+
+                // While connecting, the parameters may list several candidate transports. Now
+                // that the tunnel is up, replace them with the one it committed to, so that
+                // everything derived from the parameters -- the firewall policy and the
+                // endpoint we broadcast -- refers to the transport that is actually in use.
+                if let Some(selected_obfuscation) = selected_obfuscation {
+                    tunnel_parameters.obfuscation = match selected_obfuscation {
+                        SelectedObfuscation::Direct => None,
+                        SelectedObfuscation::Obfuscated(config) => {
+                            Some(Obfuscators::Single(config))
+                        }
+                    };
+                }
+
+                NewState(ConnectedState::enter(
+                    shared_values,
+                    metadata,
+                    self.tunnel_events,
+                    tunnel_parameters,
+                    self.tunnel_close_event,
+                    self.tunnel_close_tx,
+                ))
+            }
             Some((TunnelEvent::Down, _)) => {
                 // It is important to reset this before the tunnel device is down,
                 // or else commands that reapply the firewall rules will fail since

--- a/talpid-tunnel/src/lib.rs
+++ b/talpid-tunnel/src/lib.rs
@@ -17,7 +17,7 @@ use futures::{
     },
 };
 use talpid_routing::RouteManagerHandle;
-use talpid_types::net::AllowedTunnelTraffic;
+use talpid_types::net::{AllowedTunnelTraffic, obfuscation::ObfuscatorConfig};
 use tun_provider::TunProvider;
 
 /// Size of IPv4 header in bytes
@@ -93,6 +93,15 @@ impl TunnelMetadata {
     }
 }
 
+/// The single transport that the tunnel has committed to.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum SelectedObfuscation {
+    /// Traffic is sent directly to the relay, without obfuscation.
+    Direct,
+    /// Traffic passes through this obfuscator.
+    Obfuscated(ObfuscatorConfig),
+}
+
 /// Possible events from the VPN tunnel and the child process managing it.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum TunnelEvent {
@@ -101,7 +110,17 @@ pub enum TunnelEvent {
     /// Sent when the tunnel interface has been created, before routes are set up.
     InterfaceUp(TunnelMetadata, AllowedTunnelTraffic),
     /// Sent when the tunnel comes up and is ready for traffic.
-    Up(TunnelMetadata),
+    Up {
+        metadata: TunnelMetadata,
+        /// The transport that the obfuscation multiplexer settled on, or `None`.
+        ///
+        /// This is only set when obfuscation is multiplexed over several candidates,
+        /// in which case only one of them is in use once the tunnel is up.
+        ///
+        /// If set, this must replace the previous endpoints in
+        /// [talpid_types::net::wireguard::TunnelParameters].
+        selected_obfuscation: Option<SelectedObfuscation>,
+    },
     /// Sent when the tunnel goes down, but before destroying the tunnel device.
     Down,
 }

--- a/talpid-types/src/net/obfuscation.rs
+++ b/talpid-types/src/net/obfuscation.rs
@@ -20,7 +20,7 @@ pub enum Obfuscators {
     },
 }
 
-#[derive(Clone, Eq, PartialEq, Deserialize, Serialize, Debug)]
+#[derive(Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Debug)]
 pub enum ObfuscatorConfig {
     Udp2Tcp {
         endpoint: SocketAddr,

--- a/talpid-wireguard/src/config.rs
+++ b/talpid-wireguard/src/config.rs
@@ -118,11 +118,11 @@ impl Config {
         Ok(config)
     }
 
-    /// Derive [tunnel_obfuscation::Settings] from the current config state.
+    /// Derive [crate::obfuscation::ObfuscationSettings] from the current config state.
     ///
     /// This is computed on demand so that it always reflects the current
     /// private key (which may change during ephemeral peer negotiation).
-    pub fn obfuscation_settings(&self) -> Option<tunnel_obfuscation::Settings> {
+    pub fn obfuscation_settings(&self) -> Option<crate::obfuscation::ObfuscationSettings> {
         self.obfuscator_config.as_ref().map(|obfuscator_config| {
             crate::obfuscation::settings_from_config(
                 self.tunnel.private_key.public_key(),

--- a/talpid-wireguard/src/gotatun/mod.rs
+++ b/talpid-wireguard/src/gotatun/mod.rs
@@ -554,7 +554,10 @@ async fn create_devices(
         optimize_buffer_size: bool,
     ) -> Result<Devices, gotatun::device::Error> {
         let factory = udp_obfuscator_factory(
-            config.obfuscation_settings().as_ref(),
+            config
+                .obfuscation_settings()
+                .as_ref()
+                .and_then(|settings| settings.single()),
             optimize_buffer_size,
             #[cfg(target_os = "android")]
             android_tun,

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -20,8 +20,11 @@ use std::{
 };
 #[cfg(not(target_os = "android"))]
 use talpid_routing::{self, RequiredRoute};
-use talpid_tunnel::{EventHook, TunnelArgs, TunnelEvent, TunnelMetadata, tun_provider};
+use talpid_tunnel::{
+    EventHook, SelectedObfuscation, TunnelArgs, TunnelEvent, TunnelMetadata, tun_provider,
+};
 use talpid_tunnel::{IPV4_HEADER_SIZE, IPV6_HEADER_SIZE, WIREGUARD_HEADER_SIZE};
+use tunnel_obfuscation::multiplexer::Transport;
 
 use talpid_tunnel_config_client::DaitaSettings;
 use talpid_types::{
@@ -74,6 +77,11 @@ pub enum Error {
     #[error("Tunnel obfuscation failed")]
     ObfuscationError(#[source] tunnel_obfuscation::Error),
 
+    /// Failed to determine which obfuscator the multiplexer settled on. Without it, the firewall
+    /// cannot be restricted to the endpoint that is actually in use.
+    #[error("Failed to determine the selected obfuscator")]
+    UnknownSelectedObfuscator,
+
     /// Failed to set up connectivity monitor
     #[error("Connectivity monitor failed")]
     ConnectivityMonitorError(#[source] connectivity::Error),
@@ -98,6 +106,7 @@ impl Error {
     pub fn is_recoverable(&self) -> bool {
         match self {
             Error::ObfuscationError(_) => true,
+            Error::UnknownSelectedObfuscator => true,
             Error::EphemeralPeerNegotiationError(_) => true,
             Error::TunnelError(TunnelError::RecoverableStartWireguardError(..)) => true,
 
@@ -378,7 +387,15 @@ impl WireguardMonitor {
                 .map_err(CloseMsg::SetupError)?;
 
             let metadata = Self::tunnel_metadata(&iface_name, &config);
-            event_hook.on_event(TunnelEvent::Up(metadata)).await;
+            let selected_obfuscation = selected_obfuscation(&obfuscator)
+                .await
+                .map_err(CloseMsg::SetupError)?;
+            event_hook
+                .on_event(TunnelEvent::Up {
+                    metadata,
+                    selected_obfuscation,
+                })
+                .await;
 
             if let Err(error) = connectivity::Monitor::init(connectivity_monitor)
                 .run(Arc::downgrade(&tunnel))
@@ -551,7 +568,15 @@ impl WireguardMonitor {
             }
 
             let metadata = Self::tunnel_metadata(&iface_name, &config);
-            event_hook.on_event(TunnelEvent::Up(metadata)).await;
+            let selected_obfuscation = selected_obfuscation(&obfuscator)
+                .await
+                .map_err(CloseMsg::SetupError)?;
+            event_hook
+                .on_event(TunnelEvent::Up {
+                    metadata,
+                    selected_obfuscation,
+                })
+                .await;
 
             if let Err(error) = connectivity::Monitor::init(connectivity_monitor)
                 .run(Arc::downgrade(&tunnel))
@@ -940,6 +965,38 @@ impl WireguardMonitor {
             ipv6_gateway: config.ipv6_gateway,
         }
     }
+}
+
+/// Return the transport that the obfuscator has committed to, if it had a choice to make.
+///
+/// Only a multiplexer has one, so this is `Ok(None)` for every other configuration, whose tunnel
+/// parameters already describe the single transport in use.
+async fn selected_obfuscation(
+    obfuscator: &AsyncMutex<Option<ObfuscatorHandle>>,
+) -> Result<Option<SelectedObfuscation>> {
+    let Some(rx) = obfuscator
+        .lock()
+        .await
+        .as_mut()
+        .and_then(ObfuscatorHandle::take_selected_transport_rx)
+    else {
+        return Ok(None);
+    };
+
+    let transport = rx.await.map_err(|_err| {
+        log::error!("The multiplexer stopped before selecting a transport");
+        Error::UnknownSelectedObfuscator
+    })?;
+
+    let selected = match transport {
+        Transport::Direct(_) => SelectedObfuscation::Direct,
+        Transport::Obfuscated(settings) => {
+            SelectedObfuscation::Obfuscated(obfuscation::config_from_single_settings(&settings))
+        }
+    };
+
+    log::debug!("Selected obfuscation: {selected:?}");
+    Ok(Some(selected))
 }
 
 fn get_obfuscator(

--- a/talpid-wireguard/src/obfuscation.rs
+++ b/talpid-wireguard/src/obfuscation.rs
@@ -19,10 +19,29 @@ use talpid_types::{
         wireguard::{PeerConfig, PublicKey},
     },
 };
+use tokio::sync::oneshot;
 use tunnel_obfuscation::{
-    Settings as ObfuscationSettings, create_local_socket_obfuscator_with_bypass, lwo, multiplexer,
+    LocalSocketObfuscator, create_local_socket_obfuscator_with_bypass, lwo,
+    multiplexer::{self, Transport},
     quic, shadowsocks, udp2tcp,
 };
+
+/// Settings for the local socket obfuscator to run: either a single obfuscator or a multiplexer.
+#[derive(Debug, Clone)]
+pub enum ObfuscationSettings {
+    Single(tunnel_obfuscation::Settings),
+    Multiplexer(Vec<tunnel_obfuscation::multiplexer::Transport>),
+}
+
+impl ObfuscationSettings {
+    /// Return the settings of the single obfuscator to run, if this is not a multiplexer.
+    pub fn single(&self) -> Option<&tunnel_obfuscation::Settings> {
+        match self {
+            ObfuscationSettings::Single(settings) => Some(settings),
+            ObfuscationSettings::Multiplexer(_) => None,
+        }
+    }
+}
 
 /// Begin running obfuscation machine, if configured. This function will patch `config`'s endpoint
 /// to point to an endpoint on localhost.
@@ -34,7 +53,7 @@ use tunnel_obfuscation::{
 /// * fwmark - (Linux only) firewall mark to apply to the obfuscator's remote socket
 pub async fn spawn_local_socket_obfuscator(
     entry_peer: &mut PeerConfig,
-    obfuscation_settings: tunnel_obfuscation::Settings,
+    obfuscation_settings: ObfuscationSettings,
     close_msg_sender: sync_mpsc::Sender<CloseMsg>,
     #[cfg(target_os = "android")] tun_provider: Arc<Mutex<TunProvider>>,
     #[cfg(target_os = "linux")] fwmark: Option<u32>,
@@ -52,9 +71,31 @@ pub async fn spawn_local_socket_obfuscator(
         tun_provider,
     });
 
-    let obfuscator = create_local_socket_obfuscator_with_bypass(bypass, &obfuscation_settings)
-        .await
-        .map_err(Error::ObfuscationError)?;
+    let mut selected_transport_rx = None;
+
+    let obfuscator: Box<dyn LocalSocketObfuscator> = match obfuscation_settings {
+        ObfuscationSettings::Single(settings) => {
+            create_local_socket_obfuscator_with_bypass(bypass, &settings)
+                .await
+                .map_err(Error::ObfuscationError)?
+        }
+        ObfuscationSettings::Multiplexer(transports) => {
+            let (selected_transport_tx, selected_transport) = oneshot::channel();
+            let settings = multiplexer::Settings {
+                transports,
+                selected_transport: selected_transport_tx,
+            };
+            // The multiplexer connects to one out of several endpoints, and only commits to one
+            // of them. Have it announce its choice so that the firewall can be
+            // tightened accordingly.
+            selected_transport_rx = Some(selected_transport);
+            Box::new(
+                multiplexer::Multiplexer::new(bypass, settings)
+                    .await
+                    .map_err(Error::ObfuscationError)?,
+            )
+        }
+    };
 
     let packet_overhead = obfuscator.packet_overhead();
 
@@ -79,6 +120,7 @@ pub async fn spawn_local_socket_obfuscator(
     Ok(ObfuscatorHandle {
         obfuscation_task,
         packet_overhead,
+        selected_transport_rx,
     })
 }
 
@@ -107,12 +149,14 @@ pub fn settings_from_config(
     mtu: u16,
 ) -> ObfuscationSettings {
     match obfuscation_config {
-        Obfuscators::Single(obfuscation_config) => settings_from_single_config(
-            client_public_key,
-            server_public_key,
-            obfuscation_config,
-            mtu,
-        ),
+        Obfuscators::Single(obfuscation_config) => {
+            ObfuscationSettings::Single(settings_from_single_config(
+                client_public_key,
+                server_public_key,
+                obfuscation_config,
+                mtu,
+            ))
+        }
         Obfuscators::Multiplexer {
             direct,
             configs: (first_obfs, remaining_obfs),
@@ -130,7 +174,7 @@ pub fn settings_from_config(
                 );
                 transports.push(multiplexer::Transport::Obfuscated(settings));
             }
-            ObfuscationSettings::Multiplexer(multiplexer::Settings { transports })
+            ObfuscationSettings::Multiplexer(transports)
         }
     }
 }
@@ -140,13 +184,13 @@ fn settings_from_single_config(
     server_public_key: PublicKey,
     obfuscation_config: &ObfuscatorConfig,
     mtu: u16,
-) -> ObfuscationSettings {
+) -> tunnel_obfuscation::Settings {
     match obfuscation_config {
         ObfuscatorConfig::Udp2Tcp { endpoint } => {
-            ObfuscationSettings::Udp2Tcp(udp2tcp::Settings { peer: *endpoint })
+            tunnel_obfuscation::Settings::Udp2Tcp(udp2tcp::Settings { peer: *endpoint })
         }
         ObfuscatorConfig::Shadowsocks { endpoint } => {
-            ObfuscationSettings::Shadowsocks(shadowsocks::Settings {
+            tunnel_obfuscation::Settings::Shadowsocks(shadowsocks::Settings {
                 shadowsocks_endpoint: *endpoint,
                 wireguard_endpoint: if endpoint.is_ipv4() {
                     SocketAddr::from((Ipv4Addr::LOCALHOST, 51820))
@@ -168,9 +212,9 @@ fn settings_from_single_config(
                 wireguard_endpoint,
             )
             .mtu(mtu);
-            ObfuscationSettings::Quic(settings)
+            tunnel_obfuscation::Settings::Quic(settings)
         }
-        ObfuscatorConfig::Lwo { endpoint } => ObfuscationSettings::Lwo(lwo::Settings {
+        ObfuscatorConfig::Lwo { endpoint } => tunnel_obfuscation::Settings::Lwo(lwo::Settings {
             server_addr: *endpoint,
             client_public_key,
             server_public_key,
@@ -178,10 +222,34 @@ fn settings_from_single_config(
     }
 }
 
+/// The inverse of [`settings_from_single_config`].
+///
+/// The settings carry derived state that the config does not -- the local WireGuard endpoint and
+/// the MTU -- which is simply dropped.
+pub fn config_from_single_settings(settings: &tunnel_obfuscation::Settings) -> ObfuscatorConfig {
+    match settings {
+        tunnel_obfuscation::Settings::Udp2Tcp(settings) => ObfuscatorConfig::Udp2Tcp {
+            endpoint: settings.peer,
+        },
+        tunnel_obfuscation::Settings::Shadowsocks(settings) => ObfuscatorConfig::Shadowsocks {
+            endpoint: settings.shadowsocks_endpoint,
+        },
+        tunnel_obfuscation::Settings::Quic(settings) => ObfuscatorConfig::Quic {
+            hostname: settings.hostname().to_owned(),
+            endpoint: settings.quic_endpoint(),
+            auth_token: settings.auth_token().to_owned(),
+        },
+        tunnel_obfuscation::Settings::Lwo(settings) => ObfuscatorConfig::Lwo {
+            endpoint: settings.server_addr,
+        },
+    }
+}
+
 /// Simple wrapper that automatically cancels the future which runs an obfuscator.
 pub struct ObfuscatorHandle {
     obfuscation_task: tokio::task::JoinHandle<()>,
     packet_overhead: u16,
+    selected_transport_rx: Option<oneshot::Receiver<Transport>>,
 }
 
 impl ObfuscatorHandle {
@@ -191,6 +259,13 @@ impl ObfuscatorHandle {
 
     pub fn packet_overhead(&self) -> u16 {
         self.packet_overhead
+    }
+
+    /// Notified with the transport that the obfuscator commits to.
+    ///
+    /// Only a multiplexer has a choice to make, so this is `None` for every other obfuscator.
+    pub fn take_selected_transport_rx(&mut self) -> Option<oneshot::Receiver<Transport>> {
+        self.selected_transport_rx.take()
     }
 }
 

--- a/tunnel-obfuscation/Cargo.toml
+++ b/tunnel-obfuscation/Cargo.toml
@@ -28,7 +28,8 @@ tokio = { workspace = true, features = [
   "io-util",
   "macros",
   "net",
-  "rt-multi-thread"
+  "rt-multi-thread",
+  "sync"
 ] }
 tokio-util = { workspace = true, features = ["rt"] }
 udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "00c8482f303aa23a69cfe9ee10903582cba3eb1e" }

--- a/tunnel-obfuscation/src/lib.rs
+++ b/tunnel-obfuscation/src/lib.rs
@@ -64,13 +64,17 @@ pub trait LocalSocketObfuscator: Send {
     fn packet_overhead(&self) -> u16;
 }
 
+/// Settings for a single obfuscator.
+///
+/// The multiplexer, which races several obfuscators against each other, is deliberately not
+/// included here. It is constructed directly via [`multiplexer::Multiplexer::new`], so that it
+/// cannot be nested within itself.
 #[derive(Debug, Clone)]
 pub enum Settings {
     Udp2Tcp(udp2tcp::Settings),
     Shadowsocks(shadowsocks::Settings),
     Quic(quic::Settings),
     Lwo(lwo::Settings),
-    Multiplexer(multiplexer::Settings),
 }
 
 pub async fn create_local_socket_obfuscator(
@@ -92,9 +96,6 @@ pub async fn create_local_socket_obfuscator_with_bypass(
             .await
             .map(box_obfuscator),
         Settings::Lwo(s) => lwo::Lwo::new(bypass, s).await.map(box_obfuscator),
-        Settings::Multiplexer(s) => multiplexer::Multiplexer::new(bypass, s)
-            .await
-            .map(box_obfuscator),
     }
 }
 

--- a/tunnel-obfuscation/src/multiplexer.rs
+++ b/tunnel-obfuscation/src/multiplexer.rs
@@ -30,7 +30,7 @@ use std::{
 
 use async_trait::async_trait;
 use talpid_net::bypass::{BypassSocket, SocketBypass};
-use tokio::net::UdpSocket;
+use tokio::{net::UdpSocket, sync::oneshot};
 use tokio_util::task::AbortOnDropHandle;
 
 use crate::socket::create_remote_socket;
@@ -56,16 +56,33 @@ pub struct Multiplexer {
     /// IPv6 socket for communicating with obfuscation proxies
     proxy_socket_v6: Arc<BypassSocket<UdpSocket>>,
     /// Map of currently active transport endpoints and their configurations
-    running_endpoints: BTreeMap<SocketAddr, Transport>,
+    running_endpoints: BTreeMap<SocketAddr, RunningTransport>,
     /// Queue of transports to spawn (in priority order)
     transports: VecDeque<Transport>,
     /// Buffer of initial packets received from WireGuard to replay to new transports
     initial_packets_to_send: Vec<Vec<u8>>,
-    /// Handles to spawned obfuscation tasks
-    tasks: Vec<AbortOnDropHandle<()>>,
     /// Address of WG endpoint socket
     wg_addr: Option<SocketAddr>,
+    /// Notified with the selected transport
+    selected_transport_tx: Option<SelectedTransportTx>,
     bypass: Arc<dyn SocketBypass>,
+}
+
+/// A transport that has been spawned and is being fanned out to.
+struct RunningTransport {
+    transport: Transport,
+    /// Handle to the task running the obfuscator. `None` for [`Transport::Direct`], which needs
+    /// no obfuscator. Only held so that dropping it aborts the obfuscator.
+    #[expect(dead_code)]
+    task: Option<AbortOnDropHandle<()>>,
+}
+
+/// The transport that the multiplexer has committed to, and the peer it forwards traffic for.
+struct Selection {
+    /// Address of the local WireGuard instance
+    wg_addr: SocketAddr,
+    /// Local address of the selected obfuscator
+    proxy_addr: SocketAddr,
 }
 
 impl Multiplexer {
@@ -76,7 +93,7 @@ impl Multiplexer {
     ///
     /// # Returns
     /// A new multiplexer instance ready to start obfuscation discovery
-    pub async fn new(bypass: Arc<dyn SocketBypass>, settings: &Settings) -> crate::Result<Self> {
+    pub async fn new(bypass: Arc<dyn SocketBypass>, settings: Settings) -> crate::Result<Self> {
         let client_socket = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0))
             .await
             .map_err(crate::Error::CreateMultiplexerObfuscator)?;
@@ -95,9 +112,9 @@ impl Multiplexer {
             proxy_socket_v6: Arc::new(proxy_socket_v6),
             running_endpoints: BTreeMap::new(),
             transports: VecDeque::from(settings.transports.clone()),
-            tasks: vec![],
             initial_packets_to_send: vec![],
             wg_addr: None,
+            selected_transport_tx: Some(settings.selected_transport),
             bypass,
         })
     }
@@ -120,6 +137,23 @@ impl Multiplexer {
     async fn start(mut self) -> io::Result<()> {
         log::debug!("Running multiplexer obfuscation");
 
+        let Some(selection) = self.run_discovery().await? else {
+            return Ok(());
+        };
+
+        // Stop all transports but the selected one.
+        self.running_endpoints
+            .retain(|addr, _| *addr == selection.proxy_addr);
+
+        self.run_connected(selection.wg_addr, selection.proxy_addr)
+            .await
+    }
+
+    /// Fan traffic out to all transports until one of them responds.
+    ///
+    /// Returns the selected transport, or `None` if the local WireGuard instance went away before
+    /// any transport was selected.
+    async fn run_discovery(&mut self) -> io::Result<Option<Selection>> {
         let mut wg_recv_buf = vec![0u8; MAX_DATAGRAM_SIZE];
         let mut obfs_recv_v4_buf = vec![0u8; MAX_DATAGRAM_SIZE];
         let mut obfs_recv_v6_buf = vec![0u8; MAX_DATAGRAM_SIZE];
@@ -128,7 +162,7 @@ impl Multiplexer {
 
         /// Helper to fan out a packet to all currently running endpoints
         async fn send_to_all<'a>(
-            endpoints: &BTreeMap<SocketAddr, Transport>,
+            endpoints: &BTreeMap<SocketAddr, RunningTransport>,
             get_socket: impl Fn(SocketAddr) -> &'a Arc<BypassSocket<UdpSocket>>,
             packet: &[u8],
         ) {
@@ -179,19 +213,23 @@ impl Multiplexer {
                         },
                         Err(err) => {
                             log::error!("Failed to receive traffic from local WireGuard instance: {err}");
-                            return Ok(());
+                            return Ok(None);
                         }
                     }
                 },
 
                 // From any IPv4 proxy
                 obfuscator_recv = self.proxy_socket_v4.recv_from(&mut obfs_recv_v4_buf) => {
-                    self.process_obfuscator_recv(obfuscator_recv.map(|(n, addr)| (&obfs_recv_v4_buf[..n], addr))).await?;
+                    if let Some(selection) = self.process_obfuscator_recv(obfuscator_recv.map(|(n, addr)| (&obfs_recv_v4_buf[..n], addr))).await? {
+                        return Ok(Some(selection));
+                    }
                 },
 
                 // From any IPv6 proxy
                 obfuscator_recv = self.proxy_socket_v6.recv_from(&mut obfs_recv_v6_buf) => {
-                    self.process_obfuscator_recv(obfuscator_recv.map(|(n, addr)| (&obfs_recv_v6_buf[..n], addr))).await?;
+                    if let Some(selection) = self.process_obfuscator_recv(obfuscator_recv.map(|(n, addr)| (&obfs_recv_v6_buf[..n], addr))).await? {
+                        return Ok(Some(selection));
+                    }
                 },
 
                 // Spawning the next transport
@@ -210,29 +248,41 @@ impl Multiplexer {
     /// If received bytes were forwarded from an obfuscator back to wireguard, this indicates that
     /// a handshake response was received (hopefully) and that we should switch to connected mode.
     ///
-    /// If a packet was received, this continues running until `run_connected` returns.
+    /// Returns the selected transport if the received packet selected one.
     async fn process_obfuscator_recv(
-        &self,
+        &mut self,
         obfuscator_recv: io::Result<(&[u8], SocketAddr)>,
-    ) -> io::Result<()> {
+    ) -> io::Result<Option<Selection>> {
         match obfuscator_recv {
             Ok((received, obfuscator_addr)) => {
-                let Some(transport_config) = self.running_endpoints.get(&obfuscator_addr) else {
+                let Some(running) = self.running_endpoints.get(&obfuscator_addr) else {
                     log::trace!("Ignoring data from unexpected address {obfuscator_addr}");
-                    return Ok(());
+                    return Ok(None);
                 };
                 let Some(wg_addr) = self.wg_addr else {
                     log::trace!(
                         "Received data from {obfuscator_addr} before receiving any data from WireGuard"
                     );
-                    return Ok(());
+                    return Ok(None);
                 };
                 log::debug!(
                     "Selecting {:?} as valid transport configuration via {obfuscator_addr}",
-                    transport_config
+                    running.transport
                 );
+
+                let transport = running.transport.clone();
+                // Announce selected transport
+                let tx = self
+                    .selected_transport_tx
+                    .take()
+                    .expect("announce only once");
+                let _ = tx.send(transport);
+
                 let _ = self.client_socket.send_to(received, wg_addr).await;
-                self.run_connected(wg_addr, obfuscator_addr).await
+                Ok(Some(Selection {
+                    wg_addr,
+                    proxy_addr: obfuscator_addr,
+                }))
             }
             Err(err) => {
                 log::error!("Failed to receive traffic from obfuscators: {err}");
@@ -309,7 +359,13 @@ impl Multiplexer {
     async fn spawn_new_transport(&mut self, transport: Transport) -> crate::Result<()> {
         let endpoint = match transport.clone() {
             Transport::Direct(addr) => {
-                self.running_endpoints.insert(addr, transport);
+                self.running_endpoints.insert(
+                    addr,
+                    RunningTransport {
+                        transport,
+                        task: None,
+                    },
+                );
                 log::info!("Spawning direct forwarder");
                 Ok(addr)
             }
@@ -320,13 +376,17 @@ impl Multiplexer {
                 )
                 .await?;
                 let endpoint = obfuscator.endpoint();
-                self.running_endpoints
-                    .insert(endpoint, Transport::Obfuscated(obfuscator_settings));
-                self.tasks
-                    .push(AbortOnDropHandle::new(tokio::spawn(async move {
-                        log::info!("Spawning new obfuscator");
-                        let _ = obfuscator.run().await;
-                    })));
+                let task = AbortOnDropHandle::new(tokio::spawn(async move {
+                    log::info!("Spawning new obfuscator");
+                    let _ = obfuscator.run().await;
+                }));
+                self.running_endpoints.insert(
+                    endpoint,
+                    RunningTransport {
+                        transport: Transport::Obfuscated(obfuscator_settings),
+                        task: Some(task),
+                    },
+                );
                 Ok(endpoint)
             }
         }?;
@@ -346,13 +406,19 @@ impl Multiplexer {
     }
 }
 
+/// Notifies interested parties about which transport the multiplexer has committed to.
+pub type SelectedTransportTx = oneshot::Sender<Transport>;
+
 /// Configuration settings for multiplexer obfuscation
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Settings {
     /// List of transports to try, ordered by priority (highest to lowest).
     /// Spawn these transports progressively and select
     /// the first one that successfully establishes a connection.
     pub transports: Vec<Transport>,
+    /// Notified with the selected transport, once one has been selected. The value is only ever
+    /// set once, as the multiplexer never reconsiders its choice.
+    pub selected_transport: SelectedTransportTx,
 }
 
 /// Represents a transport method that the multiplexer can use.
@@ -399,14 +465,16 @@ mod tests {
         let server_addr2 = server_socket2.local_addr().unwrap();
 
         // Create multiplexer pointing to a single direct transport
+        let (selected_tx, selected_rx) = oneshot::channel();
         let settings = Settings {
             transports: vec![
                 Transport::Direct(server_addr),
                 Transport::Direct(server_addr2),
             ],
+            selected_transport: selected_tx,
         };
 
-        let multiplexer = Multiplexer::new(Arc::new(NoopBypass), &settings)
+        let multiplexer = Multiplexer::new(Arc::new(NoopBypass), settings)
             .await
             .unwrap();
         let multiplexer_endpoint = multiplexer.endpoint();
@@ -448,6 +516,10 @@ mod tests {
         let (bytes_received, _) = client_socket.recv_from(&mut client_buf).await.unwrap();
 
         assert_eq!(&client_buf[..bytes_received], response_data);
+
+        // The first server, and not the second, should have been announced as selected
+        let selected = selected_rx.await.unwrap();
+        assert!(matches!(selected, Transport::Direct(addr) if addr == server_addr));
 
         // Packets from unselected transports should not be forwarded after the
         // multiplexer has picked a transport.

--- a/tunnel-obfuscation/src/quic.rs
+++ b/tunnel-obfuscation/src/quic.rs
@@ -101,6 +101,15 @@ impl Settings {
     pub fn quic_endpoint(&self) -> SocketAddr {
         self.quic_endpoint
     }
+
+    pub fn hostname(&self) -> &str {
+        &self.hostname
+    }
+
+    /// The authentication token, without the "Bearer " prefix. See [`Settings::token`].
+    pub fn auth_token(&self) -> &str {
+        &self.token.0
+    }
 }
 
 /// Authorization Token used when connecting to a masque-proxy.


### PR DESCRIPTION
While connecting with multiplexer obfuscation, every candidate endpoint has to be allowed through the firewall. The multiplexer now announces the endpoint it commits to, and the connected state allows only that one for the rest of the tunnel's lifetime.

Also, drop unused transports when entering the "connected" phase of FWT.

This still leaves routes on macOS and Windows. Follow-up PR will take care of that.

Fix DES-2518

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10889)
<!-- Reviewable:end -->
