### PR TITLE
Fix crash when trying to scroll to the bottom of the DNS Screen

### DIFF
--- a/android/lib/feature/dns/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/dns/impl/DnsSettingsScreen.kt
+++ b/android/lib/feature/dns/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/dns/impl/DnsSettingsScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.compose.dropUnlessResumed
+import kotlinx.coroutines.android.awaitFrame
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.core.LocalResultStore
 import net.mullvad.mullvadvpn.core.Navigator
@@ -270,7 +271,19 @@ private fun Content(
 
     LaunchedEffect(state.customDnsEnabled) {
         if (state.customDnsEnabled) {
-            lazyListState.requestScrollToItem(lazyListState.layoutInfo.totalItemsCount - 1)
+            // This added so that the list state has time to update the totalItemsCount before
+            // scrolling to the last item.
+            // It is not guaranteed that the item count is correct after this, but theoretically it
+            // should help.
+            awaitFrame()
+
+            // Attempt to scroll to the last item in the list, if the list is not laid out yet
+            // (i.e. totalItemsCount = 0), then we will just let the user enter the screen at the
+            // top.
+            val lastIndex = lazyListState.layoutInfo.totalItemsCount - 1
+            if (lastIndex >= 0) {
+                lazyListState.requestScrollToItem(lastIndex)
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes the crash, but since I can not replicate the crash on a device, it is unclear if it is scrolled to the bottom on these devices.

An attempt was make it more likely that the scroll is made, but again I have not been able to confirm that it helps.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10920)
<!-- Reviewable:end -->
