### PR TITLE
Simplify select location view and fix filter pills animation bug

### DIFF
--- a/ios/MullvadVPN/View controllers/SelectLocation/Views/SelectLocationView.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/Views/SelectLocationView.swift
@@ -4,8 +4,7 @@ import SwiftUI
 
 struct SelectLocationView<ViewModel>: View where ViewModel: SelectLocationViewModel {
     @ObservedObject var viewModel: ViewModel
-    @State private var headerIsExpandedForEntry: Bool = false
-    @State private var headerIsExpandedForExit: Bool = false
+    @State private var isScrolledToTop: Bool = true
     @State private var disablingRecentConnectionsAlert: MullvadAlert?
     @State private var multihopWarningAlert: MullvadAlert?
     @FocusState private var focusSearchField: Bool
@@ -17,9 +16,9 @@ struct SelectLocationView<ViewModel>: View where ViewModel: SelectLocationViewMo
     private var headerIsExpanded: Bool {
         switch viewModel.multihopContext {
         case .entry:
-            viewModel.showMultihopInfo || headerIsExpandedForEntry
+            viewModel.showMultihopInfo || isScrolledToTop
         case .exit:
-            headerIsExpandedForExit
+            isScrolledToTop
         }
     }
 
@@ -28,119 +27,105 @@ struct SelectLocationView<ViewModel>: View where ViewModel: SelectLocationViewMo
     }
 
     var body: some View {
-        // Simply animating the MultihopSelectionView while scrolling leads to a slow
-        // down of the scrolling during the animation. Instead of changing the size of the scroll
-        // view, the top margin of the content is changed which solves the animation issues.
-        ZStack(alignment: .topLeading) {
-            VStack(spacing: 0) {
-                MultihopSelectionView(
-                    hops: (viewModel.isMultihopActive ? MultihopContext.allCases : [MultihopContext.exit])
-                        .map {
-                            var selectedLocation: LocationNode?
-                            var filterCount = 0
-                            switch $0 {
-                            case .entry:
-                                selectedLocation =
-                                    viewModel.showMultihopInfo
-                                    ? AutomaticLocationNode(
-                                        locationInfo: (viewModel.connectedEntryLocation.flatMap {
-                                            [$0.country]
-                                        }) ?? []
-                                    )
-                                    : viewModel.entryContext.selectedLocation
-                                filterCount = viewModel.entryContext.filter.count
-                            case .exit:
-                                selectedLocation = viewModel.exitContext.selectedLocation
-                                filterCount = viewModel.exitContext.filter.count
-                            }
-                            return Hop(
-                                multihopContext: $0,
-                                multihopState: viewModel.multihopState,
-                                selectedLocation: selectedLocation,
-                                filterCount: filterCount
-                            )
-                        },
-                    selectedMultihopContext: $viewModel.multihopContext,
-                    isExpanded: headerIsExpanded,
-                    onFilterTapped: {
-                        viewModel.showFilterView(context: $0)
-                    }
-                )
-                .padding(.horizontal, 16)
-                if headerIsExpanded {
-                    VStack {
-                        if !viewModel.visibleFilterChips.isEmpty {
-                            Spacer().frame(height: 16)
+        VStack(spacing: 0) {
+            // Eventhough the location list is not in the top,
+            // the navigation bar would changes appearence when the list gets scrolled.
+            // (see UINavigationBar+Appearance.swift)
+            // Adding an empty scroll view on top prevents that.
+            ScrollView {}.frame(height: 0)
+
+            MultihopSelectionView(
+                hops: (viewModel.isMultihopActive ? MultihopContext.allCases : [MultihopContext.exit])
+                    .map {
+                        var selectedLocation: LocationNode?
+                        var filterCount = 0
+                        switch $0 {
+                        case .entry:
+                            selectedLocation =
+                                viewModel.showMultihopInfo
+                                ? AutomaticLocationNode(
+                                    locationInfo: (viewModel.connectedEntryLocation.flatMap {
+                                        [$0.country]
+                                    }) ?? []
+                                )
+                                : viewModel.entryContext.selectedLocation
+                            filterCount = viewModel.entryContext.filter.count
+                        case .exit:
+                            selectedLocation = viewModel.exitContext.selectedLocation
+                            filterCount = viewModel.exitContext.filter.count
                         }
-                        if viewModel.multihopContext == .entry {
-                            activeFilterView(locationContext: viewModel.entryContext, transition: .move(edge: .leading))
-                        } else {
-                            activeFilterView(locationContext: viewModel.exitContext, transition: .move(edge: .trailing))
-                        }
-                    }
-                    .transition(
-                        .topSlide.combined(with: .opacity)
-                    )
+                        return Hop(
+                            multihopContext: $0,
+                            multihopState: viewModel.multihopState,
+                            selectedLocation: selectedLocation,
+                            filterCount: filterCount
+                        )
+                    },
+                selectedMultihopContext: $viewModel.multihopContext,
+                isExpanded: headerIsExpanded,
+                onFilterTapped: {
+                    viewModel.showFilterView(context: $0)
                 }
-            }
+            )
+            .padding(.horizontal, 16)
             .padding(.vertical, 8)
-            .background(Color.mullvadDarkBackground)
-            .zIndex(1)
-            .sizeOfView { size in
-                withAnimation {
-                    headerHeight = size.height
-                }
-            }
-            VStack {
-                // Prevent scroll content from touching navigation bar to avoid a change of appearence
-                // see `UINavigationBar+Appearance.swift`
-                Spacer()
-                    .frame(height: 1)
-                Group {
-                    switch viewModel.multihopContext {
-                    case .exit:
+
+            Group {
+                switch viewModel.multihopContext {
+                case .exit:
+                    VStack {
+                        if !viewModel.exitContext.filter.isEmpty && headerIsExpanded {
+                            activeFilterView(
+                                locationContext: viewModel.exitContext
+                            )
+                        }
                         ExitLocationView(
                             viewModel: viewModel,
                             context: $viewModel.exitContext,
                             onScrollVisibilityChange: {
                                 expandHeader in
-                                withAnimation {
-                                    headerIsExpandedForExit = expandHeader
+                                if viewModel.multihopContext == .exit {
+                                    withAnimation {
+                                        isScrolledToTop = expandHeader
+                                    }
                                 }
                             }
                         )
-                        .transition(
-                            .move(edge: .trailing).combined(with: .opacity)
-                        )
-                    case .entry:
+                        .contentMargins(.bottom, showSearchField ? floatingBarHeight + listBottomInset : 0)
+                    }
+                    .transition(.move(edge: .trailing).combined(with: .opacity))
+                case .entry:
+                    VStack {
+                        if !viewModel.entryContext.filter.isEmpty && headerIsExpanded {
+                            activeFilterView(
+                                locationContext: viewModel.entryContext
+                            )
+                        }
                         EntryLocationView(
                             viewModel: viewModel,
                             onScrollVisibilityChange: {
                                 expandHeader in
-                                withAnimation {
-                                    headerIsExpandedForEntry = expandHeader
+                                if viewModel.multihopContext == .entry {
+                                    withAnimation {
+
+                                        isScrolledToTop = expandHeader
+                                    }
+
                                 }
                             }
                         )
-                        .transition(
-                            .move(edge: .leading).combined(with: .opacity)
-                        )
+                        .contentMargins(.bottom, showSearchField ? floatingBarHeight + listBottomInset : 0)
                     }
+                    .transition(.move(edge: .leading).combined(with: .opacity))
                 }
-                .simultaneousGesture(
-                    DragGesture(minimumDistance: 50)
-                        .onChanged { _ in
-                            focusSearchField = false
-                        }
-                )
-                .environment(\.dismissSearchFocus, { focusSearchField = false })
-                .geometryGroup()
-                // Adds margin to the top of the scroll content. The scroll views size stays untouched
-                // which seems to be the solution to animation issues.
-                .contentMargins(.top, headerHeight - 1)
-                .contentMargins(.bottom, showSearchField ? floatingBarHeight + listBottomInset : 0)
-                .zIndex(0)
             }
+            .simultaneousGesture(
+                DragGesture(minimumDistance: 50)
+                    .onChanged { _ in
+                        focusSearchField = false
+                    }
+            )
+            .environment(\.dismissSearchFocus, { focusSearchField = false })
         }
         .overlay(alignment: .bottom) {
             FloatingSearchBar(
@@ -160,11 +145,6 @@ struct SelectLocationView<ViewModel>: View where ViewModel: SelectLocationViewMo
                 viewModel.searchText = ""
             }
         }
-        .animation(.default, value: isSearchExpanded)
-        .animation(.default, value: showSearchField)
-        .animation(.default, value: viewModel.multihopContext)
-        .animation(.default, value: viewModel.isMultihopActive)
-        .animation(.default, value: viewModel.isRecentsEnabled)
         .background(Color.mullvadDarkBackground)
         .navigationTitle("Select location")
         .navigationBarTitleDisplayMode(.inline)
@@ -254,7 +234,7 @@ struct SelectLocationView<ViewModel>: View where ViewModel: SelectLocationViewMo
         .mullvadAlert(item: $multihopWarningAlert)
     }
 
-    private func activeFilterView(locationContext: LocationContext, transition: AnyTransition) -> some View {
+    private func activeFilterView(locationContext: LocationContext) -> some View {
         ActiveFilterView(
             activeFilter: viewModel.visibleFilterChips,
             labelStyle: .general,
@@ -264,9 +244,8 @@ struct SelectLocationView<ViewModel>: View where ViewModel: SelectLocationViewMo
             viewModel.onFilterTapped(filter)
         } onRemove: { filter in
             viewModel.onFilterRemoved(filter)
-        }.transition(
-            transition
-        )
+        }
+        .transition(.move(edge: .top).combined(with: .opacity))
     }
 
     private func getMultihopFilterOverrideWarningAlert(newMultihopState: MultihopState) -> MullvadAlert? {


### PR DESCRIPTION
This PR simplifies the view hierarchy of the select location view and gets rid of some animation issues. Earlier required workarounds including the use of `ZStack` + `contentMargin` to make `List` behave during animations 
seem to no longer be necessary.

Tested on iOS 17, 18 and 26
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10929)
<!-- Reviewable:end -->
