### PR TITLE
Always use userspace obfuscation except for multiplexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Line wrap the file at 100 chars.                                              Th
 - Clicking on the tray icon will toggle the window instead of just showing it
 - Old `mullvad log set-level` command has been renamed to `mullvad log set-rust-log`.
 - Remove `mullvad tunnel set daita-direct-only` command. Superseded by automatic multihop setting.
+- Improve obfuscation performance by using GotaTun. This mainly affects Shadowsocks.
 
 #### Linux
 - Make all timestamps embedded in `.deb` and `.rpm` packages deterministic by deriving them from

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -201,8 +201,8 @@ impl WireguardMonitor {
             .block_on(get_route_mtu(params, &args.route_manager));
         let tunnel_mtu = calculate_tunnel_mtu(route_mtu, params, userspace_wireguard);
 
-        // Build obfuscation settings and optionally start a local socket obfuscator.
-        // For GotaTun + LWO/QUIC, obfuscation is applied inline and no local socket is needed.
+        // Build obfuscation settings and optionally start a local socket obfuscator. Only the
+        // multiplexer still needs one; every single method is applied inline by GotaTun.
         let obfuscation_mtu = route_mtu;
         let mut config =
             crate::config::Config::from_parameters(params, tunnel_mtu, obfuscation_mtu)
@@ -493,7 +493,7 @@ impl WireguardMonitor {
         );
 
         // Android always uses GotaTun (userspace WireGuard). When the obfuscation can be
-        // applied inline (LWO or QUIC), skip the local socket obfuscator and let
+        // applied inline, skip the local socket obfuscator and let
         // MaybeObfuscatingTransportFactory handle it directly.
         let userspace_obfuscation =
             obfuscation::userspace_transport_available(params) && !*FORCE_LOCAL_SOCKET_OBFUSCATION;

--- a/talpid-wireguard/src/obfuscation.rs
+++ b/talpid-wireguard/src/obfuscation.rs
@@ -120,14 +120,14 @@ pub async fn spawn_local_socket_obfuscator(
 
 /// Returns `true` when the obfuscation config can be applied inline in userspace WireGuard
 /// (GotaTun), avoiding the need for a local socket obfuscator.
+///
+/// Every single obfuscation method is an `ObfuscatedTransport`, which GotaTun drives directly.
+/// The multiplexer is not: it races several transports against each other and only commits to
+/// one of them once it answers, so it is still reached over a local socket.
 pub fn userspace_transport_available(
     params: &talpid_types::net::wireguard::TunnelParameters,
 ) -> bool {
-    matches!(
-        params.obfuscation.as_ref(),
-        Some(Obfuscators::Single(ObfuscatorConfig::Lwo { .. }))
-            | Some(Obfuscators::Single(ObfuscatorConfig::Quic { .. }))
-    )
+    matches!(params.obfuscation.as_ref(), Some(Obfuscators::Single(_)))
 }
 
 /// Patch the first peer in the WireGuard configuration to use the local proxy endpoint


### PR DESCRIPTION
Follow-up to #10950. Multiplexer will come in future PRs.

It is (currently) still possible to force local socket obfuscation using `TALPID_FORCE_LOCAL_SOCKET_OBFUSCATION`.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10951)
<!-- Reviewable:end -->
