### PR TITLE
Decouple local UDP socket interface from obfuscated transports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6801,6 +6801,7 @@ name = "tunnel-obfuscation"
 version = "0.0.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "criterion",
  "futures",
  "log",

--- a/tunnel-obfuscation/Cargo.toml
+++ b/tunnel-obfuscation/Cargo.toml
@@ -16,6 +16,7 @@ name = "obfuscation_throughput"
 
 [dependencies]
 async-trait = { workspace = true }
+bytes = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
 mullvad-masque-proxy = { path = "../mullvad-masque-proxy" }

--- a/tunnel-obfuscation/benches/obfuscation_throughput.rs
+++ b/tunnel-obfuscation/benches/obfuscation_throughput.rs
@@ -11,13 +11,11 @@
 
 use core::hint::black_box;
 use criterion::{Criterion, criterion_group, criterion_main};
-use std::sync::Arc;
-use talpid_net::bypass::NoopBypass;
 use talpid_types::net::wireguard::PublicKey;
 use tokio::net::UdpSocket;
 use tunnel_obfuscation::{
-    LocalSocketObfuscator,
-    lwo::{self, Lwo, Settings, obfuscate_thread_local},
+    create_local_socket_obfuscator,
+    lwo::{self, Settings, obfuscate_thread_local},
 };
 
 /// Baseline: plain UDP send -> recv, no obfuscation.
@@ -99,9 +97,11 @@ fn bench_proxy_lwo(c: &mut Criterion) {
             client_public_key: client_key.clone(),
             server_public_key: server_key.clone(),
         };
-        let lwo = Lwo::new(Arc::new(NoopBypass), &settings).await.unwrap();
+        let lwo = create_local_socket_obfuscator(&tunnel_obfuscation::Settings::Lwo(settings))
+            .await
+            .unwrap();
         let proxy_addr = lwo.endpoint();
-        tokio::spawn((Box::new(lwo) as Box<dyn LocalSocketObfuscator>).run());
+        tokio::spawn(lwo.run());
 
         // Warm up: send one packet so the proxy connects its client socket
         let wg = UdpSocket::bind("127.0.0.1:0").await.unwrap();

--- a/tunnel-obfuscation/src/lib.rs
+++ b/tunnel-obfuscation/src/lib.rs
@@ -3,12 +3,16 @@ use std::{net::SocketAddr, sync::Arc};
 use talpid_net::bypass::{NoopBypass, SocketBypass};
 use tokio::io;
 
+pub mod local_socket;
 pub mod lwo;
 pub mod multiplexer;
 pub mod quic;
 pub mod shadowsocks;
 pub mod socket;
+pub mod transport;
 pub mod udp2tcp;
+
+pub use transport::ObfuscatedTransport;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -17,40 +21,32 @@ pub enum Error {
     #[error("Failed to create Udp2Tcp obfuscator")]
     CreateUdp2TcpObfuscator(#[source] udp2tcp::Error),
 
-    #[error("Failed to run Udp2Tcp obfuscator")]
-    RunUdp2TcpObfuscator(#[source] udp2tcp::Error),
-
     #[error("Failed to initialize Shadowsocks")]
     CreateShadowsocksObfuscator(#[source] shadowsocks::Error),
-
-    #[error("Failed to run Shadowsocks")]
-    RunShadowsocksObfuscator(#[source] shadowsocks::Error),
 
     #[error("Failed to initialize Quic")]
     CreateQuicObfuscator(#[source] quic::Error),
 
-    #[error("Failed to run Quic")]
-    RunQuicObfuscator(#[source] quic::Error),
-
-    #[error("Failed to initialize LWO")]
-    CreateLwoObfuscator(#[source] lwo::Error),
-
-    #[error("Failed to run LWO")]
-    RunLwoObfuscator(#[source] lwo::Error),
-
-    #[error("Failed to bind socket")]
+    #[error("Failed to bind remote socket")]
     BindRemoteUdp(#[source] io::Error),
 
     #[error("Failed to bypass socket")]
     Bypass(#[source] io::Error),
 
-    #[error("Failed to initialize multiplexer")]
-    CreateMultiplexerObfuscator(#[source] io::Error),
+    #[error("Failed to connect remote socket")]
+    ConnectRemoteUdp(#[source] io::Error),
+
+    #[error("Failed to bind local socket")]
+    BindLocalUdp(#[source] io::Error),
+
+    #[error("Failed to run local socket obfuscator")]
+    RunLocalSocketObfuscator(#[source] io::Error),
 
     #[error("Failed to run multiplexer")]
     RunMultiplexerObfuscator(#[source] io::Error),
 }
 
+/// An obfuscator that a local WireGuard instance reaches over a UDP socket on localhost.
 #[async_trait]
 pub trait LocalSocketObfuscator: Send {
     async fn run(self: Box<Self>) -> Result<()>;
@@ -77,6 +73,23 @@ pub enum Settings {
     Lwo(lwo::Settings),
 }
 
+/// Create an [ObfuscatedTransport] that obfuscates and deobfuscates packets in place where the
+/// protocol allows it.
+pub async fn create_transport(
+    bypass: Arc<dyn SocketBypass>,
+    settings: &Settings,
+) -> Result<Arc<dyn ObfuscatedTransport>> {
+    match settings {
+        Settings::Shadowsocks(s) => shadowsocks::Shadowsocks::new(bypass, s)
+            .await
+            .map(arc_transport),
+        Settings::Quic(s) => quic::QuicTransport::new(bypass, s).await.map(arc_transport),
+        Settings::Lwo(s) => lwo::Lwo::new(bypass, s).await.map(arc_transport),
+
+        Settings::Udp2Tcp(s) => udp2tcp::Udp2Tcp::new(bypass, s).map(arc_transport),
+    }
+}
+
 pub async fn create_local_socket_obfuscator(
     settings: &Settings,
 ) -> Result<Box<dyn LocalSocketObfuscator>> {
@@ -87,16 +100,14 @@ pub async fn create_local_socket_obfuscator_with_bypass(
     bypass: Arc<dyn SocketBypass>,
     settings: &Settings,
 ) -> Result<Box<dyn LocalSocketObfuscator>> {
-    match settings {
-        Settings::Udp2Tcp(s) => udp2tcp::Udp2Tcp::new(bypass, s).await.map(box_obfuscator),
-        Settings::Shadowsocks(s) => shadowsocks::Shadowsocks::new(bypass, s)
-            .await
-            .map(box_obfuscator),
-        Settings::Quic(s) => quic::QuicLocalSocket::new(bypass, s)
-            .await
-            .map(box_obfuscator),
-        Settings::Lwo(s) => lwo::Lwo::new(bypass, s).await.map(box_obfuscator),
-    }
+    let transport = create_transport(bypass, settings).await?;
+    local_socket::LocalSocketRunner::new(transport)
+        .await
+        .map(box_obfuscator)
+}
+
+fn arc_transport(transport: impl ObfuscatedTransport + 'static) -> Arc<dyn ObfuscatedTransport> {
+    Arc::new(transport) as Arc<dyn ObfuscatedTransport>
 }
 
 fn box_obfuscator(obfs: impl LocalSocketObfuscator + 'static) -> Box<dyn LocalSocketObfuscator> {

--- a/tunnel-obfuscation/src/local_socket.rs
+++ b/tunnel-obfuscation/src/local_socket.rs
@@ -1,0 +1,109 @@
+//! Exposes an [ObfuscatedTransport] to a local WireGuard instance over a loopback UDP socket.
+
+use std::{
+    io,
+    net::{Ipv4Addr, SocketAddr},
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use tokio::net::UdpSocket;
+use tokio_util::task::AbortOnDropHandle;
+
+use crate::{
+    LocalSocketObfuscator,
+    transport::{MAX_DATAGRAM_SIZE, ObfuscatedTransport},
+};
+
+/// Runs an [ObfuscatedTransport] behind a loopback UDP socket, shuttling plaintext datagrams
+/// between a local WireGuard instance and the transport.
+pub struct LocalSocketRunner {
+    /// Socket that the local WireGuard instance sends to and receives from.
+    socket: UdpSocket,
+    endpoint: SocketAddr,
+    transport: Arc<dyn ObfuscatedTransport>,
+}
+
+impl LocalSocketRunner {
+    /// Bind a loopback socket for WireGuard to talk to.
+    pub async fn new(transport: Arc<dyn ObfuscatedTransport>) -> crate::Result<Self> {
+        let socket = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .map_err(crate::Error::BindLocalUdp)?;
+        let endpoint = socket.local_addr().map_err(crate::Error::BindLocalUdp)?;
+
+        Ok(Self {
+            socket,
+            endpoint,
+            transport,
+        })
+    }
+}
+
+#[async_trait]
+impl LocalSocketObfuscator for LocalSocketRunner {
+    fn endpoint(&self) -> SocketAddr {
+        self.endpoint
+    }
+
+    fn packet_overhead(&self) -> u16 {
+        self.transport.packet_overhead()
+    }
+
+    async fn run(self: Box<Self>) -> crate::Result<()> {
+        let Self {
+            socket, transport, ..
+        } = *self;
+
+        connect_to_wireguard(&socket)
+            .await
+            .map_err(crate::Error::RunLocalSocketObfuscator)?;
+
+        let socket = Arc::new(socket);
+
+        let mut tx = AbortOnDropHandle::new(tokio::spawn(forward_to_transport(
+            Arc::clone(&socket),
+            Arc::clone(&transport),
+        )));
+        let mut rx = AbortOnDropHandle::new(tokio::spawn(forward_to_wireguard(socket, transport)));
+
+        let result = tokio::select! {
+            Ok(result) = &mut tx => result,
+            Ok(result) = &mut rx => result,
+            else => Ok(()),
+        };
+        result.map_err(crate::Error::RunLocalSocketObfuscator)
+    }
+}
+
+/// Wait for WireGuard's first datagram and connect `socket` to its address, so that replies have
+/// somewhere to go.
+///
+/// Blocks indefinitely, until WireGuard sends something.
+async fn connect_to_wireguard(socket: &UdpSocket) -> io::Result<()> {
+    let wg_addr = socket.peek_sender().await?;
+    log::trace!("Local WireGuard instance connected from {wg_addr}");
+    socket.connect(wg_addr).await
+}
+
+async fn forward_to_transport(
+    socket: Arc<UdpSocket>,
+    transport: Arc<dyn ObfuscatedTransport>,
+) -> io::Result<()> {
+    let mut buf = vec![0u8; MAX_DATAGRAM_SIZE];
+    loop {
+        let n = socket.recv(&mut buf).await?;
+        transport.send(&mut buf[..n]).await?;
+    }
+}
+
+async fn forward_to_wireguard(
+    socket: Arc<UdpSocket>,
+    transport: Arc<dyn ObfuscatedTransport>,
+) -> io::Result<()> {
+    let mut buf = vec![0u8; MAX_DATAGRAM_SIZE];
+    loop {
+        let n = transport.recv(&mut buf).await?;
+        socket.send(&buf[..n]).await?;
+    }
+}

--- a/tunnel-obfuscation/src/lwo.rs
+++ b/tunnel-obfuscation/src/lwo.rs
@@ -1,36 +1,14 @@
 //! LWO (Lightweight WireGuard Obfuscation)
 
-use std::{
-    net::{Ipv4Addr, SocketAddr},
-    sync::Arc,
-};
+use std::{io, net::SocketAddr, sync::Arc};
 
 use async_trait::async_trait;
 use rand::RngCore;
 use talpid_net::bypass::{BypassSocket, SocketBypass};
 use talpid_types::net::wireguard::PublicKey;
-use tokio::{io, net::UdpSocket, task::JoinHandle};
-use tokio_util::sync::CancellationToken;
+use tokio::net::UdpSocket;
 
-use crate::{LocalSocketObfuscator, socket::create_remote_socket};
-
-const MAX_UDP_SIZE: usize = u16::MAX as usize;
-
-#[derive(thiserror::Error, Debug)]
-pub enum Error {
-    /// Failed to bind local UDP socket
-    #[error("Failed to bind client UDP socket")]
-    BindUdp(#[source] io::Error),
-    /// Failed to connect remote UDP socket
-    #[error("Failed to connect remote UDP socket")]
-    ConnectRemoteUdp(#[source] io::Error),
-    /// Missing UDP listener address
-    #[error("Failed to retrieve UDP socket bind address")]
-    GetUdpLocalAddress(#[source] io::Error),
-    /// Failed to get client sender address
-    #[error("Failed to retrieve client sender")]
-    PeekUdpSender(#[source] io::Error),
-}
+use crate::{socket::create_remote_socket, transport::ObfuscatedTransport};
 
 #[derive(Debug, Clone)]
 pub struct Settings {
@@ -42,175 +20,53 @@ pub struct Settings {
     pub server_public_key: PublicKey,
 }
 
+/// Obfuscates the WireGuard header in place and forwards the packet to the LWO/WG server.
 pub struct Lwo {
-    client: Client,
-    local_endpoint: SocketAddr,
+    remote_socket: BypassSocket<UdpSocket>,
+    server_addr: SocketAddr,
+    /// Key that the server obfuscates incoming packets with.
+    rx_key: PublicKey,
+    /// Key to obfuscate outgoing packets with.
+    tx_key: PublicKey,
 }
 
 impl Lwo {
     pub async fn new(bypass: Arc<dyn SocketBypass>, settings: &Settings) -> crate::Result<Self> {
         let remote_socket = create_remote_socket(&bypass, settings.server_addr.is_ipv4()).await?;
-        let remote_socket = Arc::new(remote_socket);
-        let client_socket = Arc::new(
-            UdpSocket::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
-                .await
-                .map_err(Error::BindUdp)
-                .map_err(crate::Error::CreateLwoObfuscator)?,
-        );
-        let local_endpoint = client_socket
-            .local_addr()
-            .map_err(Error::GetUdpLocalAddress)
-            .map_err(crate::Error::CreateLwoObfuscator)?;
 
-        let client = Client {
+        Ok(Self {
+            remote_socket,
             server_addr: settings.server_addr,
             rx_key: settings.client_public_key.clone(),
             tx_key: settings.server_public_key.clone(),
-            remote_socket,
-            client_socket,
-        };
-
-        Ok(Self {
-            local_endpoint,
-            client,
-        })
-    }
-
-    async fn run_forwarding(client: Client, cancel_token: CancellationToken) -> Result<(), Error> {
-        let mut running = client.connect().await?;
-        log::trace!("LWO client is running! 🎉");
-        tokio::select! {
-            _ = cancel_token.cancelled() => log::trace!("Stopping LWO obfuscation"),
-            _result = &mut running.send => log::trace!("LWO client closed (send_task)"),
-            _result = &mut running.recv => log::trace!("LWO client closed (recv_task)"),
-        };
-
-        Ok(())
-    }
-}
-
-struct Client {
-    server_addr: SocketAddr,
-
-    rx_key: PublicKey,
-    tx_key: PublicKey,
-
-    remote_socket: Arc<BypassSocket<UdpSocket>>,
-    client_socket: Arc<UdpSocket>,
-}
-
-/// Tokio task handles of a running [Client].
-struct RunningClient {
-    /// Egress task.
-    send: JoinHandle<()>,
-    /// Ingress task.
-    recv: JoinHandle<()>,
-}
-
-// Auto-abort the send/recv tasks on drop.
-impl Drop for RunningClient {
-    fn drop(&mut self) {
-        self.send.abort();
-        self.recv.abort();
-    }
-}
-
-impl Client {
-    /// Returns join handles to the send and receive tasks. These need to be aborted when the
-    /// obfuscator is aborted / finished.
-    async fn connect(self) -> Result<RunningClient, Error> {
-        let Client {
-            server_addr,
-            rx_key,
-            tx_key,
-            remote_socket,
-            client_socket,
-        } = self;
-
-        remote_socket
-            .connect(server_addr)
-            .await
-            .map_err(Error::ConnectRemoteUdp)?;
-        log::debug!("Connected to {server_addr}");
-
-        let client_addr = client_socket
-            .peek_sender()
-            .await
-            .map_err(Error::GetUdpLocalAddress)?;
-        client_socket
-            .connect(client_addr)
-            .await
-            .map_err(Error::PeekUdpSender)?;
-        log::debug!("Client socket connected to {client_addr}");
-
-        let rx_socket = client_socket.clone();
-        let tx_socket = remote_socket.clone();
-        let send_task = tokio::spawn(async move {
-            run_obfuscation(tx_key, rx_socket, tx_socket).await;
-        });
-
-        let rx_socket = remote_socket.clone();
-        let tx_socket = client_socket.clone();
-        let recv_task = tokio::spawn(async move {
-            run_deobfuscation(rx_key, rx_socket, tx_socket).await;
-        });
-
-        Ok(RunningClient {
-            send: send_task,
-            recv: recv_task,
         })
     }
 }
 
-async fn run_obfuscation(
-    key: PublicKey,
-    read_socket: Arc<UdpSocket>,
-    write_socket: Arc<BypassSocket<UdpSocket>>,
-) {
-    let mut buf = vec![0u8; MAX_UDP_SIZE];
+#[async_trait]
+impl ObfuscatedTransport for Lwo {
+    async fn send(&self, packet: &mut [u8]) -> io::Result<()> {
+        obfuscate(&mut rand::rng(), packet, self.tx_key.as_bytes());
+        self.remote_socket
+            .send_to(packet, self.server_addr)
+            .await
+            .map(drop)
+    }
 
-    loop {
-        let read_n = match read_socket.recv(&mut buf).await {
-            Ok(read_n) => read_n,
-            Err(err) => {
-                log::debug!("read_socket.recv failed: {err}");
-                return;
+    async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        loop {
+            let (n, from) = self.remote_socket.recv_from(buf).await?;
+            if from != self.server_addr {
+                continue;
             }
-        };
 
-        // TODO: recv and send concurrently
-        obfuscate(&mut rand::rng(), &mut buf, key.as_bytes());
-
-        if let Err(err) = write_socket.send(&buf[..read_n]).await {
-            log::debug!("write_socket.send_to failed: {err}");
-            return;
+            deobfuscate(&mut buf[..n], self.rx_key.as_bytes());
+            return Ok(n);
         }
     }
-}
 
-async fn run_deobfuscation(
-    key: PublicKey,
-    read_socket: Arc<BypassSocket<UdpSocket>>,
-    write_socket: Arc<UdpSocket>,
-) {
-    let mut buf = vec![0u8; MAX_UDP_SIZE];
-
-    loop {
-        let read_n = match read_socket.recv(&mut buf).await {
-            Ok(read_n) => read_n,
-            Err(err) => {
-                log::debug!("read_socket.recv failed: {err}");
-                return;
-            }
-        };
-
-        // TODO: recv and send concurrently
-        deobfuscate(&mut buf, key.as_bytes());
-
-        if let Err(err) = write_socket.send(&buf[..read_n]).await {
-            log::debug!("write_socket.send_to failed: {err}");
-            return;
-        }
+    fn packet_overhead(&self) -> u16 {
+        0
     }
 }
 
@@ -278,30 +134,6 @@ fn xor_bytes(data: &mut [u8], key: &[u8; 32]) {
     }
 }
 
-#[async_trait]
-impl LocalSocketObfuscator for Lwo {
-    fn endpoint(&self) -> SocketAddr {
-        self.local_endpoint
-    }
-
-    async fn run(self: Box<Self>) -> crate::Result<()> {
-        let token = CancellationToken::new();
-        let child_token = token.child_token();
-        // This will always cancel `child_token` as soon as `run` is finished or aborted.
-        let _drop_guard = token.drop_guard();
-
-        let client = self.client;
-        tokio::spawn(Lwo::run_forwarding(client, child_token))
-            .await
-            .unwrap()
-            .map_err(crate::Error::RunLwoObfuscator)
-    }
-
-    fn packet_overhead(&self) -> u16 {
-        0
-    }
-}
-
 /// Obfuscate a packet using a thread-local RNG.
 ///
 /// This is a convenience function for callers that do not want to manage their own RNG.
@@ -312,8 +144,6 @@ pub fn obfuscate_thread_local(packet: &mut [u8], key: &[u8; 32]) {
 
 #[cfg(test)]
 mod test {
-    use talpid_net::bypass::NoopBypass;
-
     use super::*;
 
     struct FixedByteRng(u8);
@@ -385,10 +215,12 @@ mod test {
             server_public_key: server_public_key.clone(),
         };
 
-        let lwo = Lwo::new(Arc::new(NoopBypass), &settings).await.unwrap();
-        let client_socket_addr = lwo.local_endpoint;
+        let lwo = crate::create_local_socket_obfuscator(&crate::Settings::Lwo(settings))
+            .await
+            .unwrap();
+        let client_socket_addr = lwo.endpoint();
 
-        tokio::spawn(Box::new(lwo).run());
+        tokio::spawn(lwo.run());
 
         let mut rng = &mut rand::rng();
 

--- a/tunnel-obfuscation/src/multiplexer.rs
+++ b/tunnel-obfuscation/src/multiplexer.rs
@@ -96,11 +96,11 @@ impl Multiplexer {
     pub async fn new(bypass: Arc<dyn SocketBypass>, settings: Settings) -> crate::Result<Self> {
         let client_socket = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0))
             .await
-            .map_err(crate::Error::CreateMultiplexerObfuscator)?;
+            .map_err(crate::Error::BindLocalUdp)?;
 
         let client_socket_addr = client_socket
             .local_addr()
-            .map_err(crate::Error::CreateMultiplexerObfuscator)?;
+            .map_err(crate::Error::BindLocalUdp)?;
 
         let proxy_socket_v4 = create_remote_socket(&bypass, true).await?;
         let proxy_socket_v6 = create_remote_socket(&bypass, false).await?;

--- a/tunnel-obfuscation/src/quic.rs
+++ b/tunnel-obfuscation/src/quic.rs
@@ -1,24 +1,22 @@
 //! Quic obfuscation
 
 use async_trait::async_trait;
+use bytes::BytesMut;
 use mullvad_masque_proxy::client::ClientConfig;
-use std::{
-    io,
-    net::{Ipv4Addr, Ipv6Addr, SocketAddr},
-    sync::Arc,
-};
+use std::{io, net::SocketAddr, sync::Arc};
 use talpid_net::bypass::{BypassGuard, BypassSocket, SocketBypass};
-use tokio::net::UdpSocket;
-use tokio_util::sync::CancellationToken;
+use tokio::{
+    net::UdpSocket,
+    sync::{Mutex, mpsc},
+};
+use tokio_util::task::AbortOnDropHandle;
 
 pub use mullvad_masque_proxy::{
     HTTP_MASQUE_DATAGRAM_CONTEXT_ID, MAX_INFLIGHT_PACKETS,
     client::{Client, RunningClient},
 };
 
-use crate::{LocalSocketObfuscator, socket::create_remote_socket};
-
-type Result<T> = std::result::Result<T, Error>;
+use crate::{socket::create_remote_socket, transport::ObfuscatedTransport};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -28,11 +26,15 @@ pub enum Error {
     MasqueProxyError(#[from] mullvad_masque_proxy::client::Error),
 }
 
-pub struct QuicLocalSocket {
-    local_endpoint: SocketAddr,
-    /// Local UDP socket that WireGuard sends to and receives from.
-    local_socket: UdpSocket,
-    config: ClientConfig,
+/// Tunnels WireGuard packets through a MASQUE proxy over QUIC.
+pub struct QuicTransport {
+    /// Plaintext packets to be proxied to the remote.
+    outgoing_tx: mpsc::Sender<BytesMut>,
+    /// Plaintext packets received from the remote. Only ever drained by [ObfuscatedTransport::recv],
+    /// so the lock is uncontended.
+    incoming_rx: Mutex<mpsc::Receiver<BytesMut>>,
+    /// Aborts the QUIC client when this transport is dropped.
+    _client: AbortOnDropHandle<()>,
     _bypass: BypassGuard,
 }
 
@@ -143,19 +145,11 @@ impl std::str::FromStr for AuthToken {
     }
 }
 
-impl QuicLocalSocket {
+impl QuicTransport {
     pub(crate) async fn new(
         bypass: Arc<dyn SocketBypass>,
         settings: &Settings,
     ) -> crate::Result<Self> {
-        // The address family of the local QUIC client socket has to match the address family
-        // of the endpoint we're connecting to. The address itself is not important to consumers
-        // wanting to obfuscate traffic. It is solely used by the local proxy client to know
-        // where the QUIC obfuscator is running.
-        let (local_socket, local_udp_client_addr) =
-            QuicLocalSocket::create_local_udp_socket(settings.quic_endpoint.is_ipv4())
-                .await
-                .map_err(crate::Error::CreateQuicObfuscator)?;
         let BypassSocket {
             socket: quic_socket,
             guard: _bypass,
@@ -163,81 +157,70 @@ impl QuicLocalSocket {
 
         let config = settings.build_client_config(quic_socket);
 
-        let quic = QuicLocalSocket {
-            local_endpoint: local_udp_client_addr,
-            local_socket,
-            config,
+        let (outgoing_tx, outgoing_rx) = mpsc::channel(MAX_INFLIGHT_PACKETS);
+        let (incoming_tx, incoming_rx) = mpsc::channel(MAX_INFLIGHT_PACKETS);
+
+        let client = tokio::spawn(run_client(config, outgoing_rx, incoming_tx));
+
+        Ok(Self {
+            outgoing_tx,
+            incoming_rx: Mutex::new(incoming_rx),
+            _client: AbortOnDropHandle::new(client),
             _bypass,
-        };
-
-        Ok(quic)
+        })
     }
+}
 
-    async fn run_forwarding(
-        client: Client,
-        local_socket: UdpSocket,
-        cancel_token: CancellationToken,
-    ) -> Result<()> {
-        let client = client.proxy_socket(local_socket);
-        log::trace!("QUIC client is running! QUIC Obfuscator is serving traffic 🎉");
-        tokio::select! {
-            _ = cancel_token.cancelled() => log::trace!("Stopping QUIC obfuscation"),
-            _result = client.until_closed() => log::trace!("QUIC client closed"),
-        };
+async fn run_client(
+    config: ClientConfig,
+    outgoing_rx: mpsc::Receiver<BytesMut>,
+    incoming_tx: mpsc::Sender<BytesMut>,
+) {
+    let client = match Client::connect(config).await {
+        Ok(client) => client,
+        Err(err) => {
+            log::error!("Failed to connect QUIC client: {err}");
+            return;
+        }
+    };
+    log::trace!("QUIC client is running! QUIC Obfuscator is serving traffic 🎉");
 
-        Ok(())
-    }
-
-    /// Create a local proxy client.
-    ///
-    /// The resulting UdpSocket/the SocketAddr where programs that want to obfuscate their
-    /// traffic with QUIC will write to.
-    async fn create_local_udp_socket(ipv4: bool) -> Result<(UdpSocket, SocketAddr)> {
-        let random_bind_addr = if ipv4 {
-            SocketAddr::from((Ipv4Addr::LOCALHOST, 0))
-        } else {
-            SocketAddr::from((Ipv6Addr::LOCALHOST, 0))
-        };
-        let local_udp_socket = UdpSocket::bind(random_bind_addr)
-            .await
-            .map_err(Error::BindError)?;
-        let udp_client_addr = local_udp_socket.local_addr().unwrap();
-
-        Ok((local_udp_socket, udp_client_addr))
+    if let Err(err) = client
+        .proxy_channels(outgoing_rx, incoming_tx)
+        .until_closed()
+        .await
+    {
+        log::debug!("QUIC client closed: {err}");
     }
 }
 
 #[async_trait]
-impl LocalSocketObfuscator for QuicLocalSocket {
-    fn endpoint(&self) -> SocketAddr {
-        self.local_endpoint
+impl ObfuscatedTransport for QuicTransport {
+    async fn send(&self, packet: &mut [u8]) -> io::Result<()> {
+        self.outgoing_tx
+            .send(BytesMut::from(&packet[..]))
+            .await
+            .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "QUIC client stopped"))
     }
 
-    async fn run(self: Box<Self>) -> crate::Result<()> {
-        let Self {
-            config,
-            local_socket,
-            ..
-        } = *self;
-
-        let token = CancellationToken::new();
-        let child_token = token.child_token();
-        // This will always cancel `child_token` as soon as `run` is finished or aborted.
-        let _drop_guard = token.drop_guard();
-
-        let client = Client::connect(config)
+    async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        let packet = self
+            .incoming_rx
+            .lock()
             .await
-            .map_err(Error::MasqueProxyError)
-            .map_err(crate::Error::RunQuicObfuscator)?;
+            .recv()
+            .await
+            .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "QUIC client stopped"))?;
 
-        tokio::spawn(QuicLocalSocket::run_forwarding(
-            client,
-            local_socket,
-            child_token,
-        ))
-        .await
-        .unwrap()
-        .map_err(crate::Error::RunQuicObfuscator)
+        if packet.len() > buf.len() {
+            return Err(io::Error::other(format!(
+                "QUIC packet of {} bytes does not fit in a {} byte buffer",
+                packet.len(),
+                buf.len()
+            )));
+        }
+        buf[..packet.len()].copy_from_slice(&packet);
+        Ok(packet.len())
     }
 
     fn packet_overhead(&self) -> u16 {

--- a/tunnel-obfuscation/src/shadowsocks.rs
+++ b/tunnel-obfuscation/src/shadowsocks.rs
@@ -1,25 +1,18 @@
 //! Shadowsocks obfuscation
-//!
-//! Note: It is important not to connect to the shadowsocks endpoint right away. The remote socket
-//! must be protected in `VpnService` so that the socket is not routed through the tunnel.
 
-use crate::socket::create_remote_socket;
+use crate::{socket::create_remote_socket, transport::ObfuscatedTransport};
 
-use super::LocalSocketObfuscator;
 use async_trait::async_trait;
 use shadowsocks::{
     ProxySocket,
     config::{ServerConfig, ServerConfigError, ServerType},
     context::Context,
     crypto::CipherKind,
-    relay::{
-        Address,
-        udprelay::proxy_socket::{ProxySocketError, UdpSocketType},
-    },
+    relay::{Address, udprelay::proxy_socket::UdpSocketType},
 };
 use std::{io, net::SocketAddr, sync::Arc};
 use talpid_net::bypass::{BypassSocket, SocketBypass};
-use tokio::{net::UdpSocket, sync::oneshot};
+use tokio::net::UdpSocket;
 
 const SHADOWSOCKS_CIPHER: CipherKind = CipherKind::AES_256_GCM;
 const SHADOWSOCKS_PASSWORD: &str = "mullvad";
@@ -30,26 +23,15 @@ type ShadowSocket = BypassSocket<ProxySocket<shadowsocks::net::UdpSocket>>;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    /// Failed to bind local UDP socket
-    #[error("Failed to bind UDP socket")]
-    BindUdp(#[source] io::Error),
-    /// Missing UDP listener address
-    #[error("Failed to retrieve UDP socket bind address")]
-    GetUdpLocalAddress(#[source] io::Error),
-    /// Failed to wait for UDP client
-    #[error("Failed to wait for UDP client")]
-    WaitForUdpClient(#[source] io::Error),
     /// Server config error
     #[error("Server config error")]
     ServerConfig(#[from] ServerConfigError),
 }
 
 pub struct Shadowsocks {
-    udp_client_addr: SocketAddr,
-    wireguard_endpoint: SocketAddr,
-    server: tokio::task::JoinHandle<Result<()>>,
-    // The receiver will implicitly shut down when this is dropped
-    _shutdown_tx: oneshot::Sender<()>,
+    socket: ShadowSocket,
+    shadowsocks_endpoint: SocketAddr,
+    wireguard_endpoint: Address,
 }
 
 #[derive(Debug, Clone)]
@@ -65,79 +47,25 @@ impl Shadowsocks {
         bypass: Arc<dyn SocketBypass>,
         settings: &Settings,
     ) -> crate::Result<Self> {
-        let (local_udp_socket, udp_client_addr) =
-            create_local_udp_socket(settings.shadowsocks_endpoint.is_ipv4())
-                .await
-                .map_err(crate::Error::CreateShadowsocksObfuscator)?;
-
-        let (shutdown_tx, shutdown_rx) = oneshot::channel();
-
         let remote_socket =
             create_remote_socket(&bypass, settings.shadowsocks_endpoint.is_ipv4()).await?;
 
-        let server = tokio::spawn(run_forwarding(
-            settings.shadowsocks_endpoint,
-            remote_socket,
-            local_udp_socket,
-            settings.wireguard_endpoint,
-            shutdown_rx,
-        ));
+        let socket = wrap_shadowsocks(remote_socket, settings.shadowsocks_endpoint)
+            .map_err(crate::Error::CreateShadowsocksObfuscator)?;
 
         Ok(Shadowsocks {
-            udp_client_addr,
-            wireguard_endpoint: settings.wireguard_endpoint,
-            server,
-            _shutdown_tx: shutdown_tx,
+            socket,
+            shadowsocks_endpoint: settings.shadowsocks_endpoint,
+            wireguard_endpoint: Address::SocketAddress(settings.wireguard_endpoint),
         })
     }
 }
 
-async fn run_forwarding(
-    shadowsocks_endpoint: SocketAddr,
-    remote_socket: BypassSocket<UdpSocket>,
-    local_udp_socket: UdpSocket,
-    wireguard_endpoint: SocketAddr,
-    shutdown_rx: oneshot::Receiver<()>,
-) -> Result<()> {
-    wait_for_local_udp_client(&local_udp_socket)
-        .await
-        .map_err(Error::WaitForUdpClient)?;
-
-    let shadowsocks = connect_shadowsocks(remote_socket, shadowsocks_endpoint)?;
-    let shadowsocks = Arc::new(shadowsocks);
-
-    let local_udp = Arc::new(local_udp_socket);
-
-    let wg_addr = Address::SocketAddress(wireguard_endpoint);
-
-    let mut client = tokio::spawn(handle_outgoing(
-        shadowsocks.clone(),
-        local_udp.clone(),
-        shadowsocks_endpoint,
-        wg_addr.clone(),
-    ));
-    let mut server = tokio::spawn(handle_incoming(
-        shadowsocks,
-        local_udp,
-        shadowsocks_endpoint,
-        wg_addr,
-    ));
-
-    tokio::select! {
-        _ = shutdown_rx => {
-            log::trace!("Stopping shadowsocks obfuscation");
-        }
-        _result = &mut server => log::trace!("Shadowsocks client closed"),
-        _result = &mut client => log::trace!("Local UDP client closed"),
-    }
-
-    client.abort();
-    server.abort();
-
-    Ok(())
-}
-
-fn connect_shadowsocks(
+/// Wrap the remote socket in a Shadowsocks [ProxySocket].
+///
+/// This performs no I/O; the socket has already been excluded from tunnel traffic by
+/// [create_remote_socket].
+fn wrap_shadowsocks(
     remote_socket: BypassSocket<UdpSocket>,
     shadowsocks_endpoint: SocketAddr,
 ) -> Result<ShadowSocket> {
@@ -158,107 +86,34 @@ fn connect_shadowsocks(
     Ok(BypassSocket { socket, guard })
 }
 
-async fn create_local_udp_socket(ipv4: bool) -> Result<(UdpSocket, SocketAddr)> {
-    let random_bind_addr = if ipv4 {
-        SocketAddr::new("127.0.0.1".parse().unwrap(), 0)
-    } else {
-        SocketAddr::new("::1".parse().unwrap(), 0)
-    };
-    let local_udp_socket = UdpSocket::bind(random_bind_addr)
-        .await
-        .map_err(Error::BindUdp)?;
-    let udp_client_addr = local_udp_socket
-        .local_addr()
-        .map_err(Error::GetUdpLocalAddress)?;
-
-    Ok((local_udp_socket, udp_client_addr))
-}
-
-/// Wait for a client to connect to `udp_listener` and connect the socket to that address
-async fn wait_for_local_udp_client(udp_listener: &UdpSocket) -> io::Result<()> {
-    log::trace!("Waiting for UDP socket client");
-    let client_addr = udp_listener.peek_sender().await?;
-
-    log::trace!("UDP connection from {client_addr}");
-    udp_listener.connect(client_addr).await
-}
-
-async fn handle_outgoing(
-    ss_write: Arc<ShadowSocket>,
-    local_udp_read: Arc<UdpSocket>,
-    ss_addr: SocketAddr,
-    wg_addr: Address,
-) {
-    let mut rx_buffer = vec![0u8; u16::MAX as usize];
-
-    loop {
-        let read_n = match local_udp_read.recv(&mut rx_buffer).await {
-            Ok(read_n) => read_n,
-            Err(error) => {
-                log::error!("Failed to read from local UDP socket: {error}");
-                break;
-            }
-        };
-
-        if let Err(error) = ss_write
-            .send_to(ss_addr, &wg_addr, &rx_buffer[0..read_n])
-            .await
-        {
-            if is_fatal_socket_error(&error) {
-                log::error!("Failed to write to Shadowsocks client: {error}");
-                break;
-            }
-            log::trace!("Failed to write to Shadowsocks client: {error}");
-        }
-    }
-}
-
-async fn handle_incoming(
-    ss_read: Arc<ShadowSocket>,
-    local_udp_write: Arc<UdpSocket>,
-    ss_addr: SocketAddr,
-    wg_addr: Address,
-) {
-    let mut rx_buffer = vec![0u8; u16::MAX as usize];
-
-    loop {
-        let (read_n, _rx_addr, addr, _ctrl) = match ss_read.recv_from(&mut rx_buffer).await {
-            Ok((read_n, rx_addr, addr, _ctrl)) if rx_addr == ss_addr => {
-                (read_n, rx_addr, addr, _ctrl)
-            }
-            // Ignore incoming from unexpected source
-            Ok(_) => continue,
-            Err(error) => {
-                log::error!("Failed to read from Shadowsocks client: {error}");
-                break;
-            }
-        };
-
-        if addr != wg_addr {
-            log::trace!("Ignoring packet from unexpected source: {addr}");
-            continue;
-        }
-
-        if let Err(error) = local_udp_write.send(&rx_buffer[0..read_n]).await {
-            log::error!("Failed to write to local UDP socket: {error}");
-            if is_fatal_socket_io_error(&error) {
-                break;
-            }
-        }
-    }
-}
-
 #[async_trait]
-impl LocalSocketObfuscator for Shadowsocks {
-    fn endpoint(&self) -> SocketAddr {
-        self.udp_client_addr
+impl ObfuscatedTransport for Shadowsocks {
+    async fn send(&self, packet: &mut [u8]) -> io::Result<()> {
+        self.socket
+            .send_to(self.shadowsocks_endpoint, &self.wireguard_endpoint, packet)
+            .await
+            .map_err(|error| {
+                log::trace!("Failed to write to Shadowsocks client: {error}");
+                io::Error::other(error)
+            })
+            .map(drop)
     }
 
-    async fn run(self: Box<Self>) -> crate::Result<()> {
-        match self.server.await {
-            Ok(result) => result.map_err(crate::Error::RunShadowsocksObfuscator),
-            Err(_err) if _err.is_cancelled() => Ok(()),
-            Err(_err) => panic!("server handle panicked"),
+    async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        loop {
+            let (n, rx_addr, addr, _ctrl) =
+                self.socket.recv_from(buf).await.map_err(io::Error::other)?;
+
+            if rx_addr != self.shadowsocks_endpoint {
+                log::trace!("Ignoring packet from unexpected Shadowsocks server: {rx_addr}");
+                continue;
+            }
+            if addr != self.wireguard_endpoint {
+                log::trace!("Ignoring packet from unexpected source: {addr}");
+                continue;
+            }
+
+            return Ok(n);
         }
     }
 
@@ -269,25 +124,9 @@ impl LocalSocketObfuscator for Shadowsocks {
         debug_assert!(SHADOWSOCKS_CIPHER.is_aead());
 
         let overhead = SHADOWSOCKS_CIPHER.salt_len()
-            + Address::from(self.wireguard_endpoint).serialized_len()
+            + self.wireguard_endpoint.serialized_len()
             + SHADOWSOCKS_CIPHER.tag_len();
 
         u16::try_from(overhead).expect("packet overhead is less than u16::MAX")
     }
-}
-
-/// Return whether retrying is a lost cause
-fn is_fatal_socket_error(error: &ProxySocketError) -> bool {
-    matches!(error, ProxySocketError::IoError(e) if is_fatal_socket_io_error(e))
-}
-
-fn is_fatal_socket_io_error(error: &io::Error) -> bool {
-    matches!(
-        error.kind(),
-        io::ErrorKind::NotConnected
-            | io::ErrorKind::ConnectionReset
-            | io::ErrorKind::ConnectionRefused
-            | io::ErrorKind::ConnectionAborted
-            | io::ErrorKind::BrokenPipe
-    )
 }

--- a/tunnel-obfuscation/src/transport.rs
+++ b/tunnel-obfuscation/src/transport.rs
@@ -1,0 +1,37 @@
+//! The interface between plaintext WireGuard traffic and an obfuscation method.
+
+use std::io;
+
+use async_trait::async_trait;
+
+/// The largest datagram that can be sent or received. Buffers passed to
+/// [ObfuscatedTransport::recv] should be this large.
+pub const MAX_DATAGRAM_SIZE: usize = u16::MAX as usize;
+
+/// An obfuscation method, as seen by whoever has plaintext WireGuard datagrams to move.
+///
+/// [Self::send] obfuscates a datagram and transmits it to the remote; [Self::recv] receives one
+/// from the remote and deobfuscates it.
+///
+/// # Cancel safety
+///
+/// Both methods must be cancel safe. A caller may drop a [Self::recv] future before it completes,
+/// and an implementation that loses a datagram when that happens would drop packets silently.
+///
+/// However, callers must treat the buffer as clobbered once [Self::send] has been called, as
+/// implementations may mutate it in place.
+#[async_trait]
+pub trait ObfuscatedTransport: Send + Sync {
+    /// Obfuscate `packet` and send it to the remote.
+    ///
+    /// `packet` may be modified arbitrarily.
+    async fn send(&self, packet: &mut [u8]) -> io::Result<()>;
+
+    /// Receive a packet from the remote into `buf`, deobfuscate it, and return its length.
+    ///
+    /// Blocks until a packet arrives, which may be indefinitely.
+    async fn recv(&self, buf: &mut [u8]) -> io::Result<usize>;
+
+    /// The overhead (in bytes) of this obfuscation protocol.
+    fn packet_overhead(&self) -> u16;
+}

--- a/tunnel-obfuscation/src/udp2tcp.rs
+++ b/tunnel-obfuscation/src/udp2tcp.rs
@@ -1,13 +1,22 @@
-use crate::LocalSocketObfuscator;
+//! Tunnels datagrams to the remote inside a TCP stream, each one prefixed with its length.
+
+use std::{io, net::SocketAddr, sync::Arc};
+
 use async_trait::async_trait;
-use std::{
-    io,
-    net::{Ipv4Addr, SocketAddr},
-    sync::Arc,
+use talpid_net::bypass::{BypassGuard, BypassSocket, SocketBypass};
+use tokio::{
+    net::TcpSocket,
+    sync::{Mutex, mpsc},
 };
-use talpid_net::bypass::{BypassSocket, SocketBypass};
-use tokio::net::{TcpSocket, UdpSocket};
-use udp_over_tcp::{HEADER_LEN, process_udp_over_tcp};
+use tokio_util::task::AbortOnDropHandle;
+use udp_over_tcp::{DatagramSocket, HEADER_LEN, process_udp_over_tcp};
+
+use crate::transport::ObfuscatedTransport;
+
+/// How many datagrams may be waiting in either direction between us and the forwarder.
+///
+/// Sending blocks once this many are queued.
+const DATAGRAM_QUEUE_LEN: usize = 128;
 
 #[derive(Debug, Clone)]
 pub struct Settings {
@@ -20,106 +29,98 @@ pub enum Error {
     #[error("Failed to create the TCP socket")]
     CreateTcpSocket(#[source] io::Error),
 
-    /// Failed to disable the Nagle algorithm
-    #[error("Failed to disable the Nagle algorithm")]
-    SetNodelay(#[source] io::Error),
-
-    /// Failed to bind the local UDP socket
-    #[error("Failed to bind the local UDP socket")]
-    BindLocalUdp(#[source] io::Error),
-
-    /// Failed to exclude the TCP socket from tunnel traffic
-    #[error("Failed to exclude the TCP socket from tunnel traffic")]
-    Bypass(#[source] io::Error),
-
-    /// Failed to accept the local WireGuard instance
-    #[error("Failed to accept the local WireGuard instance")]
-    ConnectLocalUdp(#[source] io::Error),
-
     /// Failed to connect to the remote
     #[error("Failed to connect to the remote")]
     ConnectTcp(#[source] io::Error),
+
+    /// Failed to disable the Nagle algorithm
+    #[error("Failed to disable the Nagle algorithm")]
+    SetNodelay(#[source] io::Error),
 }
 
-/// Forwards datagrams over a TCP stream, using `udp-over-tcp`.
+/// Forwards datagrams over a TCP stream, using the `udp-over-tcp` protocol.
+///
+/// The framing is done by `udp-over-tcp`'s forwarder, which owns the TCP stream and runs as a
+/// background task. It picks datagrams up from, and delivers them to, a pair of in-memory queues,
+/// so [Self::send] and [Self::recv] only ever touch those queues.
 pub struct Udp2Tcp {
-    udp_socket: UdpSocket,
-    tcp_socket: BypassSocket<TcpSocket>,
-    peer: SocketAddr,
+    /// Datagrams destined for the remote. Picked up by [Queues::recv].
+    outgoing: mpsc::Sender<Box<[u8]>>,
+
+    /// Datagrams that arrived from the remote, put there by [Queues::send].
+    ///
+    /// The [Mutex] is uncontended in practice, since whoever drives this transport receives from
+    /// a single task.
+    incoming: Mutex<mpsc::Receiver<Box<[u8]>>>,
+
+    /// Stops the forwarder when this transport is dropped.
+    _forwarder: AbortOnDropHandle<()>,
+
+    /// Keeps the TCP socket excluded from tunnel traffic.
+    _bypass: BypassGuard,
 }
 
 impl Udp2Tcp {
-    pub(crate) async fn new(
-        bypass: Arc<dyn SocketBypass>,
-        settings: &Settings,
-    ) -> crate::Result<Self> {
-        Self::create(bypass, settings)
-            .await
-            .map_err(crate::Error::CreateUdp2TcpObfuscator)
-    }
-
-    async fn create(bypass: Arc<dyn SocketBypass>, settings: &Settings) -> Result<Self, Error> {
-        let listen_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
-        let udp_socket = UdpSocket::bind(listen_addr)
-            .await
-            .map_err(Error::BindLocalUdp)?;
-
+    pub(crate) fn new(bypass: Arc<dyn SocketBypass>, settings: &Settings) -> crate::Result<Self> {
         let tcp_socket = match settings.peer {
             SocketAddr::V4(..) => TcpSocket::new_v4(),
             SocketAddr::V6(..) => TcpSocket::new_v6(),
         }
-        .map_err(Error::CreateTcpSocket)?;
+        .map_err(Error::CreateTcpSocket)
+        .map_err(crate::Error::CreateUdp2TcpObfuscator)?;
 
         // Disables the Nagle algorithm on the TCP socket. Improves performance
-        tcp_socket.set_nodelay(true).map_err(Error::SetNodelay)?;
+        tcp_socket
+            .set_nodelay(true)
+            .map_err(Error::SetNodelay)
+            .map_err(crate::Error::CreateUdp2TcpObfuscator)?;
 
-        let tcp_socket = BypassSocket::new(bypass, tcp_socket).map_err(Error::Bypass)?;
+        let BypassSocket {
+            socket: tcp_socket,
+            guard: _bypass,
+        } = BypassSocket::new(bypass, tcp_socket).map_err(crate::Error::Bypass)?;
+
+        let (outgoing, outgoing_rx) = mpsc::channel(DATAGRAM_QUEUE_LEN);
+        let (incoming_tx, incoming) = mpsc::channel(DATAGRAM_QUEUE_LEN);
+        let queues = Queues {
+            incoming: incoming_tx,
+            outgoing: Mutex::new(outgoing_rx),
+        };
+
+        let peer = settings.peer;
+        let forwarder = tokio::spawn(async move {
+            if let Err(err) = forward(queues, tcp_socket, peer).await {
+                log::error!("The udp-over-tcp forwarder stopped: {err}");
+            }
+        });
 
         Ok(Self {
-            udp_socket,
-            tcp_socket,
-            peer: settings.peer,
+            outgoing,
+            incoming: Mutex::new(incoming),
+            _forwarder: AbortOnDropHandle::new(forwarder),
+            _bypass,
         })
-    }
-
-    /// Wait for the local WireGuard instance, then shuttle datagrams until the stream closes.
-    async fn forward(self: Box<Self>) -> Result<(), Error> {
-        let Self {
-            udp_socket,
-            tcp_socket,
-            peer,
-        } = *self;
-
-        let wg_addr = udp_socket
-            .peek_sender()
-            .await
-            .map_err(Error::ConnectLocalUdp)?;
-        udp_socket
-            .connect(wg_addr)
-            .await
-            .map_err(Error::ConnectLocalUdp)?;
-
-        let (tcp_socket, _bypass) = (tcp_socket.socket, tcp_socket.guard);
-        let tcp_stream = tcp_socket.connect(peer).await.map_err(Error::ConnectTcp)?;
-        log::debug!("Connected to {peer}");
-
-        process_udp_over_tcp(udp_socket, tcp_stream, None).await;
-        Ok(())
     }
 }
 
 #[async_trait]
-impl LocalSocketObfuscator for Udp2Tcp {
-    fn endpoint(&self) -> SocketAddr {
-        self.udp_socket
-            .local_addr()
-            .expect("the local socket is bound")
+impl ObfuscatedTransport for Udp2Tcp {
+    async fn send(&self, packet: &mut [u8]) -> io::Result<()> {
+        self.outgoing
+            .send(Box::from(&packet[..]))
+            .await
+            .map_err(|_| stopped())
     }
 
-    async fn run(self: Box<Self>) -> crate::Result<()> {
-        self.forward()
+    async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        let datagram = self
+            .incoming
+            .lock()
             .await
-            .map_err(crate::Error::RunUdp2TcpObfuscator)
+            .recv()
+            .await
+            .ok_or_else(stopped)?;
+        copy_datagram(&datagram, buf)
     }
 
     fn packet_overhead(&self) -> u16 {
@@ -129,5 +130,128 @@ impl LocalSocketObfuscator for Udp2Tcp {
         let overhead = max_tcp_header_len - udp_header_len + HEADER_LEN;
 
         u16::try_from(overhead).expect("packet overhead is less than u16::MAX")
+    }
+}
+
+/// Connect to `peer` and shuttle datagrams between `queues` and the stream until it closes.
+///
+/// Dropping `queues` on the way out closes both of them, which is what makes [Udp2Tcp::send] and
+/// [Udp2Tcp::recv] fail once the connection is gone, rather than wait for a stream that nobody is
+/// reading.
+async fn forward(queues: Queues, tcp_socket: TcpSocket, peer: SocketAddr) -> Result<(), Error> {
+    let tcp_stream = tcp_socket.connect(peer).await.map_err(Error::ConnectTcp)?;
+    log::debug!("Connected to {peer}");
+
+    process_udp_over_tcp(queues, tcp_stream, None).await;
+    Ok(())
+}
+
+/// The forwarder's end of the queues that [Udp2Tcp] holds the other end of.
+///
+/// This stands in for the UDP socket that `udp-over-tcp` would otherwise read datagrams from and
+/// write them to, which lets the datagrams stay in memory rather than take a trip through the
+/// kernel.
+struct Queues {
+    /// Datagrams that arrived from the remote, handed to [Udp2Tcp::recv].
+    incoming: mpsc::Sender<Box<[u8]>>,
+
+    /// Datagrams destined for the remote, put there by [Udp2Tcp::send].
+    outgoing: Mutex<mpsc::Receiver<Box<[u8]>>>,
+}
+
+impl DatagramSocket for Queues {
+    async fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        self.incoming
+            .send(Box::from(buf))
+            .await
+            .map_err(|_| stopped())?;
+        Ok(buf.len())
+    }
+
+    async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        let datagram = self
+            .outgoing
+            .lock()
+            .await
+            .recv()
+            .await
+            .ok_or_else(stopped)?;
+        copy_datagram(&datagram, buf)
+    }
+}
+
+fn copy_datagram(datagram: &[u8], buf: &mut [u8]) -> io::Result<usize> {
+    buf.get_mut(..datagram.len())
+        .ok_or_else(|| io::Error::other("datagram does not fit in the receive buffer"))?
+        .copy_from_slice(datagram);
+    Ok(datagram.len())
+}
+
+fn stopped() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::BrokenPipe,
+        "the udp-over-tcp forwarder stopped",
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use talpid_net::bypass::NoopBypass;
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+    };
+
+    /// Send a packet in each direction and assert that it appears on the TCP stream with the
+    /// length header that the `udp-over-tcp` protocol prescribes.
+    #[tokio::test]
+    async fn test_length_prefixed_framing() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let peer = listener.local_addr().unwrap();
+
+        let udp2tcp = Udp2Tcp::new(Arc::new(NoopBypass), &Settings { peer }).unwrap();
+        let (mut remote, _) = listener.accept().await.unwrap();
+
+        udp2tcp.send(&mut [1, 2, 3]).await.unwrap();
+
+        let mut framed = [0u8; 5];
+        remote.read_exact(&mut framed).await.unwrap();
+        assert_eq!(framed, [0, 3, 1, 2, 3]);
+
+        remote.write_all(&[0, 2, 9, 8]).await.unwrap();
+
+        let mut buf = [0u8; crate::transport::MAX_DATAGRAM_SIZE];
+        let n = udp2tcp.recv(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], &[9, 8]);
+    }
+
+    /// Constructing the transport must not wait for the TCP handshake. A failure to connect
+    /// surfaces from `recv` instead.
+    #[tokio::test]
+    async fn test_connects_in_the_background() {
+        // Nothing is listening on this address once the listener is dropped.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let peer = listener.local_addr().unwrap();
+        drop(listener);
+
+        let udp2tcp = Udp2Tcp::new(Arc::new(NoopBypass), &Settings { peer }).unwrap();
+
+        let mut buf = [0u8; crate::transport::MAX_DATAGRAM_SIZE];
+        udp2tcp.recv(&mut buf).await.unwrap_err();
+    }
+
+    /// The transport must report an error, rather than wait forever, once the remote hangs up.
+    #[tokio::test]
+    async fn test_recv_fails_when_remote_disconnects() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let peer = listener.local_addr().unwrap();
+
+        let udp2tcp = Udp2Tcp::new(Arc::new(NoopBypass), &Settings { peer }).unwrap();
+        let (remote, _) = listener.accept().await.unwrap();
+        drop(remote);
+
+        let mut buf = [0u8; crate::transport::MAX_DATAGRAM_SIZE];
+        udp2tcp.recv(&mut buf).await.unwrap_err();
     }
 }


### PR DESCRIPTION
Every obfuscation method just implements the `ObfuscatedTransport` trait. This can be wrapped in `LocalSocketRunner` if a UDP socket interface is needed.

Future PRs will use this for implementing the remaining userspace obfuscators as well as the multiplexer.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10949)
<!-- Reviewable:end -->
