### PR TITLE
Add env var for setting lockdown mode on corrupted settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Add explicit log levels for `mullvad log set-level` command: `off`, `error`, `warn`, `info`,
   `debug` and `trace`.
+- Add support for the `MULLVAD_LOCKDOWN_ON_INVALID_SETTINGS` environment variable. Set it to false
+  to _disable_ the lockdown mode fallback if the settings file fails to parse and is reset.
 
 ### Changed
 - Update LWO to improved v2 protocol.

--- a/mullvad-daemon/src/settings/mod.rs
+++ b/mullvad-daemon/src/settings/mod.rs
@@ -115,6 +115,21 @@ fn handle_custom_list_error(
 type ChangeListener =
     Box<dyn FnMut(&Settings) -> Pin<Box<dyn Future<Output = ()> + Send + Sync>> + Send + Sync>;
 
+/// Whether the daemon should enable lockdown mode as a safety measure if
+/// it fails to parse the settings file. Defaults to true.
+///
+/// Setting the `MULLVAD_LOCKDOWN_ON_INVALID_SETTINGS` environment
+/// variable to `false` disables the fallback, causing the daemon to disconnect
+/// and leak. As we do not support downgrading settings to older formats,
+/// this can be useful for developers that frequently run different builds.
+static LOCKDOWN_ON_INVALID_SETTINGS: std::sync::LazyLock<bool> =
+    std::sync::LazyLock::new(
+        || match std::env::var("MULLVAD_LOCKDOWN_ON_INVALID_SETTINGS") {
+            Ok(value) => value != "false" && value != "0",
+            Err(_) => true,
+        },
+    );
+
 pub struct SettingsPersister {
     settings: Settings,
     path: PathBuf,
@@ -185,18 +200,23 @@ impl SettingsPersister {
             }
             Err(error) => {
                 log::warn!(
-                    "{}",
-                    error.display_chain_with_msg("Failed to load settings. Using defaults.")
+                    "Failed to parse settings. Resetting to default. {}",
+                    error.display_chain()
                 );
 
-                let settings = Settings {
-                    // Protect the user by blocking the internet by default. Previous settings may
-                    // not have caused the daemon to enter the non-blocking disconnected state.
-                    // On android lockdown mode is handled by the OS so setting this to true
-                    // has no effect.
-                    #[cfg(not(target_os = "android"))]
-                    lockdown_mode: true,
-                    ..Self::default_settings()
+                let settings = if *LOCKDOWN_ON_INVALID_SETTINGS {
+                    log::warn!("Enabling lockdown mode as a safety measure");
+                    Settings {
+                        // Protect the user by blocking the internet by default. Previous settings
+                        // may not have caused the daemon to enter the non-blocking disconnected
+                        // state. On android lockdown mode is handled by the OS so setting this to
+                        // true has no effect.
+                        #[cfg(not(target_os = "android"))]
+                        lockdown_mode: true,
+                        ..Self::default_settings()
+                    }
+                } else {
+                    Self::default_settings()
                 };
 
                 LoadSettingsResult {
@@ -227,8 +247,7 @@ impl SettingsPersister {
         let settings_bytes = fs::read(path)
             .await
             .map_err(|error| Error::ReadError(display.as_ref().display().to_string(), error))?;
-        let settings = Self::load_from_bytes(&settings_bytes)?;
-        Ok(settings)
+        Self::load_from_bytes(&settings_bytes)
     }
 
     fn load_from_bytes(bytes: &[u8]) -> Result<Settings, Error> {


### PR DESCRIPTION
Add `MULLVAD_LOCKDOWN_ON_INVALID_SETTINGS` environment variable.

When settings fail to parse, don't enable `lockdown_mode` if the new env var has been set to `false` or `0` (it defaults to true). We automatically migrate the user settings to newer formats, but we do not support downgrades. Thus, if you run a development version and then revert to a stable version, you were very likely to get put into the blocked state. This is a debug feature intended for developers to set globally on their system, to make downgrading app versions more convenient.

Fixes DES-3173.
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10921)
<!-- Reviewable:end -->
