### PR TITLE
Remove routes to unused obfuscation endpoints (for multiplexer)

### DIFF
--- a/talpid-routing/src/unix/macos/mod.rs
+++ b/talpid-routing/src/unix/macos/mod.rs
@@ -246,6 +246,10 @@ impl RouteManagerImpl {
                                 log::error!("Failed to clean up rotues: {err}");
                             }
                         },
+                        Some(RouteManagerCommand::RemoveRoutes(destinations)) => {
+                            log::debug!("Removing routes to: {destinations:?}");
+                            self.remove_routes_to(&destinations).await;
+                        },
 
                         Some(RouteManagerCommand::NewInterfaceChangeListener(tx)) => {
                             let (events_tx, events_rx) = mpsc::unbounded();
@@ -459,8 +463,10 @@ impl RouteManagerImpl {
         log::trace!("Refreshing routes");
 
         // Remove any existing ifscoped default route that we've added
-        self.remove_applied_routes(|route| route.ifscope() && route.is_default().unwrap_or(false))
-            .await;
+        self.remove_applied_routes(|_dest, route| {
+            route.ifscope() && route.is_default().unwrap_or(false)
+        })
+        .await;
 
         // Substitute route with a tunnel route
         self.apply_tunnel_default_routes().await?;
@@ -615,7 +621,7 @@ impl RouteManagerImpl {
     }
 
     async fn cleanup_routes(&mut self) -> Result<()> {
-        self.remove_applied_routes(|_| true).await;
+        self.remove_applied_routes(|_, _| true).await;
 
         // We have already removed the applied default routes
         self.tunnel_default_routes.remove(interface::Family::V4);
@@ -630,12 +636,26 @@ impl RouteManagerImpl {
         Ok(())
     }
 
+    /// Remove all routes whose destination is in `destinations`.
+    async fn remove_routes_to(&mut self, destinations: &HashSet<IpNetwork>) {
+        // These must also be forgotten, or `apply_non_tunnel_routes` adds them back the next
+        // time the default route changes.
+        self.non_tunnel_routes
+            .retain(|destination| !destinations.contains(destination));
+
+        self.remove_applied_routes(|dest, _route| destinations.contains(&dest.network))
+            .await;
+    }
+
     /// Remove all applied routes for which `filter` returns true
-    async fn remove_applied_routes(&mut self, filter: impl Fn(&RouteMessage) -> bool) {
+    async fn remove_applied_routes(
+        &mut self,
+        filter: impl Fn(&RouteDestination, &RouteMessage) -> bool,
+    ) {
         let mut deleted_routes = vec![];
 
-        self.applied_routes.retain(|_dest, route| {
-            if filter(route) {
+        self.applied_routes.retain(|dest, route| {
+            if filter(dest, route) {
                 deleted_routes.push(route.clone());
                 return false;
             }

--- a/talpid-routing/src/unix/mod.rs
+++ b/talpid-routing/src/unix/mod.rs
@@ -22,6 +22,9 @@ use std::collections::HashSet;
 #[cfg(target_os = "linux")]
 use std::net::IpAddr;
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use ipnetwork::IpNetwork;
+
 #[expect(clippy::module_inception)]
 #[cfg(target_os = "macos")]
 #[path = "macos/mod.rs"]
@@ -119,6 +122,8 @@ pub(crate) enum RouteManagerCommand {
         oneshot::Sender<Result<(), PlatformError>>,
     ),
     ClearRoutes,
+    /// Remove applied routes whose destination is one of these networks.
+    RemoveRoutes(HashSet<IpNetwork>),
     Shutdown(oneshot::Sender<()>),
     RefreshRoutes,
     NewDefaultRouteListener(oneshot::Sender<mpsc::UnboundedReceiver<DefaultRouteEvent>>),
@@ -242,6 +247,22 @@ impl RouteManagerHandle {
         self.tx
             .unbounded_send(RouteManagerCommand::ClearRoutes)
             .map_err(|_| Error::RouteManagerDown)
+    }
+
+    /// Removes the routes previously applied in [`RouteManagerHandle::add_routes`] whose
+    /// destination is one of `destinations`.
+    #[cfg(target_os = "macos")]
+    pub fn remove_routes(&self, destinations: HashSet<IpNetwork>) -> Result<(), Error> {
+        self.tx
+            .unbounded_send(RouteManagerCommand::RemoveRoutes(destinations))
+            .map_err(|_| Error::RouteManagerDown)
+    }
+
+    /// (Linux) This is a no-op, since no routes are applied per destination. Policy based
+    /// routing is used to keep traffic outside of the tunnel instead.
+    #[cfg(target_os = "linux")]
+    pub fn remove_routes(&self, _destinations: HashSet<IpNetwork>) -> Result<(), Error> {
+        Ok(())
     }
 
     /// (Android) This is a noop since we don't directly control the routes on Android.

--- a/talpid-routing/src/windows/mod.rs
+++ b/talpid-routing/src/windows/mod.rs
@@ -8,6 +8,7 @@ use futures::{
     },
 };
 pub use get_best_default_route::{InterfaceAndGateway, get_best_default_route};
+use ipnetwork::IpNetwork;
 use net::AddressFamily;
 pub use route_manager::{Callback, CallbackHandle, Route, RouteManagerInternal};
 use std::{collections::HashSet, io, net::IpAddr};
@@ -107,6 +108,8 @@ pub enum RouteManagerCommand {
     AddRoutes(HashSet<RequiredRoute>, oneshot::Sender<Result<()>>),
     GetMtuForRoute(IpAddr, oneshot::Sender<Result<u16>>),
     ClearRoutes,
+    /// Remove applied routes whose destination is one of these networks.
+    RemoveRoutes(HashSet<IpNetwork>),
     RegisterDefaultRouteChangeCallback(Callback, oneshot::Sender<CallbackHandle>),
     Shutdown(oneshot::Sender<()>),
 }
@@ -172,6 +175,14 @@ impl RouteManagerHandle {
             .map_err(|_| Error::RouteManagerDown)
     }
 
+    /// Removes the routes previously applied in [`RouteManagerInternal::add_routes`] whose
+    /// destination is one of `destinations`.
+    pub fn remove_routes(&self, destinations: HashSet<IpNetwork>) -> Result<()> {
+        self.tx
+            .unbounded_send(RouteManagerCommand::RemoveRoutes(destinations))
+            .map_err(|_| Error::RouteManagerDown)
+    }
+
     async fn run(
         mut manage_rx: UnboundedReceiver<RouteManagerCommand>,
         mut internal: RouteManagerInternal,
@@ -212,6 +223,10 @@ impl RouteManagerHandle {
                     log::error!("{}", e.display_chain_with_msg("Could not clear routes"));
                 }
                 RouteManagerCommand::ClearRoutes => {}
+                RouteManagerCommand::RemoveRoutes(destinations) => {
+                    log::debug!("Removing routes to: {destinations:?}");
+                    internal.delete_applied_routes_to(&destinations);
+                }
                 RouteManagerCommand::RegisterDefaultRouteChangeCallback(callback, tx) => {
                     let _ = tx.send(internal.register_default_route_changed_callback(callback));
                 }

--- a/talpid-routing/src/windows/route_manager.rs
+++ b/talpid-routing/src/windows/route_manager.rs
@@ -6,7 +6,7 @@ use super::{
 use crate::NetNode;
 use ipnetwork::IpNetwork;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     io,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::{Arc, Mutex},
@@ -436,6 +436,30 @@ impl RouteManagerInternal {
 
         routes.clear();
         Ok(())
+    }
+
+    /// Delete all applied routes whose destination is one of `destinations`.
+    ///
+    /// Routes that could not be deleted are kept, so that they are attempted again by
+    /// [`Self::delete_applied_routes`].
+    pub fn delete_applied_routes_to(&mut self, destinations: &HashSet<Network>) {
+        let mut routes = self.routes.lock().unwrap();
+
+        routes.retain(|record| {
+            if !destinations.contains(&record.registered_route.network) {
+                return true;
+            }
+            match Self::delete_from_routing_table(&record.registered_route) {
+                Ok(()) => false,
+                Err(error) => {
+                    log::error!(
+                        "Failed to delete route {}: {error}",
+                        record.registered_route
+                    );
+                    true
+                }
+            }
+        });
     }
 
     pub fn register_default_route_changed_callback(&self, callback: Callback) -> CallbackHandle {

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -7,6 +7,8 @@ use self::config::Config;
 use futures::channel::mpsc;
 use futures::future::Future;
 use obfuscation::ObfuscatorHandle;
+#[cfg(all(not(target_os = "android"), not(target_os = "linux")))]
+use std::collections::HashSet;
 use std::env;
 #[cfg(windows)]
 use std::io;
@@ -18,6 +20,8 @@ use std::{
     pin::Pin,
     sync::{Arc, mpsc as sync_mpsc},
 };
+#[cfg(all(not(target_os = "android"), not(target_os = "linux")))]
+use talpid_routing::RouteManagerHandle;
 #[cfg(not(target_os = "android"))]
 use talpid_routing::{self, RequiredRoute};
 use talpid_tunnel::{
@@ -27,6 +31,8 @@ use talpid_tunnel::{IPV4_HEADER_SIZE, IPV6_HEADER_SIZE, WIREGUARD_HEADER_SIZE};
 use tunnel_obfuscation::multiplexer::Transport;
 
 use talpid_tunnel_config_client::DaitaSettings;
+#[cfg(all(not(target_os = "android"), not(target_os = "linux")))]
+use talpid_types::net::obfuscation::Obfuscators;
 use talpid_types::{
     BoxedError, ErrorExt,
     net::{AllowedTunnelTraffic, Endpoint, TransportProtocol, wireguard::TunnelParameters},
@@ -390,6 +396,21 @@ impl WireguardMonitor {
             let selected_obfuscation = selected_obfuscation(&obfuscator)
                 .await
                 .map_err(CloseMsg::SetupError)?;
+
+            #[cfg(not(target_os = "linux"))]
+            if let Some(selected_addr) = selected_obfuscation
+                .as_ref()
+                .and_then(|selected| selected_endpoint_addr(selected, &config))
+            {
+                // Remove routes for candidate endpoints (used by multiplexer)
+                // Not applicable on Linux since we use policy-based routing (via fwmark).
+                Self::remove_unused_endpoint_routes(
+                    &args.route_manager,
+                    &endpoint_addrs,
+                    selected_addr,
+                );
+            }
+
             event_hook
                 .on_event(TunnelEvent::Up {
                     metadata,
@@ -822,6 +843,36 @@ impl WireguardMonitor {
         })
     }
 
+    /// Remove the routes for every endpoint but `selected_addr`.
+    ///
+    /// While connecting, the tunnel may reach out to any of the candidate endpoints, so all of
+    /// them need a route outside of the tunnel. Only the selected one is used from here on.
+    #[cfg(all(not(target_os = "android"), not(target_os = "linux")))]
+    fn remove_unused_endpoint_routes(
+        route_manager: &RouteManagerHandle,
+        endpoint_addrs: &[IpAddr],
+        selected_addr: IpAddr,
+    ) {
+        let unused: HashSet<ipnetwork::IpNetwork> = endpoint_addrs
+            .iter()
+            .copied()
+            .filter(|addr| *addr != selected_addr)
+            .map(ipnetwork::IpNetwork::from)
+            .collect();
+
+        if unused.is_empty() {
+            return;
+        }
+
+        // Failing to remove these is not fatal. The firewall blocks them either way.
+        if let Err(error) = route_manager.remove_routes(unused) {
+            log::warn!(
+                "{}",
+                error.display_chain_with_msg("Failed to remove unused endpoint routes")
+            );
+        }
+    }
+
     #[cfg_attr(not(target_os = "windows"), expect(unused_variables))]
     #[cfg(not(target_os = "android"))]
     fn get_tunnel_nodes(
@@ -997,6 +1048,21 @@ async fn selected_obfuscation(
 
     log::debug!("Selected obfuscation: {selected:?}");
     Ok(Some(selected))
+}
+
+/// Return the address of the remote endpoint that `selected` connects to, if it is known.
+///
+/// [`SelectedObfuscation::Direct`] carries no address of its own: it refers to the direct
+/// transport of the multiplexer, whose endpoint is the relay itself.
+#[cfg(all(not(target_os = "android"), not(target_os = "linux")))]
+fn selected_endpoint_addr(selected: &SelectedObfuscation, config: &Config) -> Option<IpAddr> {
+    match selected {
+        SelectedObfuscation::Obfuscated(obfuscator) => Some(obfuscator.endpoint().address.ip()),
+        SelectedObfuscation::Direct => match config.obfuscator_config.as_ref()? {
+            Obfuscators::Multiplexer { direct, .. } => Some(direct.as_ref()?.ip()),
+            Obfuscators::Single(_) => None,
+        },
+    }
 }
 
 fn get_obfuscator(


### PR DESCRIPTION
Basically, remove routes to unused endpoints when entering the connected state.

See also #10889

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10890)
<!-- Reviewable:end -->
