### PR TITLE
Remove the superfluous NSLock around SimulatorTunnelProvider.delegate

### DIFF
--- a/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProvider.swift
+++ b/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProvider.swift
@@ -43,26 +43,12 @@ import NetworkExtension
     final class SimulatorTunnelProvider: Sendable {
         static let shared = SimulatorTunnelProvider()
 
-        private let lock = NSLock()
-        nonisolated(unsafe) private var _delegate: SimulatorTunnelProviderDelegate?
-
-        var delegate: SimulatorTunnelProviderDelegate! {
-            get {
-                lock.withLock {
-                    _delegate
-                }
-            }
-            set {
-                lock.withLock {
-                    _delegate = newValue
-                }
-            }
-        }
+        nonisolated(unsafe) public var delegate: SimulatorTunnelProviderDelegate!
 
         private init() {}
 
         func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)? = nil) {
-            delegate.handleAppMessage(messageData, completionHandler: completionHandler)
+            delegate?.handleAppMessage(messageData, completionHandler: completionHandler)
         }
     }
 

--- a/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProvider.swift
+++ b/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProvider.swift
@@ -48,7 +48,7 @@ import NetworkExtension
         private init() {}
 
         func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)? = nil) {
-            delegate?.handleAppMessage(messageData, completionHandler: completionHandler)
+            delegate.handleAppMessage(messageData, completionHandler: completionHandler)
         }
     }
 


### PR DESCRIPTION
As documented, the lock was not doing all that much, and has simply been deleted, along with the `_delegate` and computed variable.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10960)
<!-- Reviewable:end -->
