### PR TITLE
Add GotaTun actor to iOS app

### DIFF
--- a/ios/MullvadTypes/ObfuscationMethod.swift
+++ b/ios/MullvadTypes/ObfuscationMethod.swift
@@ -24,4 +24,14 @@ public enum ObfuscationMethod: Equatable, Codable, Sendable {
             true
         }
     }
+
+    /// The transport layer carrying the tunnel traffic to the relay.
+    public var transportLayer: TransportLayer {
+        switch self {
+        case .udpOverTcp:
+            .tcp
+        case .off, .shadowsocks, .quic, .lwo:
+            .udp
+        }
+    }
 }

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		0107F42D2F5F62950012451B /* MullvadSettings.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58B2FDD32AA71D2A003EB5C6 /* MullvadSettings.framework */; };
 		0107F4322F5F62C80012451B /* MullvadSettings.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58B2FDD32AA71D2A003EB5C6 /* MullvadSettings.framework */; };
 		0107F4362F5F62CE0012451B /* MullvadRustRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A992DA1D2C24709F00DE7CE5 /* MullvadRustRuntime.framework */; };
+		01335D432F89B711008AB806 /* GotaTunAdapterProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D3F2F89B711008AB806 /* GotaTunAdapterProtocol.swift */; };
 		01335D5E2F89C6B2008AB903 /* mullvad_gotatunFFI.h in Headers */ = {isa = PBXBuildFile; fileRef = 01335D5F2F89C6B2008AB904 /* mullvad_gotatunFFI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		01335D612F89D400008AB806 /* ObservedStateBroadcaster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D622F89D400008AB806 /* ObservedStateBroadcaster.swift */; };
 		014E8C2A2F28B09700837D0A /* MullvadLogging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58D223F3294C8FF00029F5F8 /* MullvadLogging.framework */; };
@@ -1779,6 +1780,7 @@
 		0064CB0EF9AACDC812F39635 /* LogRedacting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogRedacting.swift; sourceTree = "<group>"; };
 		0107F3F82F56E3ED0012451B /* RelayCacheTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayCacheTrackerTests.swift; sourceTree = "<group>"; };
 		0107F4212F5B97F30012451B /* RelayListCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayListCacheTests.swift; sourceTree = "<group>"; };
+		01335D3F2F89B711008AB806 /* GotaTunAdapterProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunAdapterProtocol.swift; sourceTree = "<group>"; };
 		01335D5F2F89C6B2008AB904 /* mullvad_gotatunFFI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mullvad_gotatunFFI.h; path = include/mullvad_gotatunFFI.h; sourceTree = "<group>"; };
 		01335D622F89D400008AB806 /* ObservedStateBroadcaster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservedStateBroadcaster.swift; sourceTree = "<group>"; };
 		014E8C2F2F294FB000837D0A /* relays-test-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "relays-test-data.json"; sourceTree = "<group>"; };
@@ -3032,6 +3034,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		01335D412F89B711008AB806 /* GotaTun */ = {
+			isa = PBXGroup;
+			children = (
+				01335D3F2F89B711008AB806 /* GotaTunAdapterProtocol.swift */,
+			);
+			path = GotaTun;
+			sourceTree = "<group>";
+		};
 		01C981E72F43C3410002D284 /* Accessibility */ = {
 			isa = PBXGroup;
 			children = (
@@ -4122,6 +4132,7 @@
 		58C7A4372A863F450060C66F /* PacketTunnelCore */ = {
 			isa = PBXGroup;
 			children = (
+				01335D412F89B711008AB806 /* GotaTun */,
 				A9840BB12C69F7190030F05E /* Daita */,
 				58C7A4382A863F450060C66F /* PacketTunnelCore.h */,
 				58C9B8C52ABB23B400040B46 /* IPC */,
@@ -6638,6 +6649,7 @@
 				44DF8AC42BF20BD200869CA4 /* PacketTunnelActor+PostQuantum.swift in Sources */,
 				583832252AC318A100EA2071 /* PacketTunnelActor+ConnectionMonitoring.swift in Sources */,
 				F05919752C45194B00C301F3 /* EphemeralPeerKey.swift in Sources */,
+				01335D432F89B711008AB806 /* GotaTunAdapterProtocol.swift in Sources */,
 				58C7A4552A863FB90060C66F /* TunnelMonitor.swift in Sources */,
 				58C7A4512A863FB50060C66F /* PingerProtocol.swift in Sources */,
 				583832292AC3DF1300EA2071 /* PacketTunnelActorCommand.swift in Sources */,

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -26,6 +26,10 @@
 		0107F4322F5F62C80012451B /* MullvadSettings.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58B2FDD32AA71D2A003EB5C6 /* MullvadSettings.framework */; };
 		0107F4362F5F62CE0012451B /* MullvadRustRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A992DA1D2C24709F00DE7CE5 /* MullvadRustRuntime.framework */; };
 		01335D432F89B711008AB806 /* GotaTunAdapterProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D3F2F89B711008AB806 /* GotaTunAdapterProtocol.swift */; };
+		01335D4F2F89C396008AB806 /* RustGotaTunAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D4D2F89C396008AB806 /* RustGotaTunAdapter.swift */; };
+		01335D502F89C396008AB806 /* RustGotaTunAdapterFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D4E2F89C396008AB806 /* RustGotaTunAdapterFactory.swift */; };
+		01335D552F89C645008AB806 /* MullvadRustRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A992DA1D2C24709F00DE7CE5 /* MullvadRustRuntime.framework */; };
+		01335D5C2F89C6B2008AB901 /* mullvad_gotatun.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D5D2F89C6B2008AB902 /* mullvad_gotatun.swift */; };
 		01335D5E2F89C6B2008AB903 /* mullvad_gotatunFFI.h in Headers */ = {isa = PBXBuildFile; fileRef = 01335D5F2F89C6B2008AB904 /* mullvad_gotatunFFI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		01335D602F89D000008AB806 /* GotaTunProviderProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D5F2F89D000008AB806 /* GotaTunProviderProxy.swift */; };
 		01335D612F89D400008AB806 /* ObservedStateBroadcaster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D622F89D400008AB806 /* ObservedStateBroadcaster.swift */; };
@@ -1312,6 +1316,13 @@
 			remoteGlobalIDString = A992DA1C2C24709F00DE7CE5;
 			remoteInfo = MullvadRustRuntime;
 		};
+		01335D572F89C645008AB806 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 58CE5E58224146200008646E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A992DA1C2C24709F00DE7CE5;
+			remoteInfo = MullvadRustRuntime;
+		};
 		014E8C2C2F28B09700837D0A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 58CE5E58224146200008646E /* Project object */;
@@ -1783,6 +1794,9 @@
 		0107F3F82F56E3ED0012451B /* RelayCacheTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayCacheTrackerTests.swift; sourceTree = "<group>"; };
 		0107F4212F5B97F30012451B /* RelayListCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayListCacheTests.swift; sourceTree = "<group>"; };
 		01335D3F2F89B711008AB806 /* GotaTunAdapterProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunAdapterProtocol.swift; sourceTree = "<group>"; };
+		01335D4D2F89C396008AB806 /* RustGotaTunAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustGotaTunAdapter.swift; sourceTree = "<group>"; };
+		01335D4E2F89C396008AB806 /* RustGotaTunAdapterFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustGotaTunAdapterFactory.swift; sourceTree = "<group>"; };
+		01335D5D2F89C6B2008AB902 /* mullvad_gotatun.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = mullvad_gotatun.swift; path = generated/mullvad_gotatun.swift; sourceTree = "<group>"; };
 		01335D5F2F89C6B2008AB904 /* mullvad_gotatunFFI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mullvad_gotatunFFI.h; path = include/mullvad_gotatunFFI.h; sourceTree = "<group>"; };
 		01335D5F2F89D000008AB806 /* GotaTunProviderProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunProviderProxy.swift; sourceTree = "<group>"; };
 		01335D622F89D400008AB806 /* ObservedStateBroadcaster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservedStateBroadcaster.swift; sourceTree = "<group>"; };
@@ -2936,6 +2950,7 @@
 				58153071294CBE8B00D1702E /* MullvadREST.framework in Frameworks */,
 				44A262452D6373C400085380 /* WireGuardKit in Frameworks */,
 				58D22422294C921B0029F5F8 /* MullvadLogging.framework in Frameworks */,
+				01335D552F89C645008AB806 /* MullvadRustRuntime.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4516,6 +4531,8 @@
 				58FF23A22AB09BEE003A2AF2 /* DeviceChecker.swift */,
 				58906DDF2445C7A5002F0673 /* NEProviderStopReason+Debug.swift */,
 				01335D5F2F89D000008AB806 /* GotaTunProviderProxy.swift */,
+				01335D4D2F89C396008AB806 /* RustGotaTunAdapter.swift */,
+				01335D4E2F89C396008AB806 /* RustGotaTunAdapterFactory.swift */,
 				58F3F3692AA08E3C00D3B0A4 /* PacketTunnelProvider.swift */,
 				5864AF7C2A9F4DC9008BC928 /* SettingsReader.swift */,
 				DD68970B0A1DEEA01FB25D9E /* WireGuardGoTunnelImplementation.swift */,
@@ -4931,6 +4948,7 @@
 			isa = PBXGroup;
 			children = (
 				F0A607C42FAA0A4B00094833 /* Array+String.swift */,
+				01335D5D2F89C6B2008AB902 /* mullvad_gotatun.swift */,
 				A948809A2BC9308D0090A44C /* EphemeralPeerExchangeActor.swift */,
 				A9EB4F9C2B7FAB21002A2D7A /* EphemeralPeerNegotiator.swift */,
 				A9A557F42B7E3E5C0017ADA8 /* EphemeralPeerReceiver.swift */,
@@ -5672,6 +5690,7 @@
 				58153074294CBE8B00D1702E /* PBXTargetDependency */,
 				58FE25C92AA72779003D1918 /* PBXTargetDependency */,
 				58FE25D12AA72802003D1918 /* PBXTargetDependency */,
+				01335D582F89C645008AB806 /* PBXTargetDependency */,
 			);
 			name = PacketTunnel;
 			packageProductDependencies = (
@@ -7244,6 +7263,8 @@
 				F0570CD42C4FB8E1007BDF2D /* MultiHopEphemeralPeerExchanger.swift in Sources */,
 				44C18DE32C74DF93009BE3E1 /* TunnelPinger.swift in Sources */,
 				01335D602F89D000008AB806 /* GotaTunProviderProxy.swift in Sources */,
+				01335D4F2F89C396008AB806 /* RustGotaTunAdapter.swift in Sources */,
+				01335D502F89C396008AB806 /* RustGotaTunAdapterFactory.swift in Sources */,
 				580D6B8E2AB33BBF00B2D6E0 /* BlockedStateErrorMapper.swift in Sources */,
 				06AC116228F94C450037AF9A /* ApplicationConfiguration.swift in Sources */,
 				D56CD86C4435C3F6AF2A2662 /* WireGuardGoTunnelImplementation.swift in Sources */,
@@ -7486,6 +7507,7 @@
 			files = (
 				F0A89CB52D9D864B00580C27 /* RustProblemReportRequest.swift in Sources */,
 				7AB931242D43C2CA005FCEBA /* MullvadApiContext.swift in Sources */,
+				01335D5C2F89C6B2008AB901 /* mullvad_gotatun.swift in Sources */,
 				A9D9A4BB2C36D397004088DD /* EphemeralPeerNegotiator.swift in Sources */,
 				F0A89CB72D9D923300580C27 /* String+UnsafePointer.swift in Sources */,
 				A9D9A4B22C36D12D004088DD /* TunnelObfuscator.swift in Sources */,
@@ -7593,6 +7615,11 @@
 			isa = PBXTargetDependency;
 			target = A992DA1C2C24709F00DE7CE5 /* MullvadRustRuntime */;
 			targetProxy = 0107F4382F5F62CE0012451B /* PBXContainerItemProxy */;
+		};
+		01335D582F89C645008AB806 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A992DA1C2C24709F00DE7CE5 /* MullvadRustRuntime */;
+			targetProxy = 01335D572F89C645008AB806 /* PBXContainerItemProxy */;
 		};
 		014E8C2D2F28B09700837D0A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		0107F4322F5F62C80012451B /* MullvadSettings.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58B2FDD32AA71D2A003EB5C6 /* MullvadSettings.framework */; };
 		0107F4362F5F62CE0012451B /* MullvadRustRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A992DA1D2C24709F00DE7CE5 /* MullvadRustRuntime.framework */; };
 		01335D432F89B711008AB806 /* GotaTunAdapterProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D3F2F89B711008AB806 /* GotaTunAdapterProtocol.swift */; };
+		01335D442F89B711008AB806 /* GotaTunActor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D3E2F89B711008AB806 /* GotaTunActor.swift */; };
 		01335D4F2F89C396008AB806 /* RustGotaTunAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D4D2F89C396008AB806 /* RustGotaTunAdapter.swift */; };
 		01335D502F89C396008AB806 /* RustGotaTunAdapterFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D4E2F89C396008AB806 /* RustGotaTunAdapterFactory.swift */; };
 		01335D552F89C645008AB806 /* MullvadRustRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A992DA1D2C24709F00DE7CE5 /* MullvadRustRuntime.framework */; };
@@ -976,7 +977,6 @@
 		D59CB43F2FE40B80000B06FB /* BaseUITestCase+ApplogCaptureObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59CB43E2FE40B76000B06FB /* BaseUITestCase+ApplogCaptureObserver.swift */; };
 		D5A6A9D92FE01E40001E4796 /* AppLogCaptureObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A6A9D82FE01E40001E4796 /* AppLogCaptureObserver.swift */; };
 		D5A6A9DC2FE021B8001E4796 /* TestObservationConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A6A9DB2FE021B8001E4796 /* TestObservationConfiguration.swift */; };
-		E10A0001000000000000AB01 /* GotaTunActor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10A0001000000000000AA01 /* GotaTunActor.swift */; };
 		E10A0002000000000000AB01 /* PacketTunnelDebugSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10A0002000000000000AA01 /* PacketTunnelDebugSettings.swift */; };
 		E10A0002000000000000AB02 /* PacketTunnelDebugSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10A0002000000000000AA01 /* PacketTunnelDebugSettings.swift */; };
 		E10A0002000000000000AB03 /* PacketTunnelDebugSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10A0002000000000000AA01 /* PacketTunnelDebugSettings.swift */; };
@@ -1793,6 +1793,7 @@
 		0064CB0EF9AACDC812F39635 /* LogRedacting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogRedacting.swift; sourceTree = "<group>"; };
 		0107F3F82F56E3ED0012451B /* RelayCacheTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayCacheTrackerTests.swift; sourceTree = "<group>"; };
 		0107F4212F5B97F30012451B /* RelayListCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayListCacheTests.swift; sourceTree = "<group>"; };
+		01335D3E2F89B711008AB806 /* GotaTunActor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunActor.swift; sourceTree = "<group>"; };
 		01335D3F2F89B711008AB806 /* GotaTunAdapterProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunAdapterProtocol.swift; sourceTree = "<group>"; };
 		01335D4D2F89C396008AB806 /* RustGotaTunAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustGotaTunAdapter.swift; sourceTree = "<group>"; };
 		01335D4E2F89C396008AB806 /* RustGotaTunAdapterFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustGotaTunAdapterFactory.swift; sourceTree = "<group>"; };
@@ -2606,7 +2607,6 @@
 		D5A6A9DB2FE021B8001E4796 /* TestObservationConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestObservationConfiguration.swift; sourceTree = "<group>"; };
 		D702C13944A82CAF175A4443 /* RustLoggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustLoggingTests.swift; sourceTree = "<group>"; };
 		DD68970B0A1DEEA01FB25D9E /* WireGuardGoTunnelImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireGuardGoTunnelImplementation.swift; sourceTree = "<group>"; };
-		E10A0001000000000000AA01 /* GotaTunActor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunActor.swift; sourceTree = "<group>"; };
 		E10A0002000000000000AA01 /* PacketTunnelDebugSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelDebugSettings.swift; sourceTree = "<group>"; };
 		E1187ABA289BBB850024E748 /* OutOfTimeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutOfTimeViewController.swift; sourceTree = "<group>"; };
 		E1187ABB289BBB850024E748 /* OutOfTimeContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutOfTimeContentView.swift; sourceTree = "<group>"; };
@@ -3056,6 +3056,7 @@
 		01335D412F89B711008AB806 /* GotaTun */ = {
 			isa = PBXGroup;
 			children = (
+				01335D3E2F89B711008AB806 /* GotaTunActor.swift */,
 				01335D3F2F89B711008AB806 /* GotaTunAdapterProtocol.swift */,
 			);
 			path = GotaTun;
@@ -3907,7 +3908,6 @@
 				58342C032AAB61FB003BA12D /* State+Extensions.swift */,
 				58DDA18E2ABC32380039C360 /* Timings.swift */,
 				F04DD3D72C130DF600E03E28 /* TunnelSettingsManager.swift */,
-				E10A0001000000000000AA01 /* GotaTunActor.swift */,
 				F678736F5403E23B77CA9990 /* GotaTunTunnelImplementation.swift */,
 				B24C2F93919B5526A741ADA8 /* TunnelImplementation.swift */,
 			);
@@ -6676,6 +6676,7 @@
 				583832252AC318A100EA2071 /* PacketTunnelActor+ConnectionMonitoring.swift in Sources */,
 				F05919752C45194B00C301F3 /* EphemeralPeerKey.swift in Sources */,
 				01335D432F89B711008AB806 /* GotaTunAdapterProtocol.swift in Sources */,
+				01335D442F89B711008AB806 /* GotaTunActor.swift in Sources */,
 				58C7A4552A863FB90060C66F /* TunnelMonitor.swift in Sources */,
 				58C7A4512A863FB50060C66F /* PingerProtocol.swift in Sources */,
 				583832292AC3DF1300EA2071 /* PacketTunnelActorCommand.swift in Sources */,
@@ -6707,7 +6708,6 @@
 				F04AF92D2C466013004A8314 /* EphemeralPeerNegotiationState.swift in Sources */,
 				58FE25D92AA72A8F003D1918 /* AutoCancellingTask.swift in Sources */,
 				58C7A4582A863FB90060C66F /* TunnelMonitorProtocol.swift in Sources */,
-				E10A0001000000000000AB01 /* GotaTunActor.swift in Sources */,
 				E79BD7E565693BF2BDA5D9E6 /* GotaTunTunnelImplementation.swift in Sources */,
 				2F169CDAE6E8C601F85C543E /* TunnelImplementation.swift in Sources */,
 			);

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		0107F4362F5F62CE0012451B /* MullvadRustRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A992DA1D2C24709F00DE7CE5 /* MullvadRustRuntime.framework */; };
 		01335D432F89B711008AB806 /* GotaTunAdapterProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D3F2F89B711008AB806 /* GotaTunAdapterProtocol.swift */; };
 		01335D5E2F89C6B2008AB903 /* mullvad_gotatunFFI.h in Headers */ = {isa = PBXBuildFile; fileRef = 01335D5F2F89C6B2008AB904 /* mullvad_gotatunFFI.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		01335D602F89D000008AB806 /* GotaTunProviderProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D5F2F89D000008AB806 /* GotaTunProviderProxy.swift */; };
 		01335D612F89D400008AB806 /* ObservedStateBroadcaster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D622F89D400008AB806 /* ObservedStateBroadcaster.swift */; };
 		014E8C2A2F28B09700837D0A /* MullvadLogging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58D223F3294C8FF00029F5F8 /* MullvadLogging.framework */; };
 		014E8C302F294FB000837D0A /* relays-test-data.json in Resources */ = {isa = PBXBuildFile; fileRef = 014E8C2F2F294FB000837D0A /* relays-test-data.json */; };
@@ -43,6 +44,7 @@
 		01C981E92F43C3410002D284 /* TunnelStateAccessibilityAnnouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C981E62F43C3410002D284 /* TunnelStateAccessibilityAnnouncer.swift */; };
 		01C981EA2F43C3410002D284 /* BlockedStateReason+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C981E52F43C3410002D284 /* BlockedStateReason+Localization.swift */; };
 		01C981EB2F45D5C20002D284 /* TunnelControlPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C981EA2F45D5C20002D284 /* TunnelControlPageTests.swift */; };
+		01CBA340302CA3C800D41B65 /* TunnelProviderDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CBA33F302CA3C800D41B65 /* TunnelProviderDelegate.swift */; };
 		01D13C212F11130500EC63DE /* RustLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D13C202F11130500EC63DE /* RustLogging.swift */; };
 		01FFF9582F0469FC00BDAF45 /* IPVersionSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FFF9562F0469FC00BDAF45 /* IPVersionSettings.swift */; };
 		01FFF95F2F0BE13900BDAF45 /* SelectedEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FFF95E2F0BE13900BDAF45 /* SelectedEndpoint.swift */; };
@@ -1782,6 +1784,7 @@
 		0107F4212F5B97F30012451B /* RelayListCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayListCacheTests.swift; sourceTree = "<group>"; };
 		01335D3F2F89B711008AB806 /* GotaTunAdapterProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunAdapterProtocol.swift; sourceTree = "<group>"; };
 		01335D5F2F89C6B2008AB904 /* mullvad_gotatunFFI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mullvad_gotatunFFI.h; path = include/mullvad_gotatunFFI.h; sourceTree = "<group>"; };
+		01335D5F2F89D000008AB806 /* GotaTunProviderProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunProviderProxy.swift; sourceTree = "<group>"; };
 		01335D622F89D400008AB806 /* ObservedStateBroadcaster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservedStateBroadcaster.swift; sourceTree = "<group>"; };
 		014E8C2F2F294FB000837D0A /* relays-test-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "relays-test-data.json"; sourceTree = "<group>"; };
 		014E8C352F2BC60300837D0A /* LogRedactorBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogRedactorBenchmarkTests.swift; sourceTree = "<group>"; };
@@ -1794,6 +1797,7 @@
 		01C981E52F43C3410002D284 /* BlockedStateReason+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlockedStateReason+Localization.swift"; sourceTree = "<group>"; };
 		01C981E62F43C3410002D284 /* TunnelStateAccessibilityAnnouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelStateAccessibilityAnnouncer.swift; sourceTree = "<group>"; };
 		01C981EA2F45D5C20002D284 /* TunnelControlPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelControlPageTests.swift; sourceTree = "<group>"; };
+		01CBA33F302CA3C800D41B65 /* TunnelProviderDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelProviderDelegate.swift; sourceTree = "<group>"; };
 		01D13C202F11130500EC63DE /* RustLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustLogging.swift; sourceTree = "<group>"; };
 		01F1FF1D29F0627D007083C3 /* libmullvad_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libmullvad_ios.a; path = ../target/debug/libmullvad_ios.a; sourceTree = "<group>"; };
 		01FFF9562F0469FC00BDAF45 /* IPVersionSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPVersionSettings.swift; sourceTree = "<group>"; };
@@ -3858,6 +3862,7 @@
 		5864AF802A9F52E3008BC928 /* Actor */ = {
 			isa = PBXGroup;
 			children = (
+				01CBA33F302CA3C800D41B65 /* TunnelProviderDelegate.swift */,
 				58BDEBA02A9CA14B00F578F2 /* AnyTask.swift */,
 				58F3F3652AA086A400D3B0A4 /* AutoCancellingTask.swift */,
 				583E60952A9F6D0800DC61EF /* ConfigurationBuilder.swift */,
@@ -4510,6 +4515,7 @@
 				580D6B912AB360BE00B2D6E0 /* DeviceCheck+BlockedStateReason.swift */,
 				58FF23A22AB09BEE003A2AF2 /* DeviceChecker.swift */,
 				58906DDF2445C7A5002F0673 /* NEProviderStopReason+Debug.swift */,
+				01335D5F2F89D000008AB806 /* GotaTunProviderProxy.swift */,
 				58F3F3692AA08E3C00D3B0A4 /* PacketTunnelProvider.swift */,
 				5864AF7C2A9F4DC9008BC928 /* SettingsReader.swift */,
 				DD68970B0A1DEEA01FB25D9E /* WireGuardGoTunnelImplementation.swift */,
@@ -6636,6 +6642,7 @@
 				58FE25F42AA9D730003D1918 /* PacketTunnelActor+Extensions.swift in Sources */,
 				58DDA18F2ABC32380039C360 /* Timings.swift in Sources */,
 				580D6B8C2AB3369300B2D6E0 /* BlockedStateErrorMapperProtocol.swift in Sources */,
+				01CBA340302CA3C800D41B65 /* TunnelProviderDelegate.swift in Sources */,
 				5838321F2AC3160A00EA2071 /* PacketTunnelActor+KeyPolicy.swift in Sources */,
 				58C7AF122ABD8480007EDD7A /* TunnelProviderReply.swift in Sources */,
 				58C7A4572A863FB90060C66F /* TunnelDeviceInfoProtocol.swift in Sources */,
@@ -7236,6 +7243,7 @@
 				F0570CD22C4FB8E1007BDF2D /* SingleHopEphemeralPeerExchanger.swift in Sources */,
 				F0570CD42C4FB8E1007BDF2D /* MultiHopEphemeralPeerExchanger.swift in Sources */,
 				44C18DE32C74DF93009BE3E1 /* TunnelPinger.swift in Sources */,
+				01335D602F89D000008AB806 /* GotaTunProviderProxy.swift in Sources */,
 				580D6B8E2AB33BBF00B2D6E0 /* BlockedStateErrorMapper.swift in Sources */,
 				06AC116228F94C450037AF9A /* ApplicationConfiguration.swift in Sources */,
 				D56CD86C4435C3F6AF2A2662 /* WireGuardGoTunnelImplementation.swift in Sources */,

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		0107F4362F5F62CE0012451B /* MullvadRustRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A992DA1D2C24709F00DE7CE5 /* MullvadRustRuntime.framework */; };
 		01335D432F89B711008AB806 /* GotaTunAdapterProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D3F2F89B711008AB806 /* GotaTunAdapterProtocol.swift */; };
 		01335D442F89B711008AB806 /* GotaTunActor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D3E2F89B711008AB806 /* GotaTunActor.swift */; };
+		01335D4A2F89B88E008AB806 /* GotaTunAdapterStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D482F89B88E008AB806 /* GotaTunAdapterStub.swift */; };
+		01335D4C2F89B8F8008AB806 /* GotaTunActorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D4B2F89B8F8008AB806 /* GotaTunActorTests.swift */; };
 		01335D4F2F89C396008AB806 /* RustGotaTunAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D4D2F89C396008AB806 /* RustGotaTunAdapter.swift */; };
 		01335D502F89C396008AB806 /* RustGotaTunAdapterFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D4E2F89C396008AB806 /* RustGotaTunAdapterFactory.swift */; };
 		01335D552F89C645008AB806 /* MullvadRustRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A992DA1D2C24709F00DE7CE5 /* MullvadRustRuntime.framework */; };
@@ -34,6 +36,7 @@
 		01335D5E2F89C6B2008AB903 /* mullvad_gotatunFFI.h in Headers */ = {isa = PBXBuildFile; fileRef = 01335D5F2F89C6B2008AB904 /* mullvad_gotatunFFI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		01335D602F89D000008AB806 /* GotaTunProviderProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D5F2F89D000008AB806 /* GotaTunProviderProxy.swift */; };
 		01335D612F89D400008AB806 /* ObservedStateBroadcaster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D622F89D400008AB806 /* ObservedStateBroadcaster.swift */; };
+		01335D662F89E200008AB806 /* ObservedState+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D652F89E200008AB806 /* ObservedState+Testing.swift */; };
 		014E8C2A2F28B09700837D0A /* MullvadLogging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58D223F3294C8FF00029F5F8 /* MullvadLogging.framework */; };
 		014E8C302F294FB000837D0A /* relays-test-data.json in Resources */ = {isa = PBXBuildFile; fileRef = 014E8C2F2F294FB000837D0A /* relays-test-data.json */; };
 		014E8C312F294FB000837D0A /* relays-test-data.json in Resources */ = {isa = PBXBuildFile; fileRef = 014E8C2F2F294FB000837D0A /* relays-test-data.json */; };
@@ -1795,12 +1798,15 @@
 		0107F4212F5B97F30012451B /* RelayListCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayListCacheTests.swift; sourceTree = "<group>"; };
 		01335D3E2F89B711008AB806 /* GotaTunActor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunActor.swift; sourceTree = "<group>"; };
 		01335D3F2F89B711008AB806 /* GotaTunAdapterProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunAdapterProtocol.swift; sourceTree = "<group>"; };
+		01335D482F89B88E008AB806 /* GotaTunAdapterStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunAdapterStub.swift; sourceTree = "<group>"; };
+		01335D4B2F89B8F8008AB806 /* GotaTunActorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunActorTests.swift; sourceTree = "<group>"; };
 		01335D4D2F89C396008AB806 /* RustGotaTunAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustGotaTunAdapter.swift; sourceTree = "<group>"; };
 		01335D4E2F89C396008AB806 /* RustGotaTunAdapterFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustGotaTunAdapterFactory.swift; sourceTree = "<group>"; };
 		01335D5D2F89C6B2008AB902 /* mullvad_gotatun.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = mullvad_gotatun.swift; path = generated/mullvad_gotatun.swift; sourceTree = "<group>"; };
 		01335D5F2F89C6B2008AB904 /* mullvad_gotatunFFI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mullvad_gotatunFFI.h; path = include/mullvad_gotatunFFI.h; sourceTree = "<group>"; };
 		01335D5F2F89D000008AB806 /* GotaTunProviderProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunProviderProxy.swift; sourceTree = "<group>"; };
 		01335D622F89D400008AB806 /* ObservedStateBroadcaster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservedStateBroadcaster.swift; sourceTree = "<group>"; };
+		01335D652F89E200008AB806 /* ObservedState+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ObservedState+Testing.swift"; sourceTree = "<group>"; };
 		014E8C2F2F294FB000837D0A /* relays-test-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "relays-test-data.json"; sourceTree = "<group>"; };
 		014E8C352F2BC60300837D0A /* LogRedactorBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogRedactorBenchmarkTests.swift; sourceTree = "<group>"; };
 		014E8C392F2D594400837D0A /* RustLogRedactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustLogRedactor.swift; sourceTree = "<group>"; };
@@ -4166,6 +4172,8 @@
 		58C7A4432A863F490060C66F /* PacketTunnelCoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				01335D4B2F89B8F8008AB806 /* GotaTunActorTests.swift */,
+				01335D482F89B88E008AB806 /* GotaTunAdapterStub.swift */,
 				7A3FD1B42AD4465A0042BEA6 /* AppMessageHandlerTests.swift */,
 				F053F4B92C4A94D300FBD937 /* EphemeralPeerExchangingPipelineTests.swift */,
 				586C14572AC463BB00245C01 /* EventChannelTests.swift */,
@@ -4454,6 +4462,7 @@
 				7AD0AA202AD6CB0000119E10 /* APIRequestProxyStub.swift */,
 				58F7753C2AB8473200425B47 /* BlockedStateErrorMapperStub.swift */,
 				581F23AC2A8CF92100788AB6 /* DefaultPathObserverFake.swift */,
+				01335D652F89E200008AB806 /* ObservedState+Testing.swift */,
 				F0C4C9BF2C495E7500A79006 /* EphemeralPeerExchangeActorStub.swift */,
 				F0FBD98E2C4A60CC00EE5323 /* KeyExchangingResultStub.swift */,
 				58EC067B2A8D2A0B00BEB973 /* NetworkCounters.swift */,
@@ -6717,6 +6726,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				01335D4A2F89B88E008AB806 /* GotaTunAdapterStub.swift in Sources */,
 				7AD0AA1C2AD6A63F00119E10 /* PacketTunnelActorStub.swift in Sources */,
 				58EC067A2A8D208D00BEB973 /* TunnelDeviceInfoStub.swift in Sources */,
 				586C14582AC463BB00245C01 /* EventChannelTests.swift in Sources */,
@@ -6725,6 +6735,7 @@
 				58FE25EC2AA77639003D1918 /* TunnelMonitorStub.swift in Sources */,
 				58FE25EE2AA7764E003D1918 /* TunnelAdapterDummy.swift in Sources */,
 				581F23AD2A8CF92100788AB6 /* DefaultPathObserverFake.swift in Sources */,
+				01335D662F89E200008AB806 /* ObservedState+Testing.swift in Sources */,
 				F07751582C50F149006E6A12 /* MultiHopEphemeralPeerExchangerTests.swift in Sources */,
 				5838321B2AC1B18400EA2071 /* PacketTunnelActor+Mocks.swift in Sources */,
 				58092E542A8B832E00C3CC72 /* TunnelMonitorTests.swift in Sources */,
@@ -6733,6 +6744,7 @@
 				F07751592C50F149006E6A12 /* SingleHopEphemeralPeerExchangerTests.swift in Sources */,
 				A97D25B42B0CB59300946B2D /* TunnelObfuscationStub.swift in Sources */,
 				F0077EEE2C52844800DAB2AA /* KeyExchangingResultStub.swift in Sources */,
+				01335D4C2F89B8F8008AB806 /* GotaTunActorTests.swift in Sources */,
 				A97D25B02B0BB5C400946B2D /* ProtocolObfuscationStub.swift in Sources */,
 				58FE25F22AA77674003D1918 /* SettingsReaderStub.swift in Sources */,
 				F08B6B7C2C528C6300D0A121 /* SingleHopEphemeralPeerExchanger.swift in Sources */,

--- a/ios/MullvadVPN/Coordinators/TunnelCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/TunnelCoordinator.swift
@@ -76,6 +76,10 @@ class TunnelCoordinator: Coordinator, Presenting {
                 self?.showFeatureSetting?(.includeAllNetworks)
             case .ipVersion:
                 self?.showFeatureSetting?(.vpnSettings(.ipVersion))
+            #if NEVER_IN_PRODUCTION
+                case .gotaTun:
+                    break
+            #endif
             }
         }
     }

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ChipView/ChipFeature.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ChipView/ChipFeature.swift
@@ -33,6 +33,9 @@ enum FeatureType {
     case includeAllNetworks
     case localNetworkSharing
     case ipVersion
+    #if NEVER_IN_PRODUCTION
+        case gotaTun
+    #endif
 }
 
 struct DaitaFeature: ChipFeature {
@@ -193,3 +196,15 @@ struct IPVersionFeature: ChipFeature {
         NSLocalizedString("IPv6", comment: "")
     }
 }
+
+#if NEVER_IN_PRODUCTION
+    struct GotaTunFeature: ChipFeature {
+        let id: FeatureType = .gotaTun
+
+        var isEnabled: Bool {
+            PacketTunnelDebugSettings.useGotaTun
+        }
+
+        let name = "GotaTun"
+    }
+#endif

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/FeatureIndicatorsViewModel.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/FeatureIndicatorsViewModel.swift
@@ -56,6 +56,10 @@ class FeatureIndicatorsViewModel: ChipViewModelProtocol {
             break
         }
 
+        #if NEVER_IN_PRODUCTION
+            features.append(GotaTunFeature())
+        #endif
+
         return
             features
             .filter { $0.isEnabled }

--- a/ios/PacketTunnel/PacketTunnelProvider/GotaTunProviderProxy.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/GotaTunProviderProxy.swift
@@ -1,0 +1,114 @@
+//
+//  GotaTunProviderProxy.swift
+//  PacketTunnel
+//
+//  Created by Emīls on 2026-08-13.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+import MullvadTypes
+import NetworkExtension
+import PacketTunnelCore
+
+/// Abstracts away NEPacketTunnelProvider for GotaTun
+/// Once we drop iOS17, this struct can become non-copyable too, which enforces the constraint that it should only be used by the GotaTun actor
+struct GotaTunProviderProxy: TunnelProviderDelegate, Sendable {
+    /// `NEPacketTunnelProvider` predates Sendable, but the parts used here —
+    /// the `reasserting` setter and `setTunnelNetworkSettings` — are callable
+    /// from any thread.
+    private nonisolated(unsafe) weak var provider: NEPacketTunnelProvider?
+
+    init(provider: sending NEPacketTunnelProvider) {
+        self.provider = provider
+    }
+
+    /// Scanning for the utun control socket reads no provider state, so it needs no isolation.
+    nonisolated var tunnelFileDescriptor: Int32? {
+        var ctlInfo = ctl_info()
+        withUnsafeMutablePointer(to: &ctlInfo.ctl_name) {
+            $0.withMemoryRebound(to: CChar.self, capacity: MemoryLayout.size(ofValue: $0.pointee)) {
+                _ = strcpy($0, "com.apple.net.utun_control")
+            }
+        }
+        for fd: Int32 in 0...1024 {
+            var addr = sockaddr_ctl()
+            var ret: Int32 = -1
+            var len = socklen_t(MemoryLayout.size(ofValue: addr))
+            withUnsafeMutablePointer(to: &addr) {
+                $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    ret = getpeername(fd, $0, &len)
+                }
+            }
+            if ret != 0 || addr.sc_family != AF_SYSTEM {
+                continue
+            }
+            if ctlInfo.ctl_id == 0 {
+                ret = ioctl(fd, CTLIOCGINFO, &ctlInfo)
+                if ret != 0 {
+                    continue
+                }
+            }
+            if addr.sc_id == ctlInfo.ctl_id {
+                return fd
+            }
+        }
+        return nil
+    }
+
+    func reassertTunnel() {
+        guard let provider else { return }
+        // Setting `reasserting` to `true` invalidates all sockets bound to the tunnel interface.
+        provider.reasserting = true
+        // Setting `reasserting` to `false` indicates that sockets can again be bound to the tunnel interface.
+        // We'd prefer to keep the time interval between both as short as possible to prevent accidental leaks even when not using `includeAllNetworks`.
+        provider.reasserting = false
+    }
+
+    func applyNetworkSettings(_ settings: TunnelInterfaceSettings) async throws {
+        guard let provider else { return }
+        try await provider.setTunnelNetworkSettings(settings.asTunnelSettings())
+    }
+}
+
+// MARK: - Private socket structs for utun FD discovery
+// Layout mirrors of the types in <sys/kern_control.h>, which the iOS SDK does not ship.
+// The names intentionally match the C types.
+// swift-format-ignore: TypeNamesShouldBeCapitalized
+private struct ctl_info {
+    var ctl_id: UInt32 = 0
+    var ctl_name:
+        (
+            CChar, CChar, CChar, CChar, CChar, CChar, CChar, CChar,
+            CChar, CChar, CChar, CChar, CChar, CChar, CChar, CChar,
+            CChar, CChar, CChar, CChar, CChar, CChar, CChar, CChar,
+            CChar, CChar, CChar, CChar, CChar, CChar, CChar, CChar,
+            CChar, CChar, CChar, CChar, CChar, CChar, CChar, CChar,
+            CChar, CChar, CChar, CChar, CChar, CChar, CChar, CChar,
+            CChar, CChar, CChar, CChar, CChar, CChar, CChar, CChar,
+            CChar, CChar, CChar, CChar, CChar, CChar, CChar, CChar,
+            CChar, CChar, CChar, CChar, CChar, CChar, CChar, CChar,
+            CChar, CChar, CChar, CChar, CChar, CChar, CChar, CChar,
+            CChar, CChar, CChar, CChar, CChar, CChar, CChar, CChar,
+            CChar, CChar, CChar, CChar, CChar, CChar, CChar, CChar
+        ) = (
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        )
+}
+
+// swift-format-ignore: TypeNamesShouldBeCapitalized
+private struct sockaddr_ctl {
+    var sc_len: UInt8 = UInt8(MemoryLayout<sockaddr_ctl>.size)
+    var sc_family: UInt8 = UInt8(AF_SYSTEM)
+    var ss_sysaddr: UInt16 = 0
+    var sc_id: UInt32 = 0
+    var sc_unit: UInt32 = 0
+    var sc_reserved: (UInt32, UInt32, UInt32, UInt32, UInt32) = (0, 0, 0, 0, 0)
+}
+
+private let CTLIOCGINFO: UInt = 0xC064_4E03

--- a/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
@@ -106,7 +106,13 @@ class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
         #if DEBUG
             if PacketTunnelDebugSettings.useGotaTun {
                 providerLogger.info("Using GotaTun implementation (debug)")
-                implementation = GotaTunTunnelImplementation()
+                implementation = GotaTunTunnelImplementation(
+                    providerDelegate: GotaTunProviderProxy(provider: self),
+                    blockedStateErrorMapper: BlockedStateErrorMapper(),
+                    adapterFactory: RustGotaTunAdapterFactory(),
+                    ipOverrideWrapper: ipOverrideWrapper,
+                    settingsReader: settingsReader
+                )
             } else {
                 implementation = makeWireGuardGoImplementation(
                     ipOverrideWrapper: ipOverrideWrapper,

--- a/ios/PacketTunnel/PacketTunnelProvider/RustGotaTunAdapter.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/RustGotaTunAdapter.swift
@@ -1,0 +1,137 @@
+//
+//  RustGotaTunAdapter.swift
+//  PacketTunnel
+//
+//  Created by Emīls on 2026-08-13.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+import MullvadLogging
+import MullvadRustRuntime
+import PacketTunnelCore
+
+/// GotaTun adapter backed by the Rust FFI via the UniFFI-generated `GotaTunTunnel`.
+///
+/// This is the single boundary that maps `PacketTunnelCore`'s FFI-agnostic
+/// `GotaTunConfig` to the UniFFI-generated `MullvadRustRuntime.GotaTunConfig` and
+/// bridges the generated `GotaTunCallback` to the domain `GotaTunCallbackHandler`,
+/// keeping `PacketTunnelCore` decoupled from the FFI layer.
+/// Each instance manages a single connection attempt.
+final class RustGotaTunAdapter: GotaTunAdapterProtocol, @unchecked Sendable {
+    private let logger = Logger(label: "RustGotaTunAdapter")
+    private var tunnel: GotaTunTunnel?
+
+    func startTunnel(config: PacketTunnelCore.GotaTunConfig, callbackHandler: GotaTunCallbackHandler) throws {
+        let ffiConfig = Self.makeFfiConfig(config)
+
+        do {
+            tunnel = try GotaTunTunnel.start(
+                tunFd: config.tunnelFd,
+                config: ffiConfig,
+                callback: CallbackProxy(callbackHandler)
+            )
+        } catch let error as GotaTunFfiError {
+            throw Self.mapError(error)
+        }
+
+        logger.debug("Tunnel started via GotaTunTunnel")
+    }
+
+    func stopTunnel() {
+        tunnel?.stop()
+        tunnel = nil
+    }
+
+    func recycleUdpSockets() {
+        tunnel?.recycleUdpSockets()
+    }
+
+    func suspendTunnel() {
+        tunnel?.suspend()
+    }
+
+    func wakeTunnel() {
+        tunnel?.wake()
+    }
+
+    deinit {
+        stopTunnel()
+    }
+
+    // MARK: - Mapping
+
+    /// Build the UniFFI config from the domain config.
+    private static func makeFfiConfig(_ config: PacketTunnelCore.GotaTunConfig) -> MullvadRustRuntime.GotaTunConfig {
+        let exitPeer = GotaTunPeer(
+            publicKey: config.exitPeerPublicKey,
+            endpoint: config.exitPeerEndpoint
+        )
+
+        let entryPeer: GotaTunPeer? = {
+            guard let key = config.entryPeerPublicKey, let endpoint = config.entryPeerEndpoint
+            else { return nil }
+            return GotaTunPeer(publicKey: key, endpoint: endpoint)
+        }()
+
+        return MullvadRustRuntime.GotaTunConfig(
+            privateKey: config.privateKey,
+            ipv4Address: "\(config.ipv4Address)",
+            ipv6Address: "\(config.ipv6Address)",
+            mtu: config.mtu,
+            exitPeer: exitPeer,
+            entryPeer: entryPeer,
+            ipv4Gateway: config.ipv4Gateway,
+            establishTimeoutSecs: config.establishTimeout,
+            enablePq: config.isPostQuantum,
+            enableDaita: config.isDaitaEnabled,
+            obfuscation: makeObfuscation(config)
+        )
+    }
+
+    private static func makeObfuscation(_ config: PacketTunnelCore.GotaTunConfig) -> GotaTunObfuscation {
+        switch config.obfuscationMethod {
+        case .off:
+            return .off
+        case .udpOverTcp:
+            return .udpOverTcp
+        case .shadowsocks:
+            return .shadowsocks
+        case let .quic(hostname, token):
+            return .quic(hostname: hostname, token: token)
+        case .lwo:
+            // LWO obfuscates the handshake with the ingress relay's key.
+            let ingressPeerKey = config.entryPeerPublicKey ?? config.exitPeerPublicKey
+            return .lwo(clientPublicKey: config.clientPublicKey, serverPublicKey: ingressPeerKey)
+        }
+    }
+
+    private static func mapError(_ error: GotaTunFfiError) -> GotaTunError {
+        switch error {
+        case let .InvalidConfig(message):
+            return .invalidConfig(message)
+        case let .Internal(message):
+            return .internalError(message)
+        }
+    }
+}
+
+private final class CallbackProxy: GotaTunCallback {
+    private let handler: GotaTunCallbackHandler
+
+    init(_ handler: GotaTunCallbackHandler) {
+        self.handler = handler
+    }
+
+    func onConnected() {
+        handler.onConnected()
+    }
+
+    func onTimeout() {
+        handler.onTimeout()
+    }
+
+    func onError(message: String) {
+        handler.onError(.internalError(message))
+    }
+}

--- a/ios/PacketTunnel/PacketTunnelProvider/RustGotaTunAdapterFactory.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/RustGotaTunAdapterFactory.swift
@@ -1,0 +1,19 @@
+//
+//  RustGotaTunAdapterFactory.swift
+//  PacketTunnel
+//
+//  Created by Emīls on 2026-08-13.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+import MullvadLogging
+import PacketTunnelCore
+
+/// Factory that creates `RustGotaTunAdapter` instances backed by the Rust FFI.
+final class RustGotaTunAdapterFactory: GotaTunAdapterFactory {
+    /// Each call to `makeAdapter()` creates a new adapter for one connection attempt.
+    func makeAdapter() -> GotaTunAdapterProtocol {
+        return RustGotaTunAdapter()
+    }
+}

--- a/ios/PacketTunnelCore/Actor/GotaTunTunnelImplementation.swift
+++ b/ios/PacketTunnelCore/Actor/GotaTunTunnelImplementation.swift
@@ -8,14 +8,31 @@
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
-import MullvadLogging
+import MullvadREST
+import MullvadTypes
 
-/// GotaTun tunnel implementation. Once WireGuardGo is gone, PacketTunnelProvider can interact with GotaTunActor directly. This component is here only to bridge the gap whilst both are available
+/// GotaTun tunnel implementation.
+/// Unlike WireGuardGo, this implementation does NOT use an external state observer.
+/// GotaTunActor may be used directly by the PacketTunnelProvider once we get rid of WireGuardGo.
 public final class GotaTunTunnelImplementation: TunnelImplementation, Sendable {
-    private let _actor = GotaTunActor()
-    public var actor: any PacketTunnelActorProtocol { _actor }
+    private let gotaTunActor: GotaTunActor
+    public var actor: any PacketTunnelActorProtocol { gotaTunActor }
 
-    public init() {}
+    public init(
+        providerDelegate: sending TunnelProviderDelegate,
+        blockedStateErrorMapper: sending BlockedStateErrorMapperProtocol,
+        adapterFactory: GotaTunAdapterFactory,
+        ipOverrideWrapper: IPOverrideWrapper,
+        settingsReader: sending TunnelSettingsManager
+    ) {
+        gotaTunActor = GotaTunActor(
+            providerDelegate: providerDelegate,
+            settingsReader: settingsReader,
+            relaySelector: RelaySelectorWrapper(relayCache: ipOverrideWrapper),
+            blockedStateErrorMapper: blockedStateErrorMapper,
+            adapterFactory: adapterFactory
+        )
+    }
 
     public func startTunnel(options: StartOptions) async {
         await actor.start(options: options)

--- a/ios/PacketTunnelCore/Actor/ObservedState+Extensions.swift
+++ b/ios/PacketTunnelCore/Actor/ObservedState+Extensions.swift
@@ -66,3 +66,10 @@ extension ObservedState {
         }
     }
 }
+
+extension ObservedConnectionState {
+    mutating func incrementAttemptCount() {
+        let (value, isOverflow) = connectionAttemptCount.addingReportingOverflow(1)
+        connectionAttemptCount = isOverflow ? 0 : value
+    }
+}

--- a/ios/PacketTunnelCore/Actor/State.swift
+++ b/ios/PacketTunnelCore/Actor/State.swift
@@ -275,6 +275,8 @@ public enum NextRelays: Equatable, Codable, Sendable {
     case random
 
     /// Use currently selected relays, fallback to random if not set.
+    /// Only used by WireGuardGo.
+    // TODO: remove when WireGuardGo is removed
     case current
 
     /// Use pre-selected relays.

--- a/ios/PacketTunnelCore/Actor/TunnelProviderDelegate.swift
+++ b/ios/PacketTunnelCore/Actor/TunnelProviderDelegate.swift
@@ -1,0 +1,25 @@
+//
+//  TunnelProviderDelegate.swift
+//  PacketTunnelCore
+//
+//  Created by Emīls on 2026-08-13.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+import MullvadTypes
+
+/// Abstracts the packet tunnel provider capabilities needed to run a tunnel.
+///
+/// The concrete implementation lives in the `PacketTunnel` target where
+/// `NEPacketTunnelProvider` and `NetworkExtension` are available.
+public protocol TunnelProviderDelegate: Sendable {
+    /// The TUN device file descriptor, or nil if not yet available.
+    var tunnelFileDescriptor: Int32? { get }
+
+    /// Apply network settings to the system tunnel interface.
+    func applyNetworkSettings(_ settings: TunnelInterfaceSettings) async throws
+
+    /// Toggle the provider's `reasserting` flag to invalidate sockets bound to the old relay.
+    func reassertTunnel()
+}

--- a/ios/PacketTunnelCore/GotaTun/GotaTunActor.swift
+++ b/ios/PacketTunnelCore/GotaTun/GotaTunActor.swift
@@ -470,6 +470,7 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
     private func stopCurrentAdapter() {
         currentAdapter?.stopTunnel()
         currentAdapter = nil
+        adapterGeneration += 1
     }
 
     /// Whether `generation` identifies the adapter currently in use. Events from a replaced or

--- a/ios/PacketTunnelCore/GotaTun/GotaTunActor.swift
+++ b/ios/PacketTunnelCore/GotaTun/GotaTunActor.swift
@@ -1,0 +1,578 @@
+//
+//  GotaTunActor.swift
+//  PacketTunnelCore
+//
+//  Created by Emīls on 2026-08-13.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+import MullvadLogging
+import MullvadREST
+import MullvadSettings
+import MullvadTypes
+import Network
+
+/// Events processed by the actor's internal loop.
+private enum GotaTunEvent: Sendable {
+    case start(StartOptions)
+    case stop
+    case adapterConnected(generation: UInt64)
+    case adapterTimeout(generation: UInt64)
+    case adapterError(GotaTunError, generation: UInt64)
+    case reconnect(NextRelays, ActorReconnectReason)
+    case setErrorState(BlockedStateReason)
+    case sleep
+    case wake
+    #if NEVER_IN_PRODUCTION
+        /// Resolved once every event queued ahead of it has been handled. Lets tests observe the
+        /// actor at a known point instead of waiting for a duration.
+        case barrier(@Sendable () -> Void)
+    #endif
+}
+
+/// GotaTun packet tunnel actor.
+///
+/// Entirely separate from `PacketTunnelActor`. Shares only
+/// `PacketTunnelActorProtocol` as the integration surface with
+/// `PacketTunnelProvider`.
+///
+/// Delegates tunnel connection management to a Rust-backed adapter
+/// via `GotaTunAdapterProtocol`. Each connection attempt creates a
+/// new adapter instance.
+public actor GotaTunActor: PacketTunnelActorProtocol {
+    private let logger = Logger(label: "GotaTunActor")
+
+    // MARK: - Dependencies
+
+    private let providerDelegate: TunnelProviderDelegate
+    private let settingsReader: SettingsReaderProtocol
+    private let relaySelector: RelaySelectorProtocol
+    private let blockedStateErrorMapper: BlockedStateErrorMapperProtocol
+    private let adapterFactory: GotaTunAdapterFactory
+    private var lastAppliedSettings: TunnelInterfaceSettings?
+
+    // MARK: - State (mutated only from the event loop)
+
+    public private(set) var observedState: ObservedState = .initial {
+        didSet {
+            guard observedState != oldValue else { return }
+            stateBroadcaster.send(observedState)
+            if case .disconnected = observedState {
+                terminate()
+            }
+        }
+    }
+
+    private var stateBroadcaster = ObservedStateBroadcaster()
+    /// Unknown until the path monitor delivers its first update, which is what releases `start`.
+    private var currentReachability: NetworkReachability = .undetermined
+    private var initialReachability: CheckedContinuation<Void, Never>?
+    private var currentAdapter: GotaTunAdapterProtocol?
+    /// Incremented whenever the current adapter is replaced or stopped. Events tagged with an
+    /// older generation come from an adapter no longer in use and are dropped.
+    private var adapterGeneration: UInt64 = 0
+
+    // MARK: - Event channel
+
+    private let eventStream: AsyncStream<GotaTunEvent>
+    private let eventContinuation: AsyncStream<GotaTunEvent>.Continuation
+
+    // MARK: - Callback proxy
+
+    /// Forwards adapter callbacks into the event channel, tagged with the generation of the
+    /// adapter they came from. Sendable and safe to call from any thread.
+    private final class CallbackProxy: GotaTunCallbackHandler {
+        private let continuation: AsyncStream<GotaTunEvent>.Continuation
+        private let generation: UInt64
+
+        init(continuation: AsyncStream<GotaTunEvent>.Continuation, generation: UInt64) {
+            self.continuation = continuation
+            self.generation = generation
+        }
+
+        func onConnected() {
+            continuation.yield(.adapterConnected(generation: generation))
+        }
+
+        func onTimeout() {
+            continuation.yield(.adapterTimeout(generation: generation))
+        }
+
+        func onError(_ error: GotaTunError) {
+            continuation.yield(.adapterError(error, generation: generation))
+        }
+    }
+
+    // MARK: - Init
+
+    public init(
+        providerDelegate: sending TunnelProviderDelegate,
+        settingsReader: SettingsReaderProtocol,
+        relaySelector: RelaySelectorProtocol,
+        blockedStateErrorMapper: BlockedStateErrorMapperProtocol,
+        adapterFactory: GotaTunAdapterFactory
+    ) {
+        self.providerDelegate = providerDelegate
+        self.settingsReader = settingsReader
+        self.relaySelector = relaySelector
+        self.blockedStateErrorMapper = blockedStateErrorMapper
+        self.adapterFactory = adapterFactory
+
+        (eventStream, eventContinuation) = AsyncStream<GotaTunEvent>.makeStream()
+
+        consumeEvents()
+    }
+
+    deinit {
+        eventContinuation.finish()
+    }
+
+    /// Consume events in a detached task until the event stream is finished. This function **must** be called excatly once per the lifetime of an actor. Without this, the actor will never act on events, so no work will actually be done.
+    /// `self` is resolved weakly per iteration so the loop does not keep the actor alive.
+    private nonisolated consuming func consumeEvents() {
+        Task.detached { [weak self, eventStream] in
+            for await event in eventStream {
+                guard let self else { return }
+                await self.handleEvent(event)
+            }
+        }
+    }
+
+    // MARK: - PacketTunnelActorProtocol
+
+    public var observedStates: AsyncStream<ObservedState> {
+        stateBroadcaster.makeStream(replaying: observedState)
+    }
+
+    public func start(options: StartOptions) async {
+        eventContinuation.yield(.start(options))
+    }
+
+    nonisolated public func stop() {
+        eventContinuation.yield(.stop)
+    }
+
+    public func waitUntilDisconnected() async {
+        await observedStates.waitUntilDisconnected()
+    }
+
+    nonisolated public func onSleep() {
+        eventContinuation.yield(.sleep)
+    }
+
+    nonisolated public func onWake() {
+        eventContinuation.yield(.wake)
+    }
+
+    /// Ignored: reachability handling comes with the actor's own path observation.
+    nonisolated public func updateNetworkReachability(networkPathStatus: NWPath.Status) {}
+
+    #if NEVER_IN_PRODUCTION
+        /// Returns once every event queued before this call has been handled.
+        /// Returns immediately once the actor has stopped, since no further events can run.
+        nonisolated func drainEvents() async {
+            await withCheckedContinuation { continuation in
+                // A finished stream silently drops the barrier, so resume rather than wait forever.
+                guard case .enqueued = eventContinuation.yield(.barrier { continuation.resume() })
+                else {
+                    continuation.resume()
+                    return
+                }
+            }
+        }
+    #endif
+
+    nonisolated public func reconnect(to nextRelays: NextRelays, reconnectReason: ActorReconnectReason) {
+        eventContinuation.yield(.reconnect(nextRelays, reconnectReason))
+    }
+
+    // TODO: implement key rotation handling
+    nonisolated public func notifyKeyRotation(date: Date?) {}
+
+    nonisolated public func setErrorState(reason: BlockedStateReason) {
+        eventContinuation.yield(.setErrorState(reason))
+    }
+
+    // No-ops: PQ is handled entirely in Rust. Remove when the WireGuardGo interface is removed.
+    nonisolated public func notifyEphemeralPeerNegotiated() {}
+    nonisolated public func changeEphemeralPeerNegotiationState(
+        configuration: EphemeralPeerNegotiationState,
+        reconfigurationSemaphore: OneshotChannel
+    ) {}
+
+    // MARK: - Event loop
+
+    private func handleEvent(_ event: GotaTunEvent) async {
+        switch event {
+        case let .start(options):
+            await handleStart(options)
+        case .stop:
+            handleStop()
+        case let .adapterConnected(generation):
+            guard isCurrentAdapter(generation) else { return }
+            await handleAdapterConnected()
+        case let .adapterTimeout(generation):
+            guard isCurrentAdapter(generation) else { return }
+            await handleAdapterTimeout()
+        case let .adapterError(error, generation):
+            guard isCurrentAdapter(generation) else { return }
+            handleAdapterError(error)
+        case let .reconnect(nextRelays, reason):
+            await handleReconnect(nextRelays: nextRelays, reason: reason)
+        case let .setErrorState(reason):
+            handleSetErrorState(reason)
+        case .sleep:
+            currentAdapter?.suspendTunnel()
+        case .wake:
+            currentAdapter?.wakeTunnel()
+        #if NEVER_IN_PRODUCTION
+            case let .barrier(resume):
+                resume()
+        #endif
+        }
+    }
+
+    // MARK: - Start
+
+    private func handleStart(_ options: StartOptions) async {
+        guard case .initial = observedState else {
+            logger.debug("Ignoring start() while not in initial state")
+            return
+        }
+
+        await startConnection(nextRelays: options.selectedRelays.map { .preSelected($0) } ?? .random)
+    }
+
+    // MARK: - Stop
+
+    private func handleStop() {
+        switch observedState {
+        case .disconnected:
+            return
+        default:
+            stopCurrentAdapter()
+            observedState = .disconnected
+            logger.debug("Stopped, entering disconnected state")
+        }
+    }
+
+    /// Finish the event loop. Called upon entering `.disconnected`.
+    /// Observation streams are finished by the broadcaster.
+    private func terminate() {
+        eventContinuation.finish()
+    }
+
+    // MARK: - Adapter callbacks
+
+    private func handleAdapterConnected() async {
+        switch observedState {
+        case var .connecting(info), var .reconnecting(info):
+            info.connectionAttemptCount = 0
+            observedState = .connected(info)
+            await providerDelegate.reassertTunnel()
+            logger.debug("Connected")
+        default:
+            logger.debug("Ignoring onConnected in state \(observedState)")
+        }
+    }
+
+    private func handleAdapterTimeout() async {
+        guard observedState.connectionState != nil else {
+            logger.debug("Ignoring onTimeout in state \(observedState)")
+            return
+        }
+
+        await restartConnection(nextRelays: .random, incrementAttempt: true)
+    }
+
+    private func handleAdapterError(_ error: GotaTunError) {
+        let blockedReason = mapGotaTunError(error)
+        logger.error("Adapter error: \(error) → blocked reason: \(blockedReason)")
+        enterErrorState(reason: blockedReason)
+    }
+
+    // MARK: - Reconnect
+
+    private func handleReconnect(nextRelays: NextRelays, reason: ActorReconnectReason) async {
+        switch observedState {
+        case .error:
+            logger.debug("Reconnecting from error state")
+            stopCurrentAdapter()
+            await startConnection(nextRelays: nextRelays)
+        case .connecting, .connected, .reconnecting:
+            logger.debug("Reconnecting (reason: \(reason))")
+            await restartConnection(nextRelays: nextRelays)
+        default:
+            logger.debug("Ignoring reconnect, not connected or connecting")
+        }
+    }
+
+    // MARK: - Error state
+
+    private func handleSetErrorState(_ reason: BlockedStateReason) {
+        enterErrorState(reason: reason)
+    }
+
+    private func enterErrorState(reason: BlockedStateReason) {
+        switch observedState {
+        case .disconnected:
+            return
+
+        case let .error(blocked) where blocked.reason == reason:
+            break
+
+        case var .error(blocked):
+            blocked.reason = reason
+            observedState = .error(blocked)
+            logger.debug("Updating error state reason: \(reason)")
+
+        default:
+            stopCurrentAdapter()
+            observedState = .error(
+                ObservedBlockedState(
+                    reason: reason,
+                    relayConstraints: observedState.connectionState?.relayConstraints
+                ))
+            logger.debug("Entering error state: \(reason)")
+        }
+    }
+
+    // MARK: - Connection management
+
+    /// Replace the current connection attempt with a fresh one, carrying over the attempt count
+    /// and whether the tunnel was already established. No-op unless a connection is in progress.
+    private func restartConnection(nextRelays: NextRelays, incrementAttempt: Bool = false) async {
+        guard var info = observedState.connectionState else { return }
+
+        if incrementAttempt {
+            info.incrementAttemptCount()
+        }
+        let isReconnect = isTunnelEstablished
+        logger.debug("Restarting connection (attempt \(info.connectionAttemptCount))")
+
+        stopCurrentAdapter()
+        await startConnection(
+            nextRelays: nextRelays,
+            attemptCount: info.connectionAttemptCount,
+            isReconnect: isReconnect
+        )
+    }
+
+    private func startConnection(
+        nextRelays: NextRelays,
+        attemptCount: UInt = 0,
+        isReconnect: Bool = false
+    ) async {
+        let settings: Settings
+        do {
+            settings = try settingsReader.read()
+        } catch {
+            enterErrorState(reason: blockedStateErrorMapper.mapError(error))
+            return
+        }
+
+        let selectedRelays: SelectedRelays
+        do {
+            selectedRelays = try selectRelays(nextRelays, settings: settings, attemptCount: attemptCount)
+        } catch {
+            enterErrorState(reason: blockedStateErrorMapper.mapError(error))
+            return
+        }
+
+        do {
+            try await applyInterfaceSettingsIfNeeded(settings)
+        } catch {
+            logger.error("Failed to apply network settings: \(error)")
+            enterErrorState(reason: .tunnelAdapter)
+            return
+        }
+
+        guard let fd = providerDelegate.tunnelFileDescriptor else {
+            logger.error("Failed to obtain tunnel file descriptor")
+            enterErrorState(reason: .tunnelAdapter)
+            return
+        }
+
+        guard let (ipv4Address, ipv6Address) = interfaceAddresses(in: settings) else {
+            logger.error("Failed to extract both IPv4 and IPv6 address from settings")
+            enterErrorState(reason: .tunnelAdapter)
+            return
+        }
+
+        let config = Self.makeGotaTunConfig(
+            settings: settings,
+            selectedRelays: selectedRelays,
+            privateKey: settings.privateKey,
+            fd: fd,
+            ipv4Address: ipv4Address,
+            ipv6Address: ipv6Address,
+            establishTimeout: Self.computeEstablishTimeout(attemptCount: attemptCount)
+        )
+
+        let connectionState = Self.makeConnectionState(
+            config: config,
+            selectedRelays: selectedRelays,
+            relayConstraints: settings.tunnelSettings.relayConstraints,
+            networkReachability: .undetermined,
+            connectionAttemptCount: attemptCount,
+            lastKeyRotation: nil
+        )
+
+        observedState = isReconnect ? .reconnecting(connectionState) : .connecting(connectionState)
+
+        startAdapter(config: config)
+    }
+
+    private func selectRelays(
+        _ nextRelays: NextRelays,
+        settings: Settings,
+        attemptCount: UInt
+    ) throws -> SelectedRelays {
+        if case let .preSelected(relays) = nextRelays {
+            return relays
+        }
+        if case .current = nextRelays {
+            logger.warning("NextRelays.current is unsupported by GotaTun, selecting new relays")
+        }
+        return try relaySelector.selectRelays(
+            tunnelSettings: settings.tunnelSettings,
+            connectionAttemptCount: attemptCount
+        )
+    }
+
+    /// Pushes `settings`' interface settings (DNS, addresses) to iOS, skipping the call if unchanged.
+    private func applyInterfaceSettingsIfNeeded(_ settings: Settings) async throws {
+        let interfaceSettings = settings.interfaceSettings()
+        guard interfaceSettings != lastAppliedSettings else { return }
+        try await providerDelegate.applyNetworkSettings(interfaceSettings)
+        lastAppliedSettings = interfaceSettings
+        logger.debug("Applied tunnel network settings")
+    }
+
+    private func startAdapter(config: GotaTunConfig) {
+        let adapter = adapterFactory.makeAdapter()
+        adapterGeneration += 1
+        currentAdapter = adapter
+
+        do {
+            try adapter.startTunnel(
+                config: config,
+                callbackHandler: CallbackProxy(continuation: eventContinuation, generation: adapterGeneration)
+            )
+        } catch {
+            logger.error("Failed to start tunnel: \(error)")
+            currentAdapter = nil
+            enterErrorState(reason: .tunnelAdapter)
+        }
+    }
+
+    private func stopCurrentAdapter() {
+        currentAdapter?.stopTunnel()
+        currentAdapter = nil
+    }
+
+    /// Whether `generation` identifies the adapter currently in use. Events from a replaced or
+    /// stopped adapter can still be queued in the event stream; they must not be applied to the
+    /// current attempt.
+    private func isCurrentAdapter(_ generation: UInt64) -> Bool {
+        guard generation == adapterGeneration else {
+            logger.debug("Ignoring event from stale adapter")
+            return false
+        }
+        return true
+    }
+
+    // MARK: - Pure config building
+
+    private func interfaceAddresses(in settings: Settings) -> (IPv4Address, IPv6Address)? {
+        guard let ipv4 = settings.interfaceAddresses.lazy.compactMap({ IPv4Address("\($0.address)") }).first
+        else {
+            logger.error("No IPv4 interface address available")
+            return nil
+        }
+
+        guard let ipv6 = settings.interfaceAddresses.lazy.compactMap({ IPv6Address("\($0.address)") }).first
+        else {
+            logger.error("No IPv6 interface address available")
+            return nil
+        }
+
+        return (ipv4, ipv6)
+    }
+
+    private static func makeGotaTunConfig(
+        settings: Settings,
+        selectedRelays: SelectedRelays,
+        privateKey: WireGuard.PrivateKey,
+        fd: Int32,
+        ipv4Address: IPv4Address,
+        ipv6Address: IPv6Address,
+        establishTimeout: UInt32
+    ) -> GotaTunConfig {
+        GotaTunConfig(
+            tunnelFd: fd,
+            privateKey: privateKey.rawValue,
+            ipv4Address: ipv4Address,
+            ipv6Address: ipv6Address,
+            mtu: 1280,
+            ipv4Gateway: "\(selectedRelays.exit.endpoint.ipv4Gateway)",
+            clientPublicKey: privateKey.publicKey.rawValue,
+            exitPeerPublicKey: selectedRelays.exit.endpoint.publicKey,
+            exitPeerEndpoint: "\(selectedRelays.exit.endpoint.socketAddress)",
+            entryPeerPublicKey: selectedRelays.entry?.endpoint.publicKey,
+            entryPeerEndpoint: selectedRelays.entry.map { "\($0.endpoint.socketAddress)" },
+            isPostQuantum: settings.tunnelSettings.tunnelQuantumResistance.isEnabled,
+            isDaitaEnabled: settings.tunnelSettings.daita.isEnabled,
+            establishTimeout: establishTimeout,
+            obfuscationMethod: selectedRelays.ingress.endpoint.obfuscation
+        )
+    }
+
+    private static func makeConnectionState(
+        config: GotaTunConfig,
+        selectedRelays: SelectedRelays,
+        relayConstraints: RelayConstraints,
+        networkReachability: NetworkReachability,
+        connectionAttemptCount: UInt,
+        lastKeyRotation: Date?
+    ) -> ObservedConnectionState {
+        ObservedConnectionState(
+            selectedRelays: selectedRelays,
+            relayConstraints: relayConstraints,
+            networkReachability: networkReachability,
+            connectionAttemptCount: connectionAttemptCount,
+            transportLayer: config.obfuscationMethod.transportLayer,
+            remotePort: selectedRelays.ingress.endpoint.socketAddress.port,
+            lastKeyRotation: lastKeyRotation,
+            isPostQuantum: config.isPostQuantum,
+            isDaitaEnabled: config.isDaitaEnabled
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Whether the tunnel was already up, so a fresh attempt is reported as `.reconnecting`.
+    private var isTunnelEstablished: Bool {
+        switch observedState {
+        case .connected, .reconnecting:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func computeEstablishTimeout(attemptCount: UInt) -> UInt32 {
+        let base: UInt32 = 4
+        return min(base << min(attemptCount, 2), 15)  // 4, 8, 15 seconds
+    }
+
+    private func mapGotaTunError(_ error: GotaTunError) -> BlockedStateReason {
+        switch error {
+        case .invalidConfig:
+            return .tunnelAdapter
+        case .internalError:
+            return .unknown
+        }
+    }
+}

--- a/ios/PacketTunnelCore/GotaTun/GotaTunAdapterProtocol.swift
+++ b/ios/PacketTunnelCore/GotaTun/GotaTunAdapterProtocol.swift
@@ -1,0 +1,100 @@
+//
+//  GotaTunAdapterProtocol.swift
+//  PacketTunnelCore
+//
+//  Created by Emīls on 2026-08-13.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+import MullvadTypes
+import Network
+
+/// Error reported by the GotaTun Rust adapter during tunnel setup.
+/// Each variant maps to a non-recoverable `BlockedStateReason`.
+public enum GotaTunError: Error, Sendable, Equatable {
+    case invalidConfig(String)
+    case internalError(String)
+}
+
+/// Callback handler invoked by the GotaTun adapter (Rust → Swift).
+/// All methods are called at most once per adapter instance.
+/// Implementations must be `Sendable` since callbacks arrive from Rust-owned threads.
+public protocol GotaTunCallbackHandler: AnyObject, Sendable {
+    /// Tunnel is up, pinger confirmed traffic flows.
+    func onConnected()
+
+    /// Pinger timed out, either during initial setup or after `onConnected`.
+    func onTimeout()
+
+    /// Fatal error during setup.
+    func onError(_ error: GotaTunError)
+}
+
+/// Domain config for tunnel setup. Deliberately decoupled from the Rust FFI:
+/// the concrete adapter (`RustGotaTunAdapter`, in the `PacketTunnel` target) maps
+/// this to the UniFFI-generated `MullvadRustRuntime.GotaTunConfig`, keeping
+/// `PacketTunnelCore` agnostic to the FFI layer.
+public struct GotaTunConfig: Sendable {
+    /// File descriptor for the TUN device provided by the packet tunnel extension.
+    public let tunnelFd: Int32
+    public let privateKey: Data
+    /// Tunnel interface addresses. Required: a tunnel cannot start without them,
+    /// so the missing/invalid cases are unrepresentable here.
+    public let ipv4Address: IPv4Address
+    public let ipv6Address: IPv6Address
+    public let mtu: UInt16
+    /// IPv4 gateway address for the tunnel (e.g. "10.64.0.1").
+    public let ipv4Gateway: String
+    /// Client (device) public key, derived from privateKey.
+    public let clientPublicKey: Data
+    public let exitPeerPublicKey: Data
+    public let exitPeerEndpoint: String
+    public let entryPeerPublicKey: Data?
+    public let entryPeerEndpoint: String?
+    public let isPostQuantum: Bool
+    public let isDaitaEnabled: Bool
+    /// How long to wait for the tunnel to establish connectivity (seconds).
+    public let establishTimeout: UInt32
+    /// Obfuscation method for the ingress relay.
+    public let obfuscationMethod: ObfuscationMethod
+}
+
+/// Each instance represents a single tunnel connection attempt.
+/// Create a new instance for each retry.
+///
+/// Internally, Rust may create multiple GotaTun `Device` instances during a
+/// single connection attempt (e.g., smoltcp device for PQ negotiation, then
+/// final tunnel device). This protocol only exposes the outer connection.
+///
+/// ## Concurrency Safety
+/// All methods are safe to call from any thread. The adapter uses internal
+/// synchronization to handle races:
+/// - Once a terminal callback has fired, all subsequent calls are no-ops.
+/// - `stopTunnel()` suppresses pending callbacks.
+public protocol GotaTunAdapterProtocol: Sendable {
+    /// Start the tunnel. Non-blocking.
+    /// Exactly one of `onConnected`/`onTimeout`/`onError` will be called.
+    /// After `onConnected`, `onTimeout` may fire once more if connection is lost.
+    func startTunnel(config: GotaTunConfig, callbackHandler: GotaTunCallbackHandler) throws
+
+    /// Stop the tunnel. Safe to call multiple times or concurrently with callbacks.
+    /// After this returns, no callbacks will fire.
+    func stopTunnel()
+
+    /// Recycle UDP sockets when NWPath changes (e.g. WiFi → cellular).
+    /// No-op if tunnel has terminated or is still in PQ negotiation.
+    func recycleUdpSockets()
+
+    /// Suspend tunnel (device sleep). Pauses pinger if connected.
+    /// Abandons PQ negotiation if in progress, in which case `onTimeout` will fire.
+    func suspendTunnel()
+
+    /// Wake tunnel from suspension. Resumes pinger.
+    func wakeTunnel()
+}
+
+/// Factory for creating adapter instances. One instance per connection attempt.
+public protocol GotaTunAdapterFactory: Sendable {
+    func makeAdapter() -> GotaTunAdapterProtocol
+}

--- a/ios/PacketTunnelCoreTests/GotaTunActorTests.swift
+++ b/ios/PacketTunnelCoreTests/GotaTunActorTests.swift
@@ -1,0 +1,377 @@
+//
+//  GotaTunActorTests.swift
+//  PacketTunnelCoreTests
+//
+//  Created by Emīls on 2026-08-13.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+import MullvadTypes
+import Network
+import XCTest
+
+@testable import MullvadMockData
+@testable import MullvadREST
+@testable import MullvadSettings
+@preconcurrency @testable import PacketTunnelCore
+
+final class GotaTunActorTests: XCTestCase {
+    private let launchOptions = StartOptions(launchSource: .app)
+
+    // MARK: - Helpers
+
+    private func makeActor(
+        adapterFactory: GotaTunAdapterFactory = GotaTunAdapterFactoryStub(),
+        providerDelegate: TunnelProviderDelegate = TunnelProviderDelegateStub(),
+        settingsReader: SettingsReaderProtocol = SettingsReaderStub.staticConfiguration(),
+        relaySelector: RelaySelectorProtocol = RelaySelectorStub.nonFallible(),
+        blockedStateErrorMapper: BlockedStateErrorMapperProtocol = BlockedStateErrorMapperStub()
+    ) -> GotaTunActor {
+        GotaTunActor(
+            providerDelegate: providerDelegate,
+            settingsReader: settingsReader,
+            relaySelector: relaySelector,
+            blockedStateErrorMapper: blockedStateErrorMapper,
+            adapterFactory: adapterFactory
+        )
+    }
+
+    /// Observe the actor from before `action` runs until `stop` accepts the states seen so far,
+    /// returning all of them, including the one current at subscription.
+    @discardableResult
+    private func collectStates(
+        from actor: GotaTunActor,
+        timeout: TimeInterval = 2.0,
+        stoppingWhen stop: @Sendable @escaping ([ObservedState]) -> Bool,
+        while action: () async -> Void = {}
+    ) async -> [ObservedState] {
+        let collector = StateCollector()
+        let reached = expectation(description: "Wait for state")
+        let states = await actor.observedStates
+
+        let task = Task {
+            for await state in states {
+                await collector.append(state)
+                if stop(await collector.collected) {
+                    reached.fulfill()
+                    return
+                }
+            }
+        }
+
+        await action()
+        await fulfillment(of: [reached], timeout: timeout)
+        task.cancel()
+
+        return await collector.collected
+    }
+
+    /// Observe until a state matches `predicate`.
+    @discardableResult
+    private func collectStates(
+        from actor: GotaTunActor,
+        until predicate: @Sendable @escaping (ObservedState) -> Bool,
+        timeout: TimeInterval = 2.0,
+        while action: () async -> Void = {}
+    ) async -> [ObservedState] {
+        await collectStates(
+            from: actor,
+            timeout: timeout,
+            stoppingWhen: { $0.last.map(predicate) ?? false },
+            while: action
+        )
+    }
+
+    /// Observe until `count` states have been seen.
+    @discardableResult
+    private func collectStates(
+        from actor: GotaTunActor,
+        count: Int,
+        timeout: TimeInterval = 2.0,
+        while action: () async -> Void = {}
+    ) async -> [ObservedState] {
+        await collectStates(
+            from: actor,
+            timeout: timeout,
+            stoppingWhen: { $0.count >= count },
+            while: action
+        )
+    }
+
+    /// Wait for the actor to reach a state matching `predicate`, optionally driving it with `action`.
+    private func waitFor(
+        _ actor: GotaTunActor,
+        until predicate: @Sendable @escaping (ObservedState) -> Bool,
+        timeout: TimeInterval = 2.0,
+        while action: () async -> Void = {}
+    ) async {
+        await collectStates(from: actor, until: predicate, timeout: timeout, while: action)
+    }
+
+    // MARK: - Happy path
+
+    func testStartGoesToConnected() async throws {
+        let actor = makeActor()
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+    }
+
+    func testStartTransitionsInOrder() async throws {
+        let actor = makeActor()
+
+        let states = await collectStates(
+            from: actor, until: { $0.isConnected },
+            while: {
+                await actor.start(options: launchOptions)
+            })
+
+        XCTAssertEqual(states.map(\.name), ["Initial", "Connecting", "Connected"])
+    }
+
+    func testStartIgnoresSubsequentStarts() async throws {
+        let actor = makeActor()
+
+        await waitFor(
+            actor, until: { $0.isConnected },
+            while: {
+                await actor.start(options: launchOptions)
+                await actor.start(options: launchOptions)
+            })
+    }
+
+    // MARK: - Stop
+
+    func testStopGoesToDisconnected() async throws {
+        let actor = makeActor()
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+
+        await waitFor(actor, until: { $0.isDisconnected }, while: { actor.stop() })
+    }
+
+    // MARK: - Timeout handling
+
+    func testTimeoutStaysInConnecting() async throws {
+        let factory = GotaTunAdapterFactoryStub(outcomes: [
+            .timeout(),
+            .connected(),
+        ])
+        let actor = makeActor(adapterFactory: factory)
+
+        let states = await collectStates(
+            from: actor, until: { $0.isConnected },
+            while: {
+                await actor.start(options: launchOptions)
+            })
+
+        // The retry stays in `.connecting`; it must not report `.reconnecting`.
+        XCTAssertEqual(states.map(\.name), ["Initial", "Connecting", "Connecting", "Connected"])
+        XCTAssertEqual(factory.adaptersCreated.count, 2, "Should have created 2 adapters")
+    }
+
+    func testConnectedThenTimeoutGoesToReconnecting() async throws {
+        let factory = GotaTunAdapterFactoryStub(outcomes: [
+            .connectedThenTimeout(),
+            .connected(),
+        ])
+        let actor = makeActor(adapterFactory: factory)
+
+        let states = await collectStates(from: actor, count: 5) {
+            await actor.start(options: launchOptions)
+        }
+
+        XCTAssertEqual(
+            states.map(\.name),
+            ["Initial", "Connecting", "Connected", "Reconnecting", "Connected"]
+        )
+    }
+
+    func testAttemptCountIncrementsOnTimeout() async throws {
+        let factory = GotaTunAdapterFactoryStub(outcomes: [
+            .timeout(),
+            .timeout(),
+            .timeout(),
+            .connected(),
+        ])
+        let actor = makeActor(adapterFactory: factory)
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+
+        XCTAssertEqual(factory.adaptersCreated.count, 4, "Should have created 4 adapters (3 timeouts + 1 success)")
+    }
+
+    func testAttemptCountResetsOnConnected() async throws {
+        let factory = GotaTunAdapterFactoryStub(outcomes: [
+            .timeout(),
+            .connected(),
+        ])
+        let actor = makeActor(adapterFactory: factory)
+
+        let states = await collectStates(
+            from: actor, until: { $0.isConnected },
+            while: {
+                await actor.start(options: launchOptions)
+            })
+
+        XCTAssertEqual(
+            states.last?.connectionState?.connectionAttemptCount, 0, "Attempt count should reset")
+    }
+
+    // MARK: - Error state entry
+
+    func testAdapterErrorEntersErrorState() async throws {
+        let factory = GotaTunAdapterFactoryStub(outcome: .error(.internalError("test")))
+        let actor = makeActor(adapterFactory: factory)
+
+        await waitFor(
+            actor, until: { $0.blockedReason != nil },
+            while: {
+                await actor.start(options: launchOptions)
+            })
+    }
+
+    func testSettingsReadFailureEntersErrorState() async throws {
+        let settingsReader = SettingsReaderStub { throw POSIXError(.EPERM) }
+        let errorMapper = BlockedStateErrorMapperStub { _ in .readSettings }
+        let actor = makeActor(settingsReader: settingsReader, blockedStateErrorMapper: errorMapper)
+
+        await waitFor(
+            actor, until: { $0.blockedReason == .readSettings },
+            while: {
+                await actor.start(options: launchOptions)
+            })
+    }
+
+    func testSetErrorStateFromProvider() async throws {
+        let actor = makeActor()
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+
+        await waitFor(
+            actor, until: { $0.blockedReason == .deviceRevoked },
+            while: {
+                actor.setErrorState(reason: .deviceRevoked)
+            })
+    }
+
+    // MARK: - Error state exit
+
+    func testUserReconnectExitsErrorState() async throws {
+        let factory = GotaTunAdapterFactoryStub(outcomes: [
+            .error(.internalError("test")),
+            .connected(),
+        ])
+        let actor = makeActor(adapterFactory: factory)
+
+        await waitFor(actor, until: { $0.blockedReason != nil }, while: { await actor.start(options: launchOptions) })
+
+        await waitFor(
+            actor, until: { $0.isConnected },
+            while: {
+                actor.reconnect(to: .random, reconnectReason: .userInitiated)
+            })
+    }
+
+    func testConnectionLossReconnectRestartsAdapter() async throws {
+        let factory = GotaTunAdapterFactoryStub(outcome: .connected())
+        let actor = makeActor(adapterFactory: factory)
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+
+        // Every reason restarts the connection; a reason that stopped the adapter without
+        // starting a new one would leave the tunnel wedged with no way out.
+        await collectStates(from: actor, count: 3) {
+            actor.reconnect(to: .random, reconnectReason: .connectionLoss)
+        }
+
+        let state = await actor.observedState
+        XCTAssertEqual(factory.adaptersCreated.count, 2)
+        XCTAssertTrue(state.isConnected)
+    }
+
+    // MARK: - Stale adapter callbacks
+
+    func testStaleConnectedCallbackIsIgnored() async throws {
+        let factory = GotaTunAdapterFactoryStub(outcomes: [.connected(), .never])
+        let actor = makeActor(adapterFactory: factory)
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+
+        await waitFor(
+            actor, until: { $0.isReconnecting },
+            while: {
+                actor.reconnect(to: .random, reconnectReason: .connectionLoss)
+            })
+
+        // A callback from the replaced adapter arrives after the swap.
+        factory.adaptersCreated[0].callbackHandler?.onConnected()
+        await actor.drainEvents()
+
+        let state = await actor.observedState
+        XCTAssertTrue(state.isReconnecting, "A stale onConnected must not mark the new attempt connected")
+    }
+
+    func testStaleTimeoutCallbackIsIgnored() async throws {
+        let factory = GotaTunAdapterFactoryStub(outcomes: [.connected(), .never])
+        let actor = makeActor(adapterFactory: factory)
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+
+        await waitFor(
+            actor, until: { $0.isReconnecting },
+            while: {
+                actor.reconnect(to: .random, reconnectReason: .connectionLoss)
+            })
+
+        factory.adaptersCreated[0].callbackHandler?.onTimeout()
+        await actor.drainEvents()
+
+        let state = await actor.observedState
+        XCTAssertTrue(state.isReconnecting)
+        XCTAssertEqual(
+            factory.adaptersCreated.count, 2,
+            "A stale onTimeout must not restart the current attempt")
+    }
+
+    // MARK: - Lifecycle guards
+
+    func testReconnectBeforeStartIsIgnored() async throws {
+        let factory = GotaTunAdapterFactoryStub()
+        let actor = makeActor(adapterFactory: factory)
+
+        actor.reconnect(to: .random, reconnectReason: .userInitiated)
+        await actor.drainEvents()
+
+        XCTAssertEqual(factory.adaptersCreated.count, 0, "No adapter should be created")
+    }
+
+    func testStopFromAnyState() async throws {
+        let actor = makeActor()
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+
+        actor.stop()
+        await actor.drainEvents()
+
+        let state = await actor.observedState
+        XCTAssertEqual(state, .disconnected)
+    }
+
+    // MARK: - Stop during connection
+
+    func testStopDuringConnecting() async throws {
+        // The adapter never reports, so the actor stays in `.connecting` until stopped.
+        let factory = GotaTunAdapterFactoryStub(outcome: .never)
+        let actor = makeActor(adapterFactory: factory)
+
+        await waitFor(actor, until: { $0.isConnecting }, while: { await actor.start(options: launchOptions) })
+
+        actor.stop()
+        await actor.drainEvents()
+
+        let state = await actor.observedState
+        XCTAssertEqual(state, .disconnected, "Should be disconnected after stop during connecting")
+
+        XCTAssertEqual(factory.adaptersCreated.count, 1)
+    }
+}

--- a/ios/PacketTunnelCoreTests/GotaTunActorTests.swift
+++ b/ios/PacketTunnelCoreTests/GotaTunActorTests.swift
@@ -108,6 +108,35 @@ final class GotaTunActorTests: XCTestCase {
         await collectStates(from: actor, until: predicate, timeout: timeout, while: action)
     }
 
+    /// Reach `.reconnecting` on a second adapter, leaving `adaptersCreated[0]` replaced but still
+    /// able to report, the way a Rust device can when its callback is already in flight.
+    private func makeActorWithReplacedAdapter() async -> (GotaTunActor, GotaTunAdapterFactoryStub) {
+        let factory = GotaTunAdapterFactoryStub(outcomes: [.connected(), .never])
+        let actor = makeActor(adapterFactory: factory)
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+
+        await waitFor(
+            actor, until: { $0.isReconnecting },
+            while: {
+                actor.reconnect(to: .random, reconnectReason: .connectionLoss)
+            })
+
+        return (actor, factory)
+    }
+
+    /// Stop the actor and assert it settles in `.disconnected`.
+    private func assertStopLeadsToDisconnected(
+        _ actor: GotaTunActor,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        await waitFor(actor, until: { $0.isDisconnected }, while: { actor.stop() })
+
+        let state = await actor.observedState
+        XCTAssertEqual(state, .disconnected, file: file, line: line)
+    }
+
     // MARK: - Happy path
 
     func testStartGoesToConnected() async throws {
@@ -137,16 +166,6 @@ final class GotaTunActorTests: XCTestCase {
                 await actor.start(options: launchOptions)
                 await actor.start(options: launchOptions)
             })
-    }
-
-    // MARK: - Stop
-
-    func testStopGoesToDisconnected() async throws {
-        let actor = makeActor()
-
-        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
-
-        await waitFor(actor, until: { $0.isDisconnected }, while: { actor.stop() })
     }
 
     // MARK: - Timeout handling
@@ -289,19 +308,10 @@ final class GotaTunActorTests: XCTestCase {
         XCTAssertTrue(state.isConnected)
     }
 
-    // MARK: - Stale adapter callbacks
+    // MARK: - Callbacks from unexpected adapters
 
     func testStaleConnectedCallbackIsIgnored() async throws {
-        let factory = GotaTunAdapterFactoryStub(outcomes: [.connected(), .never])
-        let actor = makeActor(adapterFactory: factory)
-
-        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
-
-        await waitFor(
-            actor, until: { $0.isReconnecting },
-            while: {
-                actor.reconnect(to: .random, reconnectReason: .connectionLoss)
-            })
+        let (actor, factory) = await makeActorWithReplacedAdapter()
 
         // A callback from the replaced adapter arrives after the swap.
         factory.adaptersCreated[0].callbackHandler?.onConnected()
@@ -312,16 +322,7 @@ final class GotaTunActorTests: XCTestCase {
     }
 
     func testStaleTimeoutCallbackIsIgnored() async throws {
-        let factory = GotaTunAdapterFactoryStub(outcomes: [.connected(), .never])
-        let actor = makeActor(adapterFactory: factory)
-
-        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
-
-        await waitFor(
-            actor, until: { $0.isReconnecting },
-            while: {
-                actor.reconnect(to: .random, reconnectReason: .connectionLoss)
-            })
+        let (actor, factory) = await makeActorWithReplacedAdapter()
 
         factory.adaptersCreated[0].callbackHandler?.onTimeout()
         await actor.drainEvents()
@@ -331,6 +332,78 @@ final class GotaTunActorTests: XCTestCase {
         XCTAssertEqual(
             factory.adaptersCreated.count, 2,
             "A stale onTimeout must not restart the current attempt")
+    }
+
+    func testStaleErrorCallbackIsIgnored() async throws {
+        let (actor, factory) = await makeActorWithReplacedAdapter()
+
+        factory.adaptersCreated[0].callbackHandler?.onError(.internalError("stale"))
+        await actor.drainEvents()
+
+        let state = await actor.observedState
+        XCTAssertNil(state.blockedReason, "A stale onError must not block the tunnel")
+        XCTAssertTrue(state.isReconnecting)
+    }
+
+    /// A stale adapter that reports repeatedly must stay ignored, not just on its first callback.
+    func testRepeatedStaleCallbacksAreIgnored() async throws {
+        let (actor, factory) = await makeActorWithReplacedAdapter()
+
+        let stale = factory.adaptersCreated[0]
+        stale.callbackHandler?.onConnected()
+        stale.callbackHandler?.onTimeout()
+        stale.callbackHandler?.onConnected()
+        stale.callbackHandler?.onError(.invalidConfig("stale"))
+        await actor.drainEvents()
+
+        let state = await actor.observedState
+        XCTAssertTrue(state.isReconnecting)
+        XCTAssertEqual(factory.adaptersCreated.count, 2)
+    }
+
+    /// Entering the error state stops the adapter without replacing it. Its callbacks must not
+    /// resurrect the connection, nor rewrite the reason the tunnel is blocked for.
+    func testCallbacksFromAdapterStoppedByErrorStateAreIgnored() async throws {
+        let factory = GotaTunAdapterFactoryStub(outcome: .never)
+        let actor = makeActor(adapterFactory: factory)
+
+        await waitFor(actor, until: { $0.isConnecting }, while: { await actor.start(options: launchOptions) })
+
+        await waitFor(
+            actor, until: { $0.blockedReason == .deviceRevoked },
+            while: {
+                actor.setErrorState(reason: .deviceRevoked)
+            })
+
+        let stopped = factory.adaptersCreated[0]
+        XCTAssertTrue(stopped.isStopped)
+
+        stopped.callbackHandler?.onConnected()
+        stopped.callbackHandler?.onError(.internalError("late"))
+        stopped.callbackHandler?.onTimeout()
+        await actor.drainEvents()
+
+        let state = await actor.observedState
+        XCTAssertEqual(state.blockedReason, .deviceRevoked, "A stopped adapter must not change the blocked reason")
+        XCTAssertEqual(factory.adaptersCreated.count, 1, "A stopped adapter must not trigger a new attempt")
+    }
+
+    func testCallbacksAfterStopAreIgnored() async throws {
+        let factory = GotaTunAdapterFactoryStub(outcome: .never)
+        let actor = makeActor(adapterFactory: factory)
+
+        await waitFor(actor, until: { $0.isConnecting }, while: { await actor.start(options: launchOptions) })
+        await assertStopLeadsToDisconnected(actor)
+
+        let stopped = factory.adaptersCreated[0]
+        stopped.callbackHandler?.onConnected()
+        stopped.callbackHandler?.onTimeout()
+        stopped.callbackHandler?.onError(.internalError("late"))
+        await actor.drainEvents()
+
+        let state = await actor.observedState
+        XCTAssertEqual(state, .disconnected, "Nothing brings the actor back out of `.disconnected`")
+        XCTAssertEqual(factory.adaptersCreated.count, 1)
     }
 
     // MARK: - Lifecycle guards
@@ -345,32 +418,69 @@ final class GotaTunActorTests: XCTestCase {
         XCTAssertEqual(factory.adaptersCreated.count, 0, "No adapter should be created")
     }
 
-    func testStopFromAnyState() async throws {
-        let actor = makeActor()
+    // MARK: - Stop from every state
 
-        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+    // `.negotiatingEphemeralPeer` and `.disconnecting` are unreachable for this actor: PQ is
+    // handled inside Rust, and stopping enters `.disconnected` directly.
 
-        actor.stop()
-        await actor.drainEvents()
+    func testStopFromInitial() async throws {
+        let factory = GotaTunAdapterFactoryStub()
+        let actor = makeActor(adapterFactory: factory)
 
-        let state = await actor.observedState
-        XCTAssertEqual(state, .disconnected)
+        await assertStopLeadsToDisconnected(actor)
+
+        XCTAssertEqual(factory.adaptersCreated.count, 0, "Stopping before start must not connect anything")
     }
 
-    // MARK: - Stop during connection
-
-    func testStopDuringConnecting() async throws {
+    func testStopFromConnecting() async throws {
         // The adapter never reports, so the actor stays in `.connecting` until stopped.
         let factory = GotaTunAdapterFactoryStub(outcome: .never)
         let actor = makeActor(adapterFactory: factory)
 
         await waitFor(actor, until: { $0.isConnecting }, while: { await actor.start(options: launchOptions) })
 
-        actor.stop()
-        await actor.drainEvents()
+        await assertStopLeadsToDisconnected(actor)
 
-        let state = await actor.observedState
-        XCTAssertEqual(state, .disconnected, "Should be disconnected after stop during connecting")
+        XCTAssertEqual(factory.adaptersCreated.count, 1)
+        XCTAssertTrue(factory.adaptersCreated[0].isStopped, "The in-flight attempt must be torn down")
+    }
+
+    func testStopFromConnected() async throws {
+        let factory = GotaTunAdapterFactoryStub()
+        let actor = makeActor(adapterFactory: factory)
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+
+        await assertStopLeadsToDisconnected(actor)
+
+        XCTAssertTrue(factory.adaptersCreated[0].isStopped)
+    }
+
+    func testStopFromReconnecting() async throws {
+        let (actor, factory) = await makeActorWithReplacedAdapter()
+
+        await assertStopLeadsToDisconnected(actor)
+
+        XCTAssertTrue(factory.adaptersCreated[1].isStopped, "The adapter of the current attempt must be stopped")
+    }
+
+    func testStopFromErrorState() async throws {
+        let factory = GotaTunAdapterFactoryStub(outcome: .error(.internalError("test")))
+        let actor = makeActor(adapterFactory: factory)
+
+        await waitFor(actor, until: { $0.blockedReason != nil }, while: { await actor.start(options: launchOptions) })
+
+        await assertStopLeadsToDisconnected(actor)
+    }
+
+    func testStopFromDisconnectedIsIgnored() async throws {
+        let factory = GotaTunAdapterFactoryStub()
+        let actor = makeActor(adapterFactory: factory)
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+
+        await assertStopLeadsToDisconnected(actor)
+        await assertStopLeadsToDisconnected(actor)
 
         XCTAssertEqual(factory.adaptersCreated.count, 1)
     }

--- a/ios/PacketTunnelCoreTests/GotaTunAdapterStub.swift
+++ b/ios/PacketTunnelCoreTests/GotaTunAdapterStub.swift
@@ -1,0 +1,165 @@
+//
+//  GotaTunAdapterStub.swift
+//  PacketTunnelCoreTests
+//
+//  Created by Emīls on 2026-08-13.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+import PacketTunnelCore
+import os
+
+/// Configurable stub for `GotaTunAdapterProtocol`.
+/// Schedules callbacks based on the configured outcome.
+final class GotaTunAdapterStub: GotaTunAdapterProtocol, Sendable {
+    enum Outcome: Sendable {
+        case connected(after: Duration = .zero)
+        case timeout(after: Duration = .zero)
+        case error(GotaTunError, after: Duration = .zero)
+        case connectedThenTimeout(connectedAfter: Duration = .zero, timeoutAfter: Duration = .zero)
+        /// Never reports anything; the tunnel stays in whatever state it was started from.
+        case never
+
+        /// The callbacks this outcome reports, in order, each after its own delay.
+        var steps: [(delay: Duration, report: @Sendable (GotaTunCallbackHandler) -> Void)] {
+            switch self {
+            case .never:
+                return []
+            case let .connected(after):
+                return [(after, { $0.onConnected() })]
+            case let .timeout(after):
+                return [(after, { $0.onTimeout() })]
+            case let .error(error, after):
+                return [(after, { $0.onError(error) })]
+            case let .connectedThenTimeout(connectedAfter, timeoutAfter):
+                return [(connectedAfter, { $0.onConnected() }), (timeoutAfter, { $0.onTimeout() })]
+            }
+        }
+    }
+
+    private struct State {
+        var lastConfig: GotaTunConfig?
+        var callbackHandler: GotaTunCallbackHandler?
+        var callbackTask: Task<Void, Never>?
+        var isStopped = false
+        var recycleUdpSocketsCount = 0
+        var onRecycleUdpSockets: (@Sendable () -> Void)?
+    }
+
+    let outcome: Outcome
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    var lastConfig: GotaTunConfig? { state.withLock { $0.lastConfig } }
+    /// Retained after `stopTunnel` so tests can simulate a callback that was already in
+    /// flight when the adapter was stopped or replaced.
+    var callbackHandler: GotaTunCallbackHandler? { state.withLock { $0.callbackHandler } }
+    var isStopped: Bool { state.withLock { $0.isStopped } }
+    var recycleUdpSocketsCount: Int { state.withLock { $0.recycleUdpSocketsCount } }
+
+    var onRecycleUdpSockets: (@Sendable () -> Void)? {
+        get { state.withLock { $0.onRecycleUdpSockets } }
+        set { state.withLock { $0.onRecycleUdpSockets = newValue } }
+    }
+
+    init(outcome: Outcome = .connected()) {
+        self.outcome = outcome
+    }
+
+    func startTunnel(config: GotaTunConfig, callbackHandler: GotaTunCallbackHandler) throws {
+        state.withLock {
+            $0.lastConfig = config
+            $0.callbackHandler = callbackHandler
+            $0.isStopped = false
+            $0.callbackTask = Task { [outcome, state] in
+                for step in outcome.steps {
+                    if step.delay > .zero {
+                        try? await Task.sleep(for: step.delay)
+                    }
+                    guard !state.withLock({ $0.isStopped }) else { return }
+                    step.report(callbackHandler)
+                }
+            }
+        }
+    }
+
+    func stopTunnel() {
+        state.withLock {
+            $0.isStopped = true
+            $0.callbackTask?.cancel()
+            $0.callbackTask = nil
+        }
+    }
+
+    func recycleUdpSockets() {
+        let onRecycle = state.withLock {
+            $0.recycleUdpSocketsCount += 1
+            return $0.onRecycleUdpSockets
+        }
+        onRecycle?()
+    }
+
+    func suspendTunnel() {}
+
+    func wakeTunnel() {}
+}
+
+/// Stub for `TunnelProviderDelegate` that records what the actor asked of the provider.
+final class TunnelProviderDelegateStub: TunnelProviderDelegate, Sendable {
+    private struct State {
+        var applyError: Error?
+        var reassertCount = 0
+        var appliedSettings: [TunnelInterfaceSettings] = []
+    }
+
+    let tunnelFileDescriptor: Int32?
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    init(tunnelFileDescriptor: Int32? = 0) {
+        self.tunnelFileDescriptor = tunnelFileDescriptor
+    }
+
+    func applyNetworkSettings(_ settings: TunnelInterfaceSettings) async throws {
+        try self.state.withLock { state in
+            if let err = state.applyError {
+                throw err
+            }
+            state.appliedSettings.append(settings)
+        }
+    }
+
+    func reassertTunnel() {
+        self.state.withLock { state in
+            state.reassertCount += 1
+        }
+    }
+}
+
+/// Factory that returns a sequence of adapters with configurable outcomes.
+final class GotaTunAdapterFactoryStub: GotaTunAdapterFactory {
+    private let outcomes: [GotaTunAdapterStub.Outcome]
+    private let created = OSAllocatedUnfairLock(initialState: [GotaTunAdapterStub]())
+
+    var adaptersCreated: [GotaTunAdapterStub] { created.withLock { $0 } }
+
+    /// Create a factory that returns adapters with the given outcomes in order.
+    /// Once outcomes are exhausted, the last outcome is reused.
+    init(outcomes: [GotaTunAdapterStub.Outcome]) {
+        precondition(!outcomes.isEmpty)
+        self.outcomes = outcomes
+    }
+
+    /// Convenience: all adapters use the same outcome.
+    convenience init(outcome: GotaTunAdapterStub.Outcome = .connected()) {
+        self.init(outcomes: [outcome])
+    }
+
+    func makeAdapter() -> GotaTunAdapterProtocol {
+        created.withLock {
+            let adapter = GotaTunAdapterStub(outcome: outcomes[min($0.count, outcomes.count - 1)])
+            $0.append(adapter)
+            return adapter
+        }
+    }
+}

--- a/ios/PacketTunnelCoreTests/Mocks/BlockedStateErrorMapperStub.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/BlockedStateErrorMapperStub.swift
@@ -13,8 +13,8 @@ import MullvadTypes
 import PacketTunnelCore
 
 /// Blocked state error mapper stub that can be configured with a block to simulate a desired behavior.
-class BlockedStateErrorMapperStub: BlockedStateErrorMapperProtocol {
-    let block: (Error) -> BlockedStateReason
+final class BlockedStateErrorMapperStub: BlockedStateErrorMapperProtocol, Sendable {
+    let block: @Sendable (Error) -> BlockedStateReason
 
     /// Initialize a stub that always returns .unknown block reason.
     init() {
@@ -22,7 +22,7 @@ class BlockedStateErrorMapperStub: BlockedStateErrorMapperProtocol {
     }
 
     /// Initialize a stub with custom error mapper block.
-    init(block: @escaping (Error) -> BlockedStateReason) {
+    init(block: @Sendable @escaping (Error) -> BlockedStateReason) {
         self.block = block
     }
 

--- a/ios/PacketTunnelCoreTests/Mocks/ObservedState+Testing.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/ObservedState+Testing.swift
@@ -1,0 +1,51 @@
+//
+//  ObservedState+Testing.swift
+//  PacketTunnelCoreTests
+//
+//  Created by Emīls on 2026-08-13.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+@testable import PacketTunnelCore
+
+extension ObservedState {
+    var isInitial: Bool {
+        if case .initial = self { true } else { false }
+    }
+
+    var isConnecting: Bool {
+        if case .connecting = self { true } else { false }
+    }
+
+    var isConnected: Bool {
+        if case .connected = self { true } else { false }
+    }
+
+    var isReconnecting: Bool {
+        if case .reconnecting = self { true } else { false }
+    }
+
+    var isDisconnected: Bool {
+        if case .disconnected = self { true } else { false }
+    }
+
+    /// The reason the tunnel is blocked, or nil when it isn't.
+    var blockedReason: BlockedStateReason? {
+        blockedState?.reason
+    }
+}
+
+/// Thread-safe sink for states observed from a `Task`, so a test can read them back afterwards.
+public actor StateCollector {
+    private var states: [ObservedState] = []
+
+    func append(_ state: ObservedState) {
+        states.append(state)
+    }
+
+    var collected: [ObservedState] {
+        states
+    }
+}

--- a/ios/PacketTunnelCoreTests/Mocks/SettingsReaderStub.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/SettingsReaderStub.swift
@@ -28,7 +28,7 @@ extension SettingsReaderStub {
     static func staticConfiguration() -> SettingsReaderStub {
         let staticSettings = Settings(
             privateKey: WireGuard.PrivateKey(),
-            interfaceAddresses: [IPAddressRange(from: "127.0.0.1/32")!],
+            interfaceAddresses: [IPAddressRange(from: "127.0.0.1/32")!, IPAddressRange(from: "fc00::1/128")!],
             tunnelSettings: LatestTunnelSettings(
                 relayConstraints: RelayConstraints(),
                 dnsSettings: DNSSettings(),
@@ -47,7 +47,7 @@ extension SettingsReaderStub {
     static func noPostQuantumConfiguration() -> SettingsReaderStub {
         let staticSettings = Settings(
             privateKey: WireGuard.PrivateKey(),
-            interfaceAddresses: [IPAddressRange(from: "127.0.0.1/32")!],
+            interfaceAddresses: [IPAddressRange(from: "127.0.0.1/32")!, IPAddressRange(from: "fc00::1/128")!],
             tunnelSettings: LatestTunnelSettings(
                 relayConstraints: RelayConstraints(),
                 dnsSettings: DNSSettings(),

--- a/mullvad-ios/src/tunnel_adapter/ffi/mod.rs
+++ b/mullvad-ios/src/tunnel_adapter/ffi/mod.rs
@@ -11,7 +11,10 @@ use std::sync::Arc;
 
 use ipnetwork::IpNetwork;
 
-use super::{IosTunnelAdapter, ObfuscationConfig, PeerConfig, TunnelCallbackHandler, TunnelConfig};
+use super::{
+    BoundUdpTransports, IosTunnelAdapter, ObfuscationConfig, PeerConfig, TunnelCallbackHandler,
+    TunnelConfig,
+};
 
 /// A WireGuard peer (entry or exit).
 #[derive(uniffi::Record)]
@@ -70,6 +73,8 @@ pub enum GotaTunObfuscation {
 pub enum GotaTunFfiError {
     /// A field in the config was malformed (bad key length, unparseable address, ...).
     InvalidConfig(String),
+    /// UDP sockets could not be bound, typically because no interface is available.
+    BindSockets(String),
     /// An internal failure (e.g. the async runtime was unavailable).
     Internal(String),
 }
@@ -78,6 +83,7 @@ impl std::fmt::Display for GotaTunFfiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             GotaTunFfiError::InvalidConfig(msg) => write!(f, "invalid config: {msg}"),
+            GotaTunFfiError::BindSockets(msg) => write!(f, "failed to bind UDP sockets: {msg}"),
             GotaTunFfiError::Internal(msg) => write!(f, "internal error: {msg}"),
         }
     }
@@ -134,8 +140,15 @@ impl GotaTunTunnel {
     ) -> Result<Arc<Self>, GotaTunFfiError> {
         let tunnel_config = build_tunnel_config(tun_fd, config)?;
         let runtime = crate::mullvad_ios_runtime().map_err(GotaTunFfiError::Internal)?;
+
+        // Bind before returning, so a missing interface is reported to the caller instead of
+        // arriving later as a callback that races the rest of startup.
+        let udp = runtime
+            .block_on(BoundUdpTransports::bind())
+            .map_err(|e| GotaTunFfiError::BindSockets(e.to_string()))?;
+
         let handler: Arc<dyn TunnelCallbackHandler> = Arc::new(CallbackBridge(callback));
-        let adapter = IosTunnelAdapter::start(runtime, tunnel_config, handler);
+        let adapter = IosTunnelAdapter::start(runtime, tunnel_config, udp, handler);
         Ok(Arc::new(Self { adapter }))
     }
 

--- a/mullvad-ios/src/tunnel_adapter/mod.rs
+++ b/mullvad-ios/src/tunnel_adapter/mod.rs
@@ -21,7 +21,11 @@ use gotatun::{
     device::{DeviceBuilder, Peer},
     packet::{Ipv4Header, Ipv6Header, UdpHeader, WgData},
     tun::MtuWatcher,
-    udp::{channel::new_udp_tun_channel, socket::UdpSocketFactory},
+    udp::{
+        UdpTransportFactory, UdpTransportFactoryParams,
+        channel::new_udp_tun_channel,
+        socket::{UdpSocket, UdpSocketFactory},
+    },
     x25519::StaticSecret,
 };
 use ipnetwork::IpNetwork;
@@ -55,6 +59,38 @@ impl ObfuscationGuard {
 impl Drop for ObfuscationGuard {
     fn drop(&mut self) {
         self.task.abort();
+    }
+}
+
+/// A UDP transport bound ahead of the tunnel starting.
+/// Allowing them to bind ahead of time allows for reusing them and also lets the tunnel connection
+/// fail fast.
+#[derive(Clone)]
+pub struct BoundUdpTransports {
+    socket: UdpSocket,
+}
+
+impl BoundUdpTransports {
+    /// Bind the socket, or fail describing why.
+    pub async fn bind() -> io::Result<Self> {
+        let params = UdpTransportFactoryParams {
+            addr: None,
+            port: 0,
+        };
+        let (socket, _recv) = UdpSocketFactory::default().bind(&params).await?;
+        Ok(Self { socket })
+    }
+}
+
+impl UdpTransportFactory for BoundUdpTransports {
+    type Send = UdpSocket;
+    type Recv = UdpSocket;
+
+    async fn bind(
+        &mut self,
+        _params: &UdpTransportFactoryParams,
+    ) -> io::Result<(Self::Send, Self::Recv)> {
+        Ok((self.socket.clone(), self.socket.clone()))
     }
 }
 
@@ -152,6 +188,7 @@ impl IosTunnelAdapter {
     pub fn start(
         runtime: tokio::runtime::Handle,
         config: TunnelConfig,
+        udp: BoundUdpTransports,
         callback: Arc<dyn TunnelCallbackHandler>,
     ) -> Self {
         let stopped = Arc::new(AtomicBool::new(false));
@@ -159,6 +196,7 @@ impl IosTunnelAdapter {
 
         let task = runtime.spawn(Self::run(
             config,
+            udp,
             callback,
             stopped.clone(),
             stop_notify.clone(),
@@ -204,13 +242,14 @@ impl IosTunnelAdapter {
 
     async fn run(
         config: TunnelConfig,
+        udp: BoundUdpTransports,
         callback: Arc<dyn TunnelCallbackHandler>,
         stopped: Arc<AtomicBool>,
         stop_notify: Arc<Notify>,
     ) {
         // Every phase below returns a `Result`; the callback is fired exactly
         // once, here, based on the final outcome.
-        match Self::run_inner(config, &callback, &stopped, &stop_notify).await {
+        match Self::run_inner(config, udp, &callback, &stopped, &stop_notify).await {
             Ok(()) => Self::fire_timeout(&stopped, &callback),
             Err(TunnelError::Timeout) => Self::fire_timeout(&stopped, &callback),
             Err(TunnelError::Error(msg)) => Self::fire_error(&stopped, &callback, msg),
@@ -219,6 +258,7 @@ impl IosTunnelAdapter {
 
     async fn run_inner(
         mut config: TunnelConfig,
+        udp: BoundUdpTransports,
         callback: &Arc<dyn TunnelCallbackHandler>,
         stopped: &AtomicBool,
         stop_notify: &Notify,
@@ -229,7 +269,7 @@ impl IosTunnelAdapter {
 
         // 2. Negotiate the PQ/DAITA ephemeral peer(s) over a smoltcp-only device,
         //    or fall back to the static device peer.
-        let pq = Self::negotiate_pq(&mut config, stopped).await?;
+        let pq = Self::negotiate_pq(&mut config, &udp, stopped).await?;
         if stopped.load(Ordering::SeqCst) {
             // Cancelled externally; the outcome below is discarded since `run`
             // no-ops when it sees the tunnel is already stopped.
@@ -255,7 +295,7 @@ impl IosTunnelAdapter {
             });
         let (mux_recv, mux_send) = ip_mux(tun_dev.clone(), tun_dev, ip_recv, ip_send);
 
-        let devices = Self::build_devices(&config, pq, mux_recv, mux_send).await?;
+        let devices = Self::build_devices(&config, &udp, pq, mux_recv, mux_send).await?;
         if stopped.load(Ordering::SeqCst) {
             devices.stop().await;
             return Err(TunnelError::Timeout);
@@ -295,6 +335,7 @@ impl IosTunnelAdapter {
     /// device(s) with - `entry` is `Some` only for multihop PQ.
     async fn negotiate_pq(
         config: &mut TunnelConfig,
+        udp: &BoundUdpTransports,
         stopped: &AtomicBool,
     ) -> Result<PqResult, TunnelError> {
         // No PQ/DAITA: the device peer is just the static configured exit peer.
@@ -316,9 +357,14 @@ impl IosTunnelAdapter {
             config.enable_daita
         );
 
-        let (first_key, mut first_peer) =
-            Self::run_pq_exchange(config, first_peer_config, parent_pubkey.clone(), pq_timeout)
-                .await?;
+        let (first_key, mut first_peer) = Self::run_pq_exchange(
+            config,
+            udp,
+            first_peer_config,
+            parent_pubkey.clone(),
+            pq_timeout,
+        )
+        .await?;
 
         if !is_multihop {
             return Ok((None, first_key, first_peer));
@@ -383,7 +429,7 @@ impl IosTunnelAdapter {
 
         // Entry device: real UDP, channel IP pair.
         let pq2_entry = match DeviceBuilder::new()
-            .with_udp(UdpSocketFactory::default())
+            .with_udp(udp.clone())
             .with_ip_pair(ch_tx, ch_rx)
             .with_peer(entry_peer)
             .with_private_key(first_key.clone())
@@ -441,6 +487,7 @@ impl IosTunnelAdapter {
     /// their peers.
     async fn build_devices(
         config: &TunnelConfig,
+        udp: &BoundUdpTransports,
         pq: PqResult,
         mux_recv: tun_device::IosTunIpRecv,
         mux_send: tun_device::IosTunIpSend,
@@ -450,7 +497,7 @@ impl IosTunnelAdapter {
         let Some(entry_peer_config) = config.entry_peer.as_ref() else {
             // Singlehop: one device, mux'd IP pair, real UDP.
             let device = DeviceBuilder::new()
-                .with_udp(UdpSocketFactory::default())
+                .with_udp(udp.clone())
                 .with_ip_pair(mux_send, mux_recv)
                 .with_private_key(pq_exit_key)
                 .with_peer(pq_exit_peer.with_endpoint(config.exit_peer.endpoint))
@@ -493,7 +540,7 @@ impl IosTunnelAdapter {
         let entry_peer = entry_peer.with_endpoint(entry_peer_config.endpoint);
 
         let entry_device = match DeviceBuilder::new()
-            .with_udp(UdpSocketFactory::default())
+            .with_udp(udp.clone())
             .with_ip_pair(tun_channel_tx, tun_channel_rx)
             .with_peer(entry_peer)
             .with_private_key(entry_key)
@@ -548,6 +595,7 @@ impl IosTunnelAdapter {
     /// configure peer, negotiate.
     async fn run_pq_exchange(
         config: &TunnelConfig,
+        udp: &BoundUdpTransports,
         peer_config: &PeerConfig,
         parent_pubkey: PublicKey,
         timeout: Duration,
@@ -572,7 +620,7 @@ impl IosTunnelAdapter {
         initial_peer.allowed_ips = Self::config_service_allowed_ips();
 
         let pq_device = DeviceBuilder::new()
-            .with_udp(UdpSocketFactory::default())
+            .with_udp(udp.clone())
             .with_ip_pair(ip_send, ip_recv)
             .with_private_key(StaticSecret::from(config.private_key))
             .with_peer(initial_peer)
@@ -869,14 +917,14 @@ fn localhost_wg_endpoint(peer: SocketAddr) -> SocketAddr {
 enum Devices {
     Singlehop(
         gotatun::device::Device<(
-            UdpSocketFactory,
+            BoundUdpTransports,
             tun_device::IosTunIpSend,
             tun_device::IosTunIpRecv,
         )>,
     ),
     Multihop {
         entry: gotatun::device::Device<(
-            UdpSocketFactory,
+            BoundUdpTransports,
             gotatun::tun::channel::TunChannelTx,
             gotatun::tun::channel::TunChannelRx,
         )>,


### PR DESCRIPTION
In this PR, we're adding a GotaTun actor, adding some more abstractions it requires and also changing the way UDP sockets are used by GotaTun. Further, there's a DEBUG only feature indicator for GotaTun - otherwise it is really difficult to see if GotaTun is actually being used.

The packet tunnel provider is abstracted away via a delegate, same with the Rust FFI. There are lots of tests for the new actor, with more tests to come at a later date. The current actor is still a state machine, not unlike the previous one.

The expectation is that you should be able to enable GotaTun via the debug menu and the app should honour and connect via all the settings. What would not work _well_ is key rotation, offline states and roaming between networks - they would all wait until an existing tunnel times out before the tunnel reconnects. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10956)
<!-- Reviewable:end -->
