### PR TITLE
Add accessory buttons to MullvadListSectionHeader, correct fonts

### DIFF
--- a/ios/MullvadVPN/Views/MullvadListSectionHeader.swift
+++ b/ios/MullvadVPN/Views/MullvadListSectionHeader.swift
@@ -1,18 +1,33 @@
 import SwiftUI
 
 struct MullvadListSectionHeader: View {
+    struct Accessory: Identifiable {
+        enum Face: Hashable {
+            case text(String)
+            case icon(ImageResource)
+        }
+        typealias ID = Face
+        let face: Face
+        let accessibilityId: AccessibilityIdentifier? = nil
+        let accessibilityLabel: LocalizedStringKey? = nil
+        let accessibilityHint: LocalizedStringKey? = nil
+        let action: () -> Void
+        var id: ID { face }
+    }
     let title: LocalizedStringKey
     let subtitle: LocalizedStringKey?
+    let accessories: [Accessory]
 
-    init(title: LocalizedStringKey, subtitle: LocalizedStringKey? = nil) {
+    init(title: LocalizedStringKey, subtitle: LocalizedStringKey? = nil, accessories: [Accessory] = []) {
         self.title = title
         self.subtitle = subtitle
+        self.accessories = accessories
     }
 
     var body: some View {
         HStack {
             Text(title)
-                .font(.mullvadTiny)
+                .font(.mullvadTinySemiBold)
                 .foregroundStyle(Color.mullvadTextPrimary)
                 .layoutPriority(1)
             Rectangle()
@@ -24,12 +39,71 @@ struct MullvadListSectionHeader: View {
                     .foregroundStyle(Color.mullvadTextSecondary)
                     .layoutPriority(1)
             }
+            ForEach(accessories) { accessory in
+                accessoryView(accessory)
+            }
         }
         .frame(minHeight: 44, alignment: .center)
         .accessibilityAddTraits(.isHeader)
     }
+
+    func accessoryView(_ accessory: Accessory) -> some View {
+        Button(
+            action: accessory.action,
+            label: { accessoryFaceView(accessory.face) }
+        )
+        .ifLet(accessory.accessibilityLabel) { $0.accessibilityLabel($1) }
+        .ifLet(accessory.accessibilityHint) { $0.accessibilityHint($1) }
+        .ifLet(accessory.accessibilityId) { $0.accessibilityIdentifier($1.asString) }
+    }
+
+    func accessoryFaceView(_ face: Accessory.Face) -> some View {
+        switch face {
+        case .icon(let imageResource):
+            Image(imageResource)
+                .renderingMode(.template)
+                .resizable()
+                .scaledToFit()
+                .foregroundStyle(Color.mullvadTextPrimary)
+                .frame(height: 24)
+                .typeErase()
+        case .text(let text):
+            Text(text)
+                .font(.mullvadTinySemiBold)
+                .underline()
+                .foregroundStyle(Color.mullvadTextPrimary)
+                .typeErase()
+        }
+    }
 }
 
 #Preview {
-    MullvadListSectionHeader(title: "Custom lists")
+    VStack {
+        MullvadListSectionHeader(title: "Custom lists").background(Color.mullvadBackground)
+        MullvadListSectionHeader(
+            title: "Custom lists", subtitle: "Showing 32 of 194",
+            accessories: [
+                .init(
+                    face: .icon(.iconReload),
+                    action: {
+                        print("Reload")
+                    }),
+                .init(
+                    face: .icon(.iconAdd),
+                    action: {
+                        print("Add")
+                    }),
+            ]
+        ).background(Color.mullvadBackground)
+        MullvadListSectionHeader(
+            title: "Custom lists",
+            accessories: [
+                .init(
+                    face: .text("Text button"),
+                    action: {
+                        print("Text button")
+                    })
+            ]
+        ).background(Color.mullvadBackground)
+    }
 }

--- a/ios/MullvadVPN/Views/MullvadListSectionHeader.swift
+++ b/ios/MullvadVPN/Views/MullvadListSectionHeader.swift
@@ -8,9 +8,9 @@ struct MullvadListSectionHeader: View {
         }
         typealias ID = Face
         let face: Face
-        let accessibilityId: AccessibilityIdentifier? = nil
-        let accessibilityLabel: LocalizedStringKey? = nil
-        let accessibilityHint: LocalizedStringKey? = nil
+        let accessibilityId: AccessibilityIdentifier?
+        let accessibilityLabel: LocalizedStringKey?
+        let accessibilityHint: LocalizedStringKey?
         let action: () -> Void
         var id: ID { face }
     }
@@ -77,6 +77,41 @@ struct MullvadListSectionHeader: View {
     }
 }
 
+// MARK: convenience initialisers for accessories
+extension MullvadListSectionHeader.Accessory {
+    init(
+        _ text: String,
+        accessibilityId: AccessibilityIdentifier? = nil,
+        accessibilityLabel: LocalizedStringKey? = nil,
+        accessibilityHint: LocalizedStringKey? = nil,
+        action: @escaping () -> Void
+    ) {
+        self.init(
+            face: Face.text(text),
+            accessibilityId: accessibilityId,
+            accessibilityLabel: accessibilityLabel,
+            accessibilityHint: accessibilityHint,
+            action: action
+        )
+    }
+
+    init(
+        _ icon: ImageResource,
+        accessibilityId: AccessibilityIdentifier? = nil,
+        accessibilityLabel: LocalizedStringKey? = nil,
+        accessibilityHint: LocalizedStringKey? = nil,
+        action: @escaping () -> Void
+    ) {
+        self.init(
+            face: Face.icon(icon),
+            accessibilityId: accessibilityId,
+            accessibilityLabel: accessibilityLabel,
+            accessibilityHint: accessibilityHint,
+            action: action
+        )
+    }
+}
+
 #Preview {
     VStack {
         MullvadListSectionHeader(title: "Custom lists").background(Color.mullvadBackground)
@@ -84,12 +119,12 @@ struct MullvadListSectionHeader: View {
             title: "Custom lists", subtitle: "Showing 32 of 194",
             accessories: [
                 .init(
-                    face: .icon(.iconReload),
+                    .iconReload,
                     action: {
                         print("Reload")
                     }),
                 .init(
-                    face: .icon(.iconAdd),
+                    .iconAdd,
                     action: {
                         print("Add")
                     }),
@@ -99,7 +134,7 @@ struct MullvadListSectionHeader: View {
             title: "Custom lists",
             accessories: [
                 .init(
-                    face: .text("Text button"),
+                    "Text button",
                     action: {
                         print("Text button")
                     })


### PR DESCRIPTION
This adds optional trailing accessory buttons, each of which may have either an icon or a text label, to the section header. It also corrects the primary text font to be in line with the Figma

The headings look like this: 
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/30033e9c-146a-49c6-9e38-c416b633d7ea" />


<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10944)
<!-- Reviewable:end -->
