### PR TITLE
Use `windows_sys` instead of linking `iphlpapi.dll` dynamically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5917,7 +5917,6 @@ dependencies = [
  "inotify 0.10.2",
  "log",
  "nix 0.31.3",
- "once_cell",
  "parking_lot",
  "resolv-conf",
  "system-configuration",

--- a/talpid-dns/Cargo.toml
+++ b/talpid-dns/Cargo.toml
@@ -28,26 +28,23 @@ parking_lot = "0.12.0"
 system-configuration.workspace = true
 talpid-routing = { path = "../talpid-routing" }
 
-[target.'cfg(windows)'.dependencies]
-once_cell = { workspace = true }
+[target."cfg(windows)".dependencies]
 talpid-windows = { path = "../talpid-windows" }
 windows-registry = { workspace = true }
 windows-result = { workspace = true }
 
-[target.'cfg(windows)'.dependencies.windows-sys]
+[target."cfg(windows)".dependencies.windows-sys]
 workspace = true
 features = [
   "Win32_Foundation",
   "Win32_Globalization",
-  "Win32_NetworkManagement_IpHelper",
   "Win32_NetworkManagement_Ndis",
   "Win32_Networking_WinSock",
   "Win32_Security",
   "Win32_Storage_FileSystem",
+  "Win32_System_Com",
   "Win32_System_Diagnostics_ToolHelp",
   "Win32_System_IO",
-  "Win32_System_Ioctl",
-  "Win32_System_LibraryLoader",
   "Win32_System_ProcessStatus",
   "Win32_System_Registry",
   "Win32_System_Rpc",

--- a/talpid-dns/src/windows/iphlpapi.rs
+++ b/talpid-dns/src/windows/iphlpapi.rs
@@ -1,11 +1,6 @@
-//! DNS monitor that uses `SetInterfaceDnsSettings`. According to
-//! <https://learn.microsoft.com/en-us/windows/win32/api/netioapi/nf-netioapi-setinterfacednssettings>,
-//! it requires at least Windows 10, build 19041. For that reason, use run-time linking and fall
-//! back on other methods if it is not available.
-#![allow(clippy::undocumented_unsafe_blocks)] // Remove me if you dare.
+//! DNS monitor that uses `SetInterfaceDnsSettings`.
 
 use super::{DnsMonitorT, ResolvedDnsConfig};
-use once_cell::sync::OnceCell;
 use std::{
     ffi::OsString,
     io,
@@ -16,16 +11,11 @@ use std::{
 use talpid_types::win32_err;
 use talpid_windows::net::{guid_from_luid, luid_from_alias};
 use windows_sys::{
-    Win32::{
-        Foundation::{ERROR_PROC_NOT_FOUND, FreeLibrary, WIN32_ERROR},
-        NetworkManagement::IpHelper::{
-            DNS_INTERFACE_SETTINGS, DNS_INTERFACE_SETTINGS_VERSION1, DNS_SETTING_IPV6,
-            DNS_SETTING_NAMESERVER,
-        },
-        System::LibraryLoader::{GetProcAddress, LOAD_LIBRARY_SEARCH_SYSTEM32, LoadLibraryExW},
+    Win32::NetworkManagement::IpHelper::{
+        DNS_INTERFACE_SETTINGS, DNS_INTERFACE_SETTINGS_VERSION1, DNS_SETTING_IPV6,
+        DNS_SETTING_NAMESERVER, SetInterfaceDnsSettings,
     },
     core::GUID,
-    s, w,
 };
 
 /// Errors that can happen when configuring DNS on Windows.
@@ -46,70 +36,6 @@ pub enum Error {
     /// Failure to flush DNS cache.
     #[error("Failed to flush DNS resolver cache")]
     FlushResolverCache(#[source] super::dnsapi::Error),
-
-    /// Failed to load iphlpapi.dll.
-    #[error("Failed to load iphlpapi.dll")]
-    LoadDll(#[source] io::Error),
-
-    /// Failed to obtain exported function.
-    #[error("Failed to obtain DNS function")]
-    GetFunction(#[source] io::Error),
-}
-
-type SetInterfaceDnsSettingsFn = unsafe extern "system" fn(
-    interface: GUID,
-    settings: *const DNS_INTERFACE_SETTINGS,
-) -> WIN32_ERROR;
-
-struct IphlpApi {
-    set_interface_dns_settings: SetInterfaceDnsSettingsFn,
-}
-
-unsafe impl Send for IphlpApi {}
-unsafe impl Sync for IphlpApi {}
-
-static IPHLPAPI_HANDLE: OnceCell<IphlpApi> = OnceCell::new();
-
-impl IphlpApi {
-    fn new() -> Result<Self, Error> {
-        let module = unsafe {
-            LoadLibraryExW(
-                w!("iphlpapi.dll"),
-                ptr::null_mut(),
-                LOAD_LIBRARY_SEARCH_SYSTEM32,
-            )
-        };
-        if module.is_null() {
-            log::error!("Failed to load iphlpapi.dll");
-            return Err(Error::LoadDll(io::Error::last_os_error()));
-        }
-
-        // This function is loaded at runtime since it may be unavailable. See the module-level
-        // docs. TODO: `windows_sys` can be used directly when support for versions older
-        // than Windows 10, 2004, is dropped.
-        let set_interface_dns_settings =
-            unsafe { GetProcAddress(module, s!("SetInterfaceDnsSettings")) };
-        let set_interface_dns_settings = set_interface_dns_settings.ok_or_else(|| {
-            let error = io::Error::last_os_error();
-
-            if error.raw_os_error() != Some(ERROR_PROC_NOT_FOUND as i32) {
-                log::error!(
-                    "Could not find SetInterfaceDnsSettings due to an unexpected error: {error}"
-                );
-            }
-
-            unsafe { FreeLibrary(module) };
-            Error::GetFunction(error)
-        })?;
-
-        // NOTE: Leaking `module` here, since we're lazily initializing it
-
-        Ok(Self {
-            set_interface_dns_settings: unsafe {
-                *((&raw const set_interface_dns_settings).cast())
-            },
-        })
-    }
 }
 
 pub struct DnsMonitor {
@@ -118,7 +44,9 @@ pub struct DnsMonitor {
 
 impl DnsMonitor {
     pub fn is_supported() -> bool {
-        IPHLPAPI_HANDLE.get_or_try_init(IphlpApi::new).is_ok()
+        // `SetInterfaceDnsSettings` is available on all Windows versions that Mullvad supports. See
+        // `supported-platforms.md`.
+        true
     }
 }
 
@@ -159,12 +87,12 @@ impl DnsMonitorT for DnsMonitor {
     }
 
     fn reset(&mut self) -> Result<(), Error> {
-        if let Some(guid) = self.current_guid.take() {
-            set_interface_dns_servers_v4(&guid, &[])
-                .and(set_interface_dns_servers_v6(&guid, &[]))
-                .and(flush_dns_cache())?;
-        }
-        Ok(())
+        let Some(guid) = self.current_guid.take() else {
+            return Ok(());
+        };
+        set_interface_dns_servers_v4(&guid, &[])
+            .and(set_interface_dns_servers_v6(&guid, &[]))
+            .and(flush_dns_cache())
     }
 
     fn reset_before_interface_removal(&mut self) -> Result<(), Self::Error> {
@@ -175,20 +103,18 @@ impl DnsMonitorT for DnsMonitor {
 }
 
 fn set_interface_dns_servers_v4(guid: &GUID, servers: &[&Ipv4Addr]) -> Result<(), Error> {
-    set_interface_dns_servers(guid, servers, DNS_SETTING_NAMESERVER)
+    set_interface_dns_servers(guid, servers, ConfigureNameServer::Ipv4)
 }
 
 fn set_interface_dns_servers_v6(guid: &GUID, servers: &[&Ipv6Addr]) -> Result<(), Error> {
-    set_interface_dns_servers(guid, servers, DNS_SETTING_NAMESERVER | DNS_SETTING_IPV6)
+    set_interface_dns_servers(guid, servers, ConfigureNameServer::Ipv6)
 }
 
 fn set_interface_dns_servers<T: ToString>(
     guid: &GUID,
     servers: &[T],
-    flags: u32,
+    flags: ConfigureNameServer,
 ) -> Result<(), Error> {
-    let iphlpapi = IPHLPAPI_HANDLE.get_or_try_init(IphlpApi::new)?;
-
     // Create comma-separated nameserver list
     let nameservers = servers
         .iter()
@@ -202,7 +128,7 @@ fn set_interface_dns_servers<T: ToString>(
 
     let dns_interface_settings = DNS_INTERFACE_SETTINGS {
         Version: DNS_INTERFACE_SETTINGS_VERSION1,
-        Flags: u64::from(flags),
+        Flags: flags as u64,
         Domain: ptr::null_mut(),
         NameServer: nameservers.as_mut_ptr(),
         SearchList: ptr::null_mut(),
@@ -213,10 +139,27 @@ fn set_interface_dns_servers<T: ToString>(
         ProfileNameServer: ptr::null_mut(),
     };
 
+    // SAFETY:
+    // - `&raw const dns_interface_settings` is a valid pointer to a DNS_INTERFACE_SETTINGS-type structure.
+    // - `dns_interface_settings` is live for the entire call to SetInterfaceDnsSettings.
+    // - DNS_INTERFACE_SETTINGS::Version member is set to DNS_INTERFACE_SETTINGS_VERSION1.
+    // - DNS_INTERFACE_SETTINGS.NameServer member is populated while the other members are zeroed.
     win32_err!(unsafe {
-        (iphlpapi.set_interface_dns_settings)(guid.to_owned(), &raw const dns_interface_settings)
+        // <https://learn.microsoft.com/en-us/windows/win32/api/netioapi/nf-netioapi-setinterfacednssettings>.
+        SetInterfaceDnsSettings(guid.to_owned(), &raw const dns_interface_settings)
     })
     .map_err(Error::SetInterfaceDnsSettings)
+}
+
+/// DNS_INTERFACE_SETTINGS.Flags argument for configures static adapter DNS servers on the specified interface via the NameServer member.
+///
+/// See <https://learn.microsoft.com/en-us/windows/win32/api/netioapi/ns-netioapi-dns_interface_settings>.
+#[repr(u32)]
+enum ConfigureNameServer {
+    /// `DNS_SETTING_NAMESERVER`.
+    Ipv4 = DNS_SETTING_NAMESERVER,
+    /// `DNS_SETTING_NAMESERVER | DNS_SETTING_IPV6`.
+    Ipv6 = (DNS_SETTING_NAMESERVER | DNS_SETTING_IPV6),
 }
 
 fn flush_dns_cache() -> Result<(), Error> {


### PR DESCRIPTION
Remove some `unsafe` used for linking `iphlpapi.dll` dynamically to call `SetInterfaceDnsSettings`. Import the function from `windows_sys` instead. This is possible because the Mullvad app only support Windows 10 builds 22H2 and newer, which is newer than Windows 10 Build 19041 where `SetInterfaceDnsSettings` was introduced.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10935)
<!-- Reviewable:end -->
