### PR TITLE
Add support for getting and clearing migrations

### DIFF
--- a/desktop/packages/mullvad-vpn/src/main/daemon-rpc.ts
+++ b/desktop/packages/mullvad-vpn/src/main/daemon-rpc.ts
@@ -28,6 +28,7 @@ import {
   NewCustomList,
   ObfuscationSettings,
   RelaySettings,
+  type SettingsMigration,
   type ShadowsocksCipher,
   TunnelState,
   VoucherResponse,
@@ -41,6 +42,7 @@ import {
   convertFromDevice,
   convertFromDeviceState,
   convertFromGrpcShadowsocksCiphers,
+  convertFromMigrationEvent,
   convertFromRelayList,
   convertFromSettings,
   convertFromTunnelState,
@@ -363,6 +365,14 @@ export class DaemonRpc extends GrpcClient<ManagementServiceClient> {
   public async getSettings(): Promise<ISettings> {
     const response = await this.callEmpty<grpcTypes.Settings>(this.client.getSettings);
     return convertFromSettings(response)!;
+  }
+
+  public async getSettingsMigrations(): Promise<SettingsMigration[]> {
+    const response = await this.callEmpty<grpcTypes.SplitFilterMigration>(
+      this.client.getMigrationEvent,
+    );
+    const migrations = convertFromMigrationEvent(response);
+    return migrations;
   }
 
   public async getAccountHistory(): Promise<AccountNumber | undefined> {

--- a/desktop/packages/mullvad-vpn/src/main/daemon-rpc.ts
+++ b/desktop/packages/mullvad-vpn/src/main/daemon-rpc.ts
@@ -375,6 +375,10 @@ export class DaemonRpc extends GrpcClient<ManagementServiceClient> {
     return migrations;
   }
 
+  public async clearSettingsMigrations(): Promise<void> {
+    await this.callEmpty(this.client.clearMigrationMessage);
+  }
+
   public async getAccountHistory(): Promise<AccountNumber | undefined> {
     const response = await this.callEmpty<grpcTypes.AccountHistory>(this.client.getAccountHistory);
     return response.getNumber()?.getValue();

--- a/desktop/packages/mullvad-vpn/src/main/grpc-type-convertions.ts
+++ b/desktop/packages/mullvad-vpn/src/main/grpc-type-convertions.ts
@@ -53,8 +53,10 @@ import {
   RelayLocationGeographical,
   RelayProtocol,
   RelaySettings,
+  type SettingsMigration,
   type ShadowsocksCipher,
   SocksAuth,
+  type SplitFilterMigrationScenario,
   TunnelParameterError,
   TunnelState,
   wrapConstraint,
@@ -456,6 +458,61 @@ export function convertFromSettings(settings: grpcTypes.Settings): ISettings | u
     relayOverrides,
     recents,
   };
+}
+
+export function convertFromMigrationEvent(
+  splitFilterMigration: grpcTypes.SplitFilterMigration,
+): SettingsMigration[] {
+  // We need to check `hasScenario` since `getScenario()` will return 0 if the scenario is not set,
+  // which is a valid value for the enum.
+  const scenario = splitFilterMigration.hasScenario()
+    ? splitFilterMigration.getScenario()
+    : undefined;
+
+  if (scenario === undefined) {
+    return [];
+  }
+  return [
+    {
+      type: 'split-filter',
+      scenario: convertFromSplitFilterMigrationScenario(scenario),
+    },
+  ];
+}
+
+function convertFromSplitFilterMigrationScenario(
+  scenario: grpcTypes.SplitFilterMigration.Scenario,
+): SplitFilterMigrationScenario {
+  switch (scenario) {
+    case grpcTypes.SplitFilterMigration.Scenario.ONEA:
+      return 'one-a';
+    case grpcTypes.SplitFilterMigration.Scenario.ONEB:
+      return 'one-b';
+    case grpcTypes.SplitFilterMigration.Scenario.TWO:
+      return 'two';
+    case grpcTypes.SplitFilterMigration.Scenario.THREEA:
+      return 'three-a';
+    case grpcTypes.SplitFilterMigration.Scenario.THREEB:
+      return 'three-b';
+    case grpcTypes.SplitFilterMigration.Scenario.FOURA:
+      return 'four-a';
+    case grpcTypes.SplitFilterMigration.Scenario.FOURB:
+      return 'four-b';
+    case grpcTypes.SplitFilterMigration.Scenario.FIVEA:
+      return 'five-a';
+    case grpcTypes.SplitFilterMigration.Scenario.FIVEB:
+      return 'five-b';
+    case grpcTypes.SplitFilterMigration.Scenario.SIXA:
+      return 'six-a';
+    case grpcTypes.SplitFilterMigration.Scenario.SIXB:
+      return 'six-b';
+    case grpcTypes.SplitFilterMigration.Scenario.SEVENA:
+      return 'seven-a';
+    case grpcTypes.SplitFilterMigration.Scenario.SEVENB:
+      return 'seven-b';
+    default:
+      return scenario satisfies never;
+  }
 }
 
 function convertFromRecents(recents: grpcTypes.Recents | undefined): Recents | undefined {

--- a/desktop/packages/mullvad-vpn/src/main/index.ts
+++ b/desktop/packages/mullvad-vpn/src/main/index.ts
@@ -19,6 +19,7 @@ import {
   ErrorStateCause,
   IRelayListWithEndpointData,
   ISettings,
+  type SettingsMigration,
   type ShadowsocksCipher,
   TunnelState,
 } from '../shared/daemon-rpc-types';
@@ -135,6 +136,8 @@ class ApplicationMain
   private navigationHistory?: IHistoryObject;
 
   private relayList?: IRelayListWithEndpointData;
+
+  private migrations?: SettingsMigration[];
 
   private currentApiAccessMethod?: AccessMethodSetting;
 
@@ -667,6 +670,16 @@ class ApplicationMain
       return this.handleBootstrapError(error);
     }
 
+    // fetch settings migrations
+    try {
+      this.migrations = await this.daemonRpc.getSettingsMigrations();
+    } catch (e) {
+      const error = e as Error;
+      log.error(`Failed to fetch settings migrations: ${error.message}`);
+
+      return this.handleBootstrapError(error);
+    }
+
     // fetch the daemon's version
     try {
       this.version.setDaemonVersion(await this.daemonRpc.getCurrentVersion());
@@ -865,6 +878,7 @@ class ApplicationMain
       relayList: this.relayList,
       currentVersion: this.version.currentVersion,
       upgradeVersion: this.version.upgradeVersion,
+      migrations: this.migrations ?? [],
       guiSettings: this.settings.gui.state,
       translations: this.translations,
       splitTunnelingApplications: this.splitTunnelingApplications,

--- a/desktop/packages/mullvad-vpn/src/main/settings.ts
+++ b/desktop/packages/mullvad-vpn/src/main/settings.ts
@@ -83,6 +83,12 @@ export default class Settings implements Readonly<ISettings> {
     IpcMainEventChannel.settings.handleSetEnableRecents((enabled) => {
       return this.daemonRpc.setEnableRecents(enabled);
     });
+    IpcMainEventChannel.settings.handleClearMigrations(async () => {
+      await this.daemonRpc.clearSettingsMigrations();
+
+      const migrations = await this.daemonRpc.getSettingsMigrations();
+      IpcMainEventChannel.settings.notifyMigrationsChange?.(migrations);
+    });
     IpcMainEventChannel.settings.handleImportText((text) => {
       return this.daemonRpc.applyJsonSettings(text);
     });

--- a/desktop/packages/mullvad-vpn/src/renderer/app.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/app.tsx
@@ -137,6 +137,10 @@ export default class AppRenderer {
       }
     });
 
+    IpcRendererEventChannel.settings.listenMigrationsChange((migrations) => {
+      this.reduxActions.settings.updateMigrations(migrations);
+    });
+
     IpcRendererEventChannel.daemon.listenConnected(() => {
       void this.onDaemonConnected();
     });
@@ -477,6 +481,9 @@ export default class AppRenderer {
   public clearAllRelayOverrides = () => IpcRendererEventChannel.settings.clearAllRelayOverrides();
   public setEnabledRecents = (enabled: boolean) =>
     IpcRendererEventChannel.settings.setEnableRecents(enabled);
+  public clearSettingsMigrations = () => {
+    return IpcRendererEventChannel.settings.clearMigrations();
+  };
   public getMapData = () => IpcRendererEventChannel.map.getData();
   public setAnimateMap = (displayMap: boolean): void =>
     IpcRendererEventChannel.guiSettings.setAnimateMap(displayMap);

--- a/desktop/packages/mullvad-vpn/src/renderer/app.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/app.tsx
@@ -32,6 +32,7 @@ import {
   NewCustomList,
   ObfuscationSettings,
   RelaySettings,
+  type SettingsMigration,
   type ShadowsocksCipher,
   TunnelState,
 } from '../shared/daemon-rpc-types';
@@ -332,6 +333,7 @@ export default class AppRenderer {
     this.setRelayListPair(initialState.relayList);
     this.setCurrentVersion(initialState.currentVersion);
     this.setUpgradeVersion(initialState.upgradeVersion);
+    this.setMigrations(initialState.migrations);
     this.setGuiSettings(initialState.guiSettings);
     this.storeAutoStart(initialState.autoStart);
     this.setChangelog(initialState.changelog);
@@ -1018,6 +1020,10 @@ export default class AppRenderer {
 
   private setUpgradeVersion(upgradeVersion: IAppVersionInfo) {
     this.reduxActions.version.updateLatest(upgradeVersion);
+  }
+
+  private setMigrations(migrations: SettingsMigration[]) {
+    this.reduxActions.settings.updateMigrations(migrations);
   }
 
   private setGuiSettings(guiSettings: IGuiSettingsState) {

--- a/desktop/packages/mullvad-vpn/src/renderer/redux/settings/actions.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/redux/settings/actions.ts
@@ -8,6 +8,7 @@ import {
   ObfuscationSettings,
   type Recents,
   RelayOverride,
+  type SettingsMigration,
   type ShadowsocksCipher,
 } from '../../../shared/daemon-rpc-types';
 import { IGuiSettingsState } from '../../../shared/gui-settings-state';
@@ -133,6 +134,11 @@ export interface ISetRecents {
   recents?: Recents;
 }
 
+export interface ISetMigrations {
+  type: 'SET_MIGRATIONS';
+  migrations: SettingsMigration[];
+}
+
 export type SettingsAction =
   | IUpdateGuiSettingsAction
   | IUpdateRelayAction
@@ -154,6 +160,7 @@ export type SettingsAction =
   | ISetObfuscationSettings
   | ISetCustomLists
   | ISetRecents
+  | ISetMigrations
   | ISetApiAccessMethods
   | ISetCurrentApiAccessMethod
   | ISetRelayOverrides
@@ -332,6 +339,13 @@ function updateRecents(recents?: Recents): ISetRecents {
   };
 }
 
+function updateMigrations(migrations: SettingsMigration[]): ISetMigrations {
+  return {
+    type: 'SET_MIGRATIONS',
+    migrations,
+  };
+}
+
 function updateShadowsocksCiphers(ciphers: ShadowsocksCipher[]): ISetShadowsocksCiphers {
   return {
     type: 'SET_SHADOWSOCKS_CIPHERS',
@@ -363,5 +377,6 @@ export default {
   updateCurrentApiAccessMethod,
   updateRelayOverrides,
   updateRecents,
+  updateMigrations,
   updateShadowsocksCiphers,
 };

--- a/desktop/packages/mullvad-vpn/src/renderer/redux/settings/reducers.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/redux/settings/reducers.ts
@@ -17,6 +17,7 @@ import {
   RelayLocation,
   RelayOverride,
   RelayProtocol,
+  type SettingsMigration,
   type ShadowsocksCipher,
 } from '../../../shared/daemon-rpc-types';
 import { IGuiSettingsState } from '../../../shared/gui-settings-state';
@@ -104,6 +105,7 @@ export interface ISettingsReduxState {
   obfuscationSettings: ObfuscationSettings;
   customLists: CustomLists;
   recents?: Recents;
+  migrations: SettingsMigration[];
   apiAccessMethods: ApiAccessMethodSettings;
   currentApiAccessMethod?: AccessMethodSetting;
   relayOverrides: Array<RelayOverride>;
@@ -192,6 +194,7 @@ const initialState: ISettingsReduxState = {
   },
   customLists: [],
   recents: undefined,
+  migrations: [],
   apiAccessMethods: getDefaultApiAccessMethods(),
   currentApiAccessMethod: undefined,
   relayOverrides: [],
@@ -329,6 +332,12 @@ export default function (
       return {
         ...state,
         recents: action.recents,
+      };
+
+    case 'SET_MIGRATIONS':
+      return {
+        ...state,
+        migrations: action.migrations,
       };
 
     case 'SET_API_ACCESS_METHODS':

--- a/desktop/packages/mullvad-vpn/src/shared/daemon-rpc-types.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/daemon-rpc-types.ts
@@ -446,6 +446,29 @@ export interface IDeviceRemoval {
 
 export type CustomLists = Array<ICustomList>;
 
+// Extend with new event types as needed.
+export type SettingsMigration = SplitFilterMigrationEvent;
+
+export type SplitFilterMigrationScenario =
+  | 'one-a'
+  | 'one-b'
+  | 'two'
+  | 'three-a'
+  | 'three-b'
+  | 'four-a'
+  | 'four-b'
+  | 'five-a'
+  | 'five-b'
+  | 'six-a'
+  | 'six-b'
+  | 'seven-a'
+  | 'seven-b';
+
+export type SplitFilterMigrationEvent = {
+  type: 'split-filter';
+  scenario: SplitFilterMigrationScenario;
+};
+
 export type Recents = {
   entries: RelayLocation[];
   exits: RelayLocation[];

--- a/desktop/packages/mullvad-vpn/src/shared/ipc-schema.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/ipc-schema.ts
@@ -216,6 +216,8 @@ export const ipcSchema = {
     clearAllRelayOverrides: invoke<void, void>(),
     setEnableDaita: invoke<boolean, void>(),
     setEnableRecents: invoke<boolean, void>(),
+    migrationsChange: notifyRenderer<SettingsMigration[]>(),
+    clearMigrations: invoke<void, void>(),
   },
   guiSettings: {
     '': notifyRenderer<IGuiSettingsState>(),

--- a/desktop/packages/mullvad-vpn/src/shared/ipc-schema.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/ipc-schema.ts
@@ -26,6 +26,7 @@ import {
   NewCustomList,
   ObfuscationSettings,
   RelaySettings,
+  type SettingsMigration,
   type ShadowsocksCipher,
   TunnelState,
   VoucherResponse,
@@ -75,6 +76,7 @@ export interface IAppStateSnapshot {
   relayList?: IRelayListWithEndpointData;
   currentVersion: ICurrentAppVersionInfo;
   upgradeVersion: IAppVersionInfo;
+  migrations: SettingsMigration[];
   guiSettings: IGuiSettingsState;
   translations: ITranslations;
   splitTunnelingApplications?: ISplitTunnelingApplication[];

--- a/desktop/packages/mullvad-vpn/test/e2e/setup/main.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/setup/main.ts
@@ -143,6 +143,7 @@ class ApplicationMain {
       splitTunnelingApplications: [],
       macOsScrollbarVisibility: MacOsScrollbarVisibility.whenScrolling,
       changelog: [],
+      migrations: [],
       navigationHistory: undefined,
       scrollPositions: {},
       isMacOs13OrNewer: true,


### PR DESCRIPTION
Adds support for fetching and clearing settings migrations.

Fixes DES-3051

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10919)
<!-- Reviewable:end -->
