### PR TITLE
Ensure UITests waiting a long time does not hit an arbitrary threshold

### DIFF
--- a/ios/MullvadVPNUITests/XCUIElement+Extensions.swift
+++ b/ios/MullvadVPNUITests/XCUIElement+Extensions.swift
@@ -142,11 +142,22 @@ extension XCUIElement {
         // 10 sec * 3 tries + 2 sec + 2 sec ^ 2 = 36
         case longerThanMullvadAPITimeout = 37
         case extremelyLong = 180
-    }
 
-    private struct PredicatePollerDefaults {
-        static let pollInterval = 0.2
-        static let maxIterations = 100
+        var pollInterval: TimeInterval {
+            switch self {
+            case .short, .default, .long, .veryLong: 0.2
+            case .longerThanMullvadAPITimeout: 0.5
+            case .extremelyLong: 1
+            }
+        }
+
+        var maxIterations: Int {
+            switch self {
+            case .short, .default, .long, .veryLong, .longerThanMullvadAPITimeout: 100
+            // 1 check per second for 180 seconds < 200
+            case .extremelyLong: 200
+            }
+        }
     }
 
     // This function actively polls the hierarchy on a set interval. This speeds up the waiting process
@@ -168,7 +179,7 @@ extension XCUIElement {
 
         while Date() < timeoutDate {
             iterationCount += 1
-            if iterationCount > PredicatePollerDefaults.maxIterations {
+            if iterationCount > timeout.maxIterations {
                 return false
             }
 
@@ -177,7 +188,7 @@ extension XCUIElement {
                 return true
             }
 
-            RunLoop.current.run(until: Date().addingTimeInterval(PredicatePollerDefaults.pollInterval))
+            RunLoop.current.run(until: Date().addingTimeInterval(timeout.pollInterval))
         }
 
         return false


### PR DESCRIPTION
This PR guarantees that when waiting on a long timeout, UITests do not run out of retries.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10893)
<!-- Reviewable:end -->
