### PR TITLE
Add Debian GUI runtime dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Line wrap the file at 100 chars.                                              Th
 - Stop embedding a `dpkg-sig` signature in `.deb` packages. apt verifies the signature on the
   repository, not one inside the package, and the tool making these signatures has been removed
   from Debian. `.rpm` packages are still signed, since dnf does verify that signature.
+- Add missing GUI runtime dependencies to Debian packages.
 
 #### Windows
 - Make the timestamps embedded in the Rust Windows binaries + winfw.dll deterministic.

--- a/desktop/packages/mullvad-vpn/tasks/distribution.cjs
+++ b/desktop/packages/mullvad-vpn/tasks/distribution.cjs
@@ -192,8 +192,8 @@ function newConfig() {
     },
 
     deb: {
+      depends: ['libgtk-3-0', 'libnss3', 'libasound2', 'libgbm1'],
       fpm: [
-        '--no-depends',
         '--version',
         getLinuxVersion(),
         '--before-install',


### PR DESCRIPTION
The Debian package currently declares no required dependencies. This usually works because the libraries are already installed on desktop systems, but the GUI fails to start on minimal systems when one is missing.

This adds the four direct runtime dependencies confirmed through leave-one-out testing: `libgtk-3-0`, `libnss3`, `libasound2`, and `libgbm1`.

To reproduce, install the current package with `--no-install-recommends` in a minimal Debian VM/container and launch the GUI. The patched package was tested the same way on Debian 13 using Xvfb.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10913)
<!-- Reviewable:end -->
