### PR TITLE
Remove cosmetic spacing elements from accessibility

### DIFF
--- a/ios/MullvadVPN/View controllers/SelectLocation/Views/AutomaticLocationListItem.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/Views/AutomaticLocationListItem.swift
@@ -17,7 +17,7 @@ struct AutomaticLocationListItem: View {
     let onSelect: (LocationNode) -> Void
 
     var body: some View {
-        Color.clear.frame(height: 4)
+        Color.clear.frame(height: 4).accessibilityHidden(true)
 
         SegmentedListItem(
             accessibilityIdentifier: isRecent ? .recentListItem(location.name) : .locationListItem(location.name),

--- a/ios/MullvadVPN/View controllers/SelectLocation/Views/ExitLocationView.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/Views/ExitLocationView.swift
@@ -137,7 +137,7 @@ struct ExitLocationView<ViewModel: SelectLocationViewModel>: View {
                 // RecentLocationsListView cannot be put in a container since the context menu
                 // will group the individual locations as well. Therefore adding padding in this
                 // convoluted way.
-                Spacer(minLength: 24)
+                Spacer(minLength: 24).accessibilityHidden(true)
             } else {
                 MullvadListSectionFooter(title: "No recent selection history")
                     .padding(.horizontal, context.recents.isEmpty ? 0 : 16)

--- a/ios/MullvadVPN/View controllers/SelectLocation/Views/LocationListItem.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/Views/LocationListItem.swift
@@ -35,7 +35,7 @@ struct LocationListItem<ContextMenu>: View where ContextMenu: View {
         let isCustomList = location.asCustomListNode != nil
 
         if level == 0 {
-            Color.clear.frame(height: 4)
+            Color.clear.frame(height: 4).accessibilityHidden(true)
         }
 
         SegmentedListItem(

--- a/ios/MullvadVPN/View controllers/SelectLocation/Views/RecentLocationListItem.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/Views/RecentLocationListItem.swift
@@ -28,7 +28,7 @@ struct RecentLocationListItem<ContextMenu>: View where ContextMenu: View {
 
     @ViewBuilder
     var recentLocationListItem: some View {
-        Color.clear.frame(height: 4)
+        Color.clear.frame(height: 4).accessibilityHidden(true)
 
         SegmentedListItem(
             userInteraction: location.isExcluded ? .disabled : .enabled,


### PR DESCRIPTION
For some reason, Accessibility was deciding that `Color.clear` and `Spacer` elements were of interest to the user. This explicitly tells it that they are not.
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10923)
<!-- Reviewable:end -->
