### PR TITLE
Replace use of `nseventforwarder` for macOS >= 27

### DIFF
--- a/desktop/packages/mullvad-vpn/src/main/platform-version.ts
+++ b/desktop/packages/mullvad-vpn/src/main/platform-version.ts
@@ -10,6 +10,11 @@ export function isMacOs13OrNewer() {
   return process.platform === 'darwin' && major >= 22;
 }
 
+export function isMacOs27OrNewer() {
+  const [major] = parseVersion();
+  return process.platform === 'darwin' && major >= 27;
+}
+
 // Windows 11 has the internal version 10.0.22000+.
 export function isWindows11OrNewer() {
   const [major, minor, patch] = parseVersion();

--- a/desktop/packages/mullvad-vpn/src/main/user-interface.ts
+++ b/desktop/packages/mullvad-vpn/src/main/user-interface.ts
@@ -17,7 +17,7 @@ import {
   unsetIpcWebContents,
 } from './ipc-event-channel';
 import { WebContentsConsoleInput } from './logging';
-import { isMacOs11OrNewer } from './platform-version';
+import { isMacOs11OrNewer, isMacOs27OrNewer } from './platform-version';
 import { resolveBin } from './proc';
 import { createTray } from './tray';
 import TrayIconController, { TrayIconType } from './tray-icon-controller';
@@ -520,6 +520,8 @@ export default class UserInterface implements WindowControllerDelegate {
       // Detect if blur happened when user had a cursor above the tray icon.
       const trayBounds = this.tray.getBounds();
       const cursorPos = screen.getCursorScreenPoint();
+      // NOTE: This is broken, because the cursor can be on the tray icon even if blur was not
+      // caused by a click.
       const isCursorInside =
         cursorPos.x >= trayBounds.x &&
         cursorPos.y >= trayBounds.y &&
@@ -533,6 +535,10 @@ export default class UserInterface implements WindowControllerDelegate {
 
   // setup NSEvent forwarder to fix inconsistent window.blur on macOS
   // see https://github.com/electron/electron/issues/8689
+  //
+  // NOTE: The inconsistent window.blur is only present on macOS 26
+  // and below. For macOS 27 and above we do not need any special
+  // handling as the blur events fire properly.
   private async installMacOsMenubarAppWindowHandlers() {
     if (this.delegate.isUnpinnedWindow()) {
       return;
@@ -541,16 +547,38 @@ export default class UserInterface implements WindowControllerDelegate {
     const nseventforwarder = await import('nseventforwarder');
     let nseventforwarderStop: ReturnType<typeof nseventforwarder.start>;
 
-    this.windowController.window?.on(
-      'show',
-      () => (nseventforwarderStop = nseventforwarder.start(() => this.windowController.hide())),
-    );
-    this.windowController.window?.on('closed', () => nseventforwarderStop?.());
-    this.windowController.window?.on('hide', () => nseventforwarderStop?.());
+    this.windowController.window?.on('show', () => {
+      if (!isMacOs27OrNewer()) {
+        nseventforwarderStop = nseventforwarder.start(() => this.windowController.hide());
+      }
+    });
+    this.windowController.window?.on('closed', () => {
+      if (!isMacOs27OrNewer()) {
+        nseventforwarderStop?.();
+      }
+    });
+    this.windowController.window?.on('hide', () => {
+      if (isMacOs27OrNewer()) {
+        this.windowController.hide();
+      } else {
+        nseventforwarderStop?.();
+      }
+    });
     this.windowController.window?.on('blur', () => {
+      const trayBounds = this.tray.getBounds();
+      const cursorPos = screen.getCursorScreenPoint();
+      // NOTE: This is broken, because the cursor can be on the tray icon even if blur was not
+      // caused by a click.
+      const isCursorInside =
+        cursorPos.x >= trayBounds.x &&
+        cursorPos.y >= trayBounds.y &&
+        cursorPos.x <= trayBounds.x + trayBounds.width &&
+        cursorPos.y <= trayBounds.y + trayBounds.height;
+
       // Make sure to hide the menubar window when other program captures the focus if the app is unpinned.
       // But avoid hiding the window when dev tools capture the focus to make it possible to inspect the UI.
       if (
+        !isCursorInside &&
         this.windowController.window?.isVisible() &&
         !this.delegate.isUnpinnedWindow() &&
         !this.windowController.window?.webContents.isDevToolsFocused()
@@ -593,7 +621,14 @@ export default class UserInterface implements WindowControllerDelegate {
           if (event.metaKey) {
             setImmediate(() => this.windowController.updatePosition());
           } else {
-            if (isMacOs11OrNewer() && !this.windowController.isVisible()) {
+            // Show window when the tray icon is clicked.
+            //
+            // The logic to hide the window is handled in the 'blur' and 'hide' event handlers
+            // for the window controller event.
+
+            // macOS < 11 and macOS >= 27 can be shown in the same way,
+            // however macOS >= 11 and macOS <= 26 needs a workaround,
+            if (isMacOs11OrNewer() && !isMacOs27OrNewer() && !this.windowController.isVisible()) {
               // This is a workaround for this Electron issue, when it's resolved
               // `this.windowController.toggle()` should do the trick on all platforms:
               // https://github.com/electron/electron/issues/28776


### PR DESCRIPTION
Electron's native event handlers now fire properly for the blur event and we do not need the `nseventforwarder` workaround anymore.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10932)
<!-- Reviewable:end -->
