### PR TITLE
Add information about which YubiKey the pin is for

### DIFF
--- a/ci/android/build-server/run.sh
+++ b/ci/android/build-server/run.sh
@@ -42,6 +42,7 @@ if [[ ! -d "$UPLOAD_DIR" ]]; then
 fi
 
 if [[ "$ENABLE_SIGNING" == "true" && -z ${YUBIKEY_PIN-} ]]; then
+    echo "Please enter the pin for the android-release.keystore YubiKey."
     read -rsp "YUBIKEY_PIN = " YUBIKEY_PIN
     echo ""
     export YUBIKEY_PIN


### PR DESCRIPTION
This PR clarifies which YubiKey pin is needed when starting the Android app build script on the build-server.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10906)
<!-- Reviewable:end -->
