### PR TITLE
Do not revoke the device on invalid access tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ Line wrap the file at 100 chars.                                              Th
 - Ignore DAITA tunnel config responses unless DAITA was requested.
 - Fix infinite loop of account checks when account ran out of time.
 - Fix IPv6 obfuscation relay selection when the relay's WireGuard endpoint only has IPv4.
+- Fix the device sometimes being incorrectly marked as revoked when the API rejects an expired
+  access token.
 
 #### Linux
 - Parse the `resolv.conf` format using `resolv-conf` crate. This will lead to fewer false negatives

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3188,6 +3188,7 @@ dependencies = [
  "ipnetwork",
  "libc",
  "log",
+ "mockito",
  "mullvad-api-constants",
  "mullvad-encrypted-dns-proxy",
  "mullvad-fs",

--- a/mullvad-api/Cargo.toml
+++ b/mullvad-api/Cargo.toml
@@ -53,6 +53,7 @@ tower = { workspace = true }
 vec1 = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
+mockito = { workspace = true }
 talpid-time = { path = "../talpid-time", features = ["test"] }
 tokio = { workspace = true, features = ["test-util", "time"] }
 

--- a/mullvad-api/src/access.rs
+++ b/mullvad-api/src/access.rs
@@ -153,15 +153,11 @@ impl AccessTokenStore {
         rx.await.map_err(|_| rest::Error::Aborted)?
     }
 
-    /// Remove an access token if the API response calls for it.
-    pub fn check_response<T>(&self, account: &AccountNumber, response: &Result<T, rest::Error>) {
-        if let Err(rest::Error::ApiError(_status, code)) = response
-            && code == crate::INVALID_ACCESS_TOKEN
-        {
-            let _ = self
-                .tx
-                .unbounded_send(StoreAction::InvalidateToken(account.to_owned()));
-        }
+    /// Forget the cached access token for an account, so that the next request obtains a new one.
+    pub fn invalidate_token(&self, account: &AccountNumber) {
+        let _ = self
+            .tx
+            .unbounded_send(StoreAction::InvalidateToken(account.to_owned()));
     }
 }
 

--- a/mullvad-api/src/access.rs
+++ b/mullvad-api/src/access.rs
@@ -11,7 +11,8 @@ use mullvad_types::account::{AccessToken, AccessTokenData, AccountNumber};
 use std::{borrow::Cow, collections::HashMap};
 use tokio::select;
 
-pub const AUTH_URL_PREFIX: &str = "auth/v1";
+/// Path of the API endpoint that hands out access tokens.
+pub const ACCESS_TOKEN_PATH: &str = "auth/v1/token";
 
 #[derive(Debug, Clone)]
 pub struct AccessTokenStore {
@@ -173,7 +174,7 @@ async fn fetch_access_token(
     let request = AccessTokenRequest { account_number };
 
     let rest_request = factory
-        .post_json(&format!("{AUTH_URL_PREFIX}/token"), &request)?
+        .post_json(ACCESS_TOKEN_PATH, &request)?
         .expected_status(&[StatusCode::OK]);
     service.request(rest_request).await?.deserialize().await
 }

--- a/mullvad-api/src/rest.rs
+++ b/mullvad-api/src/rest.rs
@@ -797,3 +797,101 @@ impl_into_arc_err!(hyper_util::client::legacy::Error);
 impl_into_arc_err!(serde_json::Error);
 impl_into_arc_err!(http::Error);
 impl_into_arc_err!(http::uri::InvalidUri);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        ACCOUNTS_URL_PREFIX, DefaultDnsResolver,
+        access::ACCESS_TOKEN_PATH,
+        availability::State,
+        proxy::{ApiConnectionMode, StaticConnectionModeProvider},
+    };
+    use mockito::{Mock, Server, ServerGuard};
+
+    const ACCOUNT_NUMBER: &str = "1234123412341234";
+
+    /// An endpoint that requires an access token.
+    fn account_data_path() -> String {
+        format!("{ACCOUNTS_URL_PREFIX}/accounts/me")
+    }
+
+    /// Mock the access token endpoint, handing out `token` once.
+    async fn mock_access_token(server: &mut ServerGuard, token: &str) -> Mock {
+        server
+            .mock("POST", &*format!("/{ACCESS_TOKEN_PATH}"))
+            .with_body(format!(
+                r#"{{"access_token": "{token}", "expiry": "2100-01-01T00:00:00Z"}}"#
+            ))
+            .expect(1)
+            .create_async()
+            .await
+    }
+
+    /// Mock an endpoint that rejects `token`, once.
+    async fn mock_rejected_token(server: &mut ServerGuard, token: &str) -> Mock {
+        server
+            .mock("GET", &*format!("/{}", account_data_path()))
+            .match_header(header::AUTHORIZATION.as_str(), &*format!("Bearer {token}"))
+            .with_status(StatusCode::UNAUTHORIZED.as_u16().into())
+            .with_body(format!(r#"{{"code": "{}"}}"#, crate::INVALID_ACCESS_TOKEN))
+            .expect(1)
+            .create_async()
+            .await
+    }
+
+    /// A REST client that talks to `server`. TLS is disabled, so the hostname is only used to
+    /// construct the URI. Giving it the port of the mock server makes the connector dial it.
+    fn client(server: &ServerGuard) -> (RequestServiceHandle, RequestFactory) {
+        let service = RequestService::spawn(
+            ApiAvailability::new(State::default()),
+            StaticConnectionModeProvider::new(ApiConnectionMode::Direct),
+            Arc::new(DefaultDnsResolver),
+            #[cfg(target_os = "android")]
+            None,
+            true,
+        );
+        let host = server.host_with_port();
+        let store = AccessTokenStore::new(service.clone(), host.clone());
+        (service.clone(), RequestFactory::new(host, Some(store)))
+    }
+
+    /// Test that a request whose access token is rejected is sent again with a new token.
+    ///
+    /// The invalid access token error should only be forwarded to the caller if we fail to renew
+    /// it.
+    #[tokio::test]
+    async fn retry_request_with_new_access_token() {
+        let mut server = Server::new_async().await;
+
+        let expired_token = mock_access_token(&mut server, "expired-token").await;
+        let fresh_token = mock_access_token(&mut server, "fresh-token").await;
+        let rejected_request = mock_rejected_token(&mut server, "expired-token").await;
+        let accepted_request = server
+            .mock("GET", &*format!("/{}", account_data_path()))
+            .match_header(header::AUTHORIZATION.as_str(), "Bearer fresh-token")
+            .with_body("{}")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let (service, factory) = client(&server);
+        let request = factory
+            .get(&account_data_path())
+            .unwrap()
+            .account(AccountNumber::from(ACCOUNT_NUMBER))
+            .unwrap()
+            .expected_status(&[StatusCode::OK]);
+        let response = service.request(request).await;
+
+        let status = response
+            .expect("the retried request should succeed")
+            .status();
+        assert_eq!(status, StatusCode::OK);
+
+        expired_token.assert_async().await;
+        fresh_token.assert_async().await;
+        rejected_request.assert_async().await;
+        accepted_request.assert_async().await;
+    }
+}

--- a/mullvad-api/src/rest.rs
+++ b/mullvad-api/src/rest.rs
@@ -248,9 +248,7 @@ impl<T: ConnectionModeProvider + 'static> RequestService<T> {
         let tx = self.command_tx.upgrade();
 
         let api_availability = self.api_availability.clone();
-        let request_future = request
-            .map(|r| http::Request::map(r, BodyExt::boxed))
-            .into_future(self.client.clone(), api_availability.clone());
+        let request_future = request.into_future(self.client.clone(), api_availability.clone());
 
         let connection_mode_generation = self.connection_mode_generation;
 
@@ -428,15 +426,10 @@ where
     }
 }
 
-impl<B> Request<B>
-where
-    B: Body + Send + 'static + Unpin,
-    B::Data: Send,
-    B::Error: Into<Box<dyn StdError + Send + Sync>>,
-{
+impl Request<BoxBody<Bytes, Error>> {
     async fn into_future<C: Connect + Clone + Send + Sync + 'static>(
         self,
-        hyper_client: hyper_util::client::legacy::Client<C, B>,
+        hyper_client: hyper_util::client::legacy::Client<C, BoxBody<Bytes, Error>>,
         api_availability: ApiAvailability,
     ) -> Result<Response<Incoming>> {
         let timeout = self.timeout;
@@ -447,8 +440,8 @@ where
     }
 
     async fn into_future_without_timeout<C>(
-        mut self,
-        hyper_client: hyper_util::client::legacy::Client<C, B>,
+        self,
+        hyper_client: hyper_util::client::legacy::Client<C, BoxBody<Bytes, Error>>,
         api_availability: ApiAvailability,
     ) -> Result<Response<Incoming>>
     where
@@ -456,48 +449,71 @@ where
     {
         let _ = api_availability.wait_for_unsuspend().await;
 
-        // Obtain access token first
-        if let (Some(account), Some(store)) = (&self.account, &self.access_token_store) {
-            let access_token = store.get_token(account).await?;
-            let auth = HeaderValue::from_str(&format!("Bearer {access_token}"))
-                .map_err(|_| Error::InvalidHeaderError)?;
-            self.request
-                .headers_mut()
-                .insert(header::AUTHORIZATION, auth);
-        }
+        let Self {
+            request,
+            access_token_store,
+            account,
+            expected_status,
+            ..
+        } = self;
 
-        // Make request to hyper client
-        let response = hyper_client
-            .request(self.request)
-            .await
-            .map_err(Error::from);
+        let (parts, body) = request.into_parts();
+        let body = BodyExt::collect(body).await?.to_bytes();
+        let auth = account.zip(access_token_store);
 
-        // Notify access token store of expired tokens
-        if let (Some(account), Some(store)) = (&self.account, &self.access_token_store) {
-            store.check_response(account, &response);
-        }
+        let send_request = async || {
+            let mut request =
+                hyper::Request::from_parts(parts.clone(), box_body(Full::new(body.clone())));
 
-        // Parse unexpected responses and errors
-        let response = response?;
-
-        if !self.expected_status.contains(&response.status()) {
-            if !self.expected_status.is_empty() {
-                log::error!(
-                    "Unexpected HTTP status code {}, expected codes [{}]",
-                    response.status(),
-                    self.expected_status
-                        .iter()
-                        .map(ToString::to_string)
-                        .collect::<Vec<_>>()
-                        .join(",")
-                );
+            // Obtain access token first
+            if let Some((account, store)) = &auth {
+                let access_token = store.get_token(account).await?;
+                let authorization = HeaderValue::from_str(&format!("Bearer {access_token}"))
+                    .map_err(|_| Error::InvalidHeaderError)?;
+                request
+                    .headers_mut()
+                    .insert(header::AUTHORIZATION, authorization);
             }
-            if !response.status().is_success() {
-                return handle_error_response(response).await;
-            }
-        }
 
-        Ok(Response::new(response))
+            // Make request to hyper client
+            let response = hyper_client.request(request).await.map_err(Error::from)?;
+
+            // Parse unexpected responses and errors
+            if !expected_status.contains(&response.status()) {
+                if !expected_status.is_empty() {
+                    log::error!(
+                        "Unexpected HTTP status code {}, expected codes [{}]",
+                        response.status(),
+                        expected_status
+                            .iter()
+                            .map(ToString::to_string)
+                            .collect::<Vec<_>>()
+                            .join(",")
+                    );
+                }
+                if !response.status().is_success() {
+                    return Err(handle_error_response(response).await);
+                }
+            }
+
+            Ok(Response::new(response))
+        };
+
+        let result = send_request().await;
+
+        // The access token may have expired since it was obtained. Notify the access token store,
+        // and give the request another chance with a new token.
+        if let Err(Error::ApiError(_, code)) = &result
+            && code == crate::INVALID_ACCESS_TOKEN
+            && let Some((account, store)) = &auth
+        {
+            log::debug!("Access token was rejected. Retrying with a new one");
+            store.invalidate_token(account);
+            // Retry with new token
+            send_request().await
+        } else {
+            result
+        }
     }
 }
 
@@ -690,7 +706,8 @@ fn get_body_length<B>(response: &hyper::Response<B>) -> usize {
         .unwrap_or(0)
 }
 
-async fn handle_error_response<T, B: Body>(response: hyper::Response<B>) -> Result<T>
+/// Return the [`Error`] described by an unsuccessful response.
+async fn handle_error_response<B: Body>(response: hyper::Response<B>) -> Error
 where
     Error: From<B::Error>,
 {
@@ -705,24 +722,26 @@ where
                         // TODO: We should make sure we unify the new error format and the old
                         // error format so that they both produce the same Errors for the same
                         // problems after being processed.
-                        let err: NewErrorResponse = deserialize_body_inner(response).await?;
-                        // The new error type replaces the `code` field with the `type` field.
-                        // This is what is used to programmatically check the error.
-                        Err(Error::ApiError(
-                            status,
-                            err.r#type
-                                .unwrap_or_else(|| String::from(DEFAULT_ERROR_TYPE)),
-                        ))
+                        match deserialize_body_inner::<NewErrorResponse, _>(response).await {
+                            // The new error type replaces the `code` field with the `type` field.
+                            // This is what is used to programmatically check the error.
+                            Ok(err) => Error::ApiError(
+                                status,
+                                err.r#type
+                                    .unwrap_or_else(|| String::from(DEFAULT_ERROR_TYPE)),
+                            ),
+                            Err(error) => error,
+                        }
                     }
-                    _ => {
-                        let err: OldErrorResponse = deserialize_body_inner(response).await?;
-                        Err(Error::ApiError(status, err.code))
-                    }
+                    _ => match deserialize_body_inner::<OldErrorResponse, _>(response).await {
+                        Ok(err) => Error::ApiError(status, err.code),
+                        Err(error) => error,
+                    },
                 };
             }
         },
     };
-    Err(Error::ApiError(status, error_message.to_owned()))
+    Error::ApiError(status, error_message.to_owned())
 }
 
 async fn deserialize_body_inner<T, B>(response: hyper::Response<B>) -> Result<T>

--- a/mullvad-daemon/src/device/service.rs
+++ b/mullvad-daemon/src/device/service.rs
@@ -512,9 +512,7 @@ fn map_rest_error(error: rest::Error) -> Error {
     match error {
         rest::Error::ApiError(_status, ref code) => match code.as_str() {
             // TODO: Implement invalid payment
-            mullvad_api::DEVICE_NOT_FOUND | mullvad_api::INVALID_ACCESS_TOKEN => {
-                Error::InvalidDevice
-            }
+            mullvad_api::DEVICE_NOT_FOUND => Error::InvalidDevice,
             mullvad_api::INVALID_ACCOUNT => Error::InvalidAccount,
             mullvad_api::MAX_DEVICES_REACHED => Error::MaxDevicesReached,
             mullvad_api::INVALID_VOUCHER => Error::InvalidVoucher,

--- a/mullvad-types/src/account.rs
+++ b/mullvad-types/src/account.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, offset::Utc};
+use chrono::{DateTime, TimeDelta, offset::Utc};
 use serde::{Deserialize, Serialize};
 
 /// Account identifier used for authentication.
@@ -59,8 +59,12 @@ pub struct AccessTokenData {
 }
 
 impl AccessTokenData {
-    /// Return true if the token is no longer valid.
+    /// How long before its actual expiry an access token is considered expired. Tolerates a small
+    /// amount of clock skew relative to the API.
+    const EXPIRY_MARGIN: TimeDelta = TimeDelta::minutes(1);
+
+    /// Return true if the token is no longer valid, or expires within [`Self::EXPIRY_MARGIN`].
     pub fn is_expired(&self) -> bool {
-        Utc::now() >= self.expiry
+        self.expiry - Utc::now() <= Self::EXPIRY_MARGIN
     }
 }


### PR DESCRIPTION
Changes:
* The REST client didn't properly renew the access token when it was invalid. It was only revoked when expired, but it can also be invalidated due to the account being deleted.
* Some checks resulted in `INVALID_ACCESS_TOKEN` being mapped to `InvalidDevice`, causing the daemon to think that the device had been revoked.
* Add test that REST client handles access tokens correctly.

Fix DES-3181

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10945)
<!-- Reviewable:end -->
