### PR TITLE
Write a safer wrapper for nslock enforce its use ios 1719

### DIFF
--- a/.github/actions/ios/setup-project-toolchain/action.yml
+++ b/.github/actions/ios/setup-project-toolchain/action.yml
@@ -50,6 +50,11 @@ runs:
         brew install protobuf
       shell: bash
 
+    - name: Install ripgrep
+      run: |
+        brew install ripgrep
+      shell: bash
+
     - name: Setup Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:

--- a/.github/workflows/ios-screenshots-tests.yml
+++ b/.github/workflows/ios-screenshots-tests.yml
@@ -46,6 +46,10 @@ jobs:
         run: |
           brew install zip
 
+      - name: Install ripgrep
+        run: |
+          brew install ripgrep
+
       - name: Run screenshot tests
         run: |
           set -o pipefail && env NSUnbufferedIO=YES xcodebuild \

--- a/ios/MullvadLogging/OSLogHandler.swift
+++ b/ios/MullvadLogging/OSLogHandler.swift
@@ -26,16 +26,15 @@ public struct OSLogHandler: LogHandler {
     private static let registryLock = NSLock()
 
     private static func getOSLog(subsystem: String, category: String) -> OSLog {
-        registryLock.lock()
-        defer { registryLock.unlock() }
-
-        let key = RegistryKey(subsystem: subsystem, category: category)
-        if let log = osLogRegistry[key] {
-            return log
-        } else {
-            let newLog = OSLog(subsystem: subsystem, category: category)
-            osLogRegistry[key] = newLog
-            return newLog
+        registryLock.withLock {
+            let key = RegistryKey(subsystem: subsystem, category: category)
+            if let log = osLogRegistry[key] {
+                return log
+            } else {
+                let newLog = OSLog(subsystem: subsystem, category: category)
+                osLogRegistry[key] = newLog
+                return newLog
+            }
         }
     }
 

--- a/ios/MullvadREST/Relay/StoredRelays.swift
+++ b/ios/MullvadREST/Relay/StoredRelays.swift
@@ -95,21 +95,20 @@ private final class DeserializationCache: @unchecked Sendable {
     private var result: Result<CachedRelays, Error>?
 
     func get(_ compute: () throws -> CachedRelays) throws -> CachedRelays {
-        lock.lock()
-        defer { lock.unlock() }
+        try lock.withLock {
+            if let result {
+                return try result.get()
+            }
 
-        if let result {
-            return try result.get()
+            let newResult = Result { try compute() }
+            result = newResult
+            return try newResult.get()
         }
-
-        let newResult = Result { try compute() }
-        result = newResult
-        return try newResult.get()
     }
 
     func set(_ value: Result<CachedRelays, Error>) {
-        lock.lock()
-        defer { lock.unlock() }
-        result = value
+        lock.withLock {
+            result = value
+        }
     }
 }

--- a/ios/MullvadREST/Transport/Shadowsocks/ShadowsocksConfigurationCache.swift
+++ b/ios/MullvadREST/Transport/Shadowsocks/ShadowsocksConfigurationCache.swift
@@ -30,32 +30,30 @@ public final class ShadowsocksConfigurationCache: ShadowsocksConfigurationCacheP
     /// Returns configuration from memory cache if available, otherwise attempts to load it from disk cache before
     /// returning.
     public func read() throws -> ShadowsocksConfiguration {
-        configurationLock.lock()
-        defer { configurationLock.unlock() }
-
-        if let cachedConfiguration {
-            return cachedConfiguration
-        } else {
-            let readConfiguration = try fileCache.read()
-            cachedConfiguration = readConfiguration
-            return readConfiguration
+        try configurationLock.withLock {
+            if let cachedConfiguration {
+                return cachedConfiguration
+            } else {
+                let readConfiguration = try fileCache.read()
+                cachedConfiguration = readConfiguration
+                return readConfiguration
+            }
         }
     }
 
     /// Replace memory cache with new configuration and attempt to persist it on disk.
     public func write(_ configuration: ShadowsocksConfiguration) throws {
-        configurationLock.lock()
-        defer { configurationLock.unlock() }
-
-        cachedConfiguration = configuration
-        try fileCache.write(configuration)
+        try configurationLock.withLock {
+            cachedConfiguration = configuration
+            try fileCache.write(configuration)
+        }
     }
 
     /// Clear cached configuration.
     public func clear() throws {
-        configurationLock.lock()
-        defer { configurationLock.unlock() }
-        cachedConfiguration = nil
-        try fileCache.clear()
+        try configurationLock.withLock {
+            cachedConfiguration = nil
+            try fileCache.clear()
+        }
     }
 }

--- a/ios/MullvadTypes/FileCache.swift
+++ b/ios/MullvadTypes/FileCache.swift
@@ -41,61 +41,58 @@ public final class FileCache<Content: Codable>: FileCacheProtocol, @unchecked Se
     }
 
     public func read() throws -> Content {
-        cacheLock.lock()
-        defer { cacheLock.unlock() }
+        try cacheLock.withLock {
+            // Stat before reading, so that a concurrent replacement between the stat and the read can
+            // only mark the cache as stale and cause an extra re-read, never serve stale content.
+            let modificationTime = fileModificationTime(at: fileURL)
+            if let cachedContent, let contentModified, modificationTime != nil,
+                contentModified == modificationTime
+            {
+                return cachedContent
+            }
 
-        // Stat before reading, so that a concurrent replacement between the stat and the read can
-        // only mark the cache as stale and cause an extra re-read, never serve stale content.
-        let modificationTime = fileModificationTime(at: fileURL)
-        if let cachedContent, let contentModified, modificationTime != nil,
-            contentModified == modificationTime
-        {
-            return cachedContent
+            let data = try Data(contentsOf: fileURL)
+            let content = try JSONDecoder().decode(Content.self, from: data)
+
+            cachedContent = content
+            contentModified = modificationTime
+
+            return content
         }
-
-        let data = try Data(contentsOf: fileURL)
-        let content = try JSONDecoder().decode(Content.self, from: data)
-
-        cachedContent = content
-        contentModified = modificationTime
-
-        return content
     }
 
     public func write(_ content: Content) throws {
-        cacheLock.lock()
-        defer { cacheLock.unlock() }
+        try cacheLock.withLock {
+            let data = try JSONEncoder().encode(content)
 
-        let data = try JSONEncoder().encode(content)
+            // Write to a uniquely named temporary file, then atomically rename into place. The unique
+            // name prevents concurrent writers in this or another process from clobbering each other's
+            // in-progress writes.
+            let tempURL = fileURL.appendingPathExtension("tmp-\(UUID().uuidString)")
+            try data.write(to: tempURL)
 
-        // Write to a uniquely named temporary file, then atomically rename into place. The unique
-        // name prevents concurrent writers in this or another process from clobbering each other's
-        // in-progress writes.
-        let tempURL = fileURL.appendingPathExtension("tmp-\(UUID().uuidString)")
-        try data.write(to: tempURL)
+            // Capture the modification time before the rename, which preserves it. If another process
+            // replaces the file afterwards, the stored time no longer matches and the next read
+            // re-reads from disk.
+            let writtenModificationTime = fileModificationTime(at: tempURL)
 
-        // Capture the modification time before the rename, which preserves it. If another process
-        // replaces the file afterwards, the stored time no longer matches and the next read
-        // re-reads from disk.
-        let writtenModificationTime = fileModificationTime(at: tempURL)
+            if rename(tempURL.path, fileURL.path) != 0 {
+                try? FileManager.default.removeItem(at: tempURL)
+                throw FileCacheError.renameFailed(errno)
+            }
 
-        if rename(tempURL.path, fileURL.path) != 0 {
-            try? FileManager.default.removeItem(at: tempURL)
-            throw FileCacheError.renameFailed(errno)
+            cachedContent = content
+            contentModified = writtenModificationTime
         }
-
-        cachedContent = content
-        contentModified = writtenModificationTime
     }
 
     public func clear() throws {
-        cacheLock.lock()
-        defer { cacheLock.unlock() }
+        try cacheLock.withLock {
+            try FileManager.default.removeItem(at: fileURL)
 
-        try FileManager.default.removeItem(at: fileURL)
-
-        cachedContent = nil
-        contentModified = nil
+            cachedContent = nil
+            contentModified = nil
+        }
     }
 
     // MARK: - Private

--- a/ios/MullvadTypes/ObserverList.swift
+++ b/ios/MullvadTypes/ObserverList.swift
@@ -35,52 +35,46 @@ final public class ObserverList<T>: Sendable {
     public init() {}
 
     public func append(_ observer: T) {
-        lock.lock()
+        lock.withLock {
+            let hasObserver = observers.contains { box in
+                box == WeakBox(observer)
+            }
 
-        let hasObserver = observers.contains { box in
-            box == WeakBox(observer)
+            if !hasObserver {
+                observers.append(WeakBox(observer))
+            }
         }
-
-        if !hasObserver {
-            observers.append(WeakBox(observer))
-        }
-
-        lock.unlock()
     }
 
     public func remove(_ observer: T) {
-        lock.lock()
+        lock.withLock {
+            let index = observers.firstIndex { box in
+                box == WeakBox(observer)
+            }
 
-        let index = observers.firstIndex { box in
-            box == WeakBox(observer)
+            if let index {
+                observers.remove(at: index)
+            }
         }
-
-        if let index {
-            observers.remove(at: index)
-        }
-
-        lock.unlock()
     }
 
     public func notify(_ body: (T) -> Void) {
-        lock.lock()
-
         var indicesToRemove = [Int]()
         var observersToNotify = [T]()
 
-        for (index, box) in observers.enumerated() {
-            if let observer = box.value {
-                observersToNotify.append(observer)
-            } else {
-                indicesToRemove.append(index)
+        lock.withLock {
+            for (index, box) in observers.enumerated() {
+                if let observer = box.value {
+                    observersToNotify.append(observer)
+                } else {
+                    indicesToRemove.append(index)
+                }
+            }
+
+            for index in indicesToRemove.reversed() {
+                observers.remove(at: index)
             }
         }
-
-        for index in indicesToRemove.reversed() {
-            observers.remove(at: index)
-        }
-
-        lock.unlock()
 
         for observer in observersToNotify {
             body(observer)

--- a/ios/MullvadTypes/Promise.swift
+++ b/ios/MullvadTypes/Promise.swift
@@ -8,46 +8,6 @@
 
 import Foundation
 
-public final class Promise<Success, Failure: Error>: @unchecked Sendable {
-    public typealias Result = Swift.Result<Success, Failure>
-
-    private let nslock = NSLock()
-    private var observers: [(Result) -> Void] = []
-    private var result: Result?
-
-    public init(_ executor: (@escaping (Result) -> Void) -> Void) {
-        executor(resolve)
-    }
-
-    public func observe(_ completion: @escaping (Result) -> Void) {
-        nslock.lock()
-        if let result {
-            nslock.unlock()
-            completion(result)
-        } else {
-            observers.append(completion)
-            nslock.unlock()
-        }
-    }
-
-    private func resolve(result: Result) {
-        nslock.lock()
-        if self.result == nil {
-            self.result = result
-
-            let observers = observers
-            self.observers.removeAll()
-            nslock.unlock()
-
-            for observer in observers {
-                observer(result)
-            }
-        } else {
-            nslock.unlock()
-        }
-    }
-}
-
 // This object can be used like an async semaphore with exactly 1 writer. It
 // allows the waiter to wait to `receive()` from another operation
 // asynchronously. It is important not to forget to call `send`, otherwise this

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -3327,7 +3327,6 @@
 		581943F228F8014500B0CB5E /* MullvadTypes */ = {
 			isa = PBXGroup;
 			children = (
-				449EBA242B975B7C00DFA4EB /* Protocols */,
 				588D7ED72AF3A533005DF40A /* AccessMethodKind.swift */,
 				584D26BE270C550B004EA533 /* AnyIPAddress.swift */,
 				586A951329013235007BAF2B /* AnyIPEndpoint.swift */,
@@ -3360,6 +3359,7 @@
 				586C0D962B04E0AC00E7CDD7 /* PersistentAccessMethod.swift */,
 				44EC6C592E3BB3EF0087F54A /* PersistentProxyConfiguration.swift */,
 				58CAFA01298530DC00BE19F7 /* Promise.swift */,
+				449EBA242B975B7C00DFA4EB /* Protocols */,
 				5898D2B12902A6DE00EB5EBA /* RelayConstraint.swift */,
 				58781CC822AE7CA8009B9D8E /* RelayConstraints.swift */,
 				7AF9BE8A2A321BEF00DBFEDB /* RelayFilter.swift */,
@@ -5602,6 +5602,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 58CE5E72224146210008646E /* Build configuration list for PBXNativeTarget "MullvadVPN" */;
 			buildPhases = (
+				A938DC0F302E0B27005AF92F /* Disable NSLock usage */,
 				580E3F212A9860F20061809D /* Run SwiftLint */,
 				58CE5E5C224146200008646E /* Sources */,
 				58CE5E5D224146200008646E /* Frameworks */,
@@ -6216,6 +6217,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "./format.sh lint\n";
+		};
+		A938DC0F302E0B27005AF92F /* Disable NSLock usage */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Disable NSLock usage";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n./disable_nslock.sh ${SRCROOT}\n";
 		};
 		A93969802CE603110032A7A0 /* Import maybenot_machines */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/ios/MullvadVPN/AddressCacheUpdateScheduler/AddressCacheUpdateScheduler.swift
+++ b/ios/MullvadVPN/AddressCacheUpdateScheduler/AddressCacheUpdateScheduler.swift
@@ -55,36 +55,34 @@ final class AddressCacheUpdateScheduler: @unchecked Sendable {
     }
 
     func startPeriodicUpdates() {
-        nslock.lock()
-        defer { nslock.unlock() }
+        nslock.withLock {
+            guard !isPeriodicUpdatesEnabled else {
+                return
+            }
 
-        guard !isPeriodicUpdatesEnabled else {
-            return
+            logger.debug("Start periodic address cache updates.")
+
+            isPeriodicUpdatesEnabled = true
+
+            let scheduleDate = _nextScheduleDate()
+
+            logger.debug("Schedule address cache update at \(scheduleDate.logFormatted).")
+
+            scheduleEndpointsUpdate(startTime: .now() + scheduleDate.timeIntervalSinceNow)
         }
-
-        logger.debug("Start periodic address cache updates.")
-
-        isPeriodicUpdatesEnabled = true
-
-        let scheduleDate = _nextScheduleDate()
-
-        logger.debug("Schedule address cache update at \(scheduleDate.logFormatted).")
-
-        scheduleEndpointsUpdate(startTime: .now() + scheduleDate.timeIntervalSinceNow)
     }
 
     func stopPeriodicUpdates() {
-        nslock.lock()
-        defer { nslock.unlock() }
+        nslock.withLock {
+            guard isPeriodicUpdatesEnabled else { return }
 
-        guard isPeriodicUpdatesEnabled else { return }
+            logger.debug("Stop periodic address cache updates.")
 
-        logger.debug("Stop periodic address cache updates.")
+            isPeriodicUpdatesEnabled = false
 
-        isPeriodicUpdatesEnabled = false
-
-        timer?.cancel()
-        timer = nil
+            timer?.cancel()
+            timer = nil
+        }
     }
 
     func updateEndpoints(completionHandler: ((sending Result<Bool, Error>) -> Void)? = nil) {
@@ -93,10 +91,9 @@ final class AddressCacheUpdateScheduler: @unchecked Sendable {
     }
 
     func nextScheduleDate() -> Date {
-        nslock.lock()
-        defer { nslock.unlock() }
-
-        return _nextScheduleDate()
+        nslock.withLock {
+            _nextScheduleDate()
+        }
     }
 
     private func scheduleEndpointsUpdate(startTime: DispatchWallTime) {
@@ -113,18 +110,18 @@ final class AddressCacheUpdateScheduler: @unchecked Sendable {
     }
 
     private func handleTimer() {
-        updateEndpoints { _ in
-            self.nslock.lock()
-            defer { self.nslock.unlock() }
+        updateEndpoints { [weak self] _ in
+            guard let self else { return }
+            self.nslock.withLock {
+                guard self.isPeriodicUpdatesEnabled else { return }
 
-            guard self.isPeriodicUpdatesEnabled else { return }
+                let scheduleDate = self._nextScheduleDate()
 
-            let scheduleDate = self._nextScheduleDate()
+                self.logger
+                    .debug("Schedule next address cache update at \(scheduleDate.logFormatted).")
 
-            self.logger
-                .debug("Schedule next address cache update at \(scheduleDate.logFormatted).")
-
-            self.scheduleEndpointsUpdate(startTime: .now() + scheduleDate.timeIntervalSinceNow)
+                self.scheduleEndpointsUpdate(startTime: .now() + scheduleDate.timeIntervalSinceNow)
+            }
         }
     }
 
@@ -137,8 +134,8 @@ final class AddressCacheUpdateScheduler: @unchecked Sendable {
     }
 
     private func recordUpdateRequestTime() {
-        nslock.lock()
-        defer { nslock.unlock() }
-        lastUpdateRequestDate = Date()
+        nslock.withLock {
+            lastUpdateRequestDate = Date()
+        }
     }
 }

--- a/ios/MullvadVPN/RelayCacheTracker/RelayCacheTracker.swift
+++ b/ios/MullvadVPN/RelayCacheTracker/RelayCacheTracker.swift
@@ -141,32 +141,30 @@ final class RelayCacheTracker: RelayCacheTrackerProtocol, @unchecked Sendable {
     }
 
     func startPeriodicUpdates() {
-        relayCacheLock.lock()
-        defer { relayCacheLock.unlock() }
+        relayCacheLock.withLock {
+            guard !isPeriodicUpdatesEnabled else { return }
 
-        guard !isPeriodicUpdatesEnabled else { return }
+            logger.debug("Start periodic relay updates.")
 
-        logger.debug("Start periodic relay updates.")
+            isPeriodicUpdatesEnabled = true
 
-        isPeriodicUpdatesEnabled = true
+            let nextUpdate = _getNextUpdateDate()
 
-        let nextUpdate = _getNextUpdateDate()
-
-        scheduleRepeatingTimer(startTime: .now() + nextUpdate.timeIntervalSinceNow)
+            scheduleRepeatingTimer(startTime: .now() + nextUpdate.timeIntervalSinceNow)
+        }
     }
 
     func stopPeriodicUpdates() {
-        relayCacheLock.lock()
-        defer { relayCacheLock.unlock() }
+        relayCacheLock.withLock {
+            guard isPeriodicUpdatesEnabled else { return }
 
-        guard isPeriodicUpdatesEnabled else { return }
+            logger.debug("Stop periodic relay updates.")
 
-        logger.debug("Stop periodic relay updates.")
+            isPeriodicUpdatesEnabled = false
 
-        isPeriodicUpdatesEnabled = false
-
-        timerSource?.cancel()
-        timerSource = nil
+            timerSource?.cancel()
+            timerSource = nil
+        }
     }
 
     func updateRelays(completionHandler: ((sending Result<RelaysFetchResult, Error>) -> Void)? = nil)
@@ -198,29 +196,27 @@ final class RelayCacheTracker: RelayCacheTrackerProtocol, @unchecked Sendable {
     }
 
     func getCachedRelays() throws -> CachedRelays {
-        relayCacheLock.lock()
-        defer { relayCacheLock.unlock() }
-
-        if let cachedRelays {
-            return cachedRelays
-        } else {
-            throw NoCachedRelaysError()
+        try relayCacheLock.withLock {
+            if let cachedRelays {
+                return cachedRelays
+            } else {
+                throw NoCachedRelaysError()
+            }
         }
     }
 
     func refreshCachedRelays() throws {
         let newCachedRelays = try cache.read()
 
-        relayCacheLock.lock()
-        cachedRelays = newCachedRelays
-        relayCacheLock.unlock()
+        relayCacheLock.withLock {
+            cachedRelays = newCachedRelays
+        }
     }
 
     func getNextUpdateDate() -> Date {
-        relayCacheLock.lock()
-        defer { relayCacheLock.unlock() }
-
-        return _getNextUpdateDate()
+        relayCacheLock.withLock {
+            _getNextUpdateDate()
+        }
     }
 
     // MARK: - Private

--- a/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProvider.swift
+++ b/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProvider.swift
@@ -48,15 +48,14 @@ import NetworkExtension
 
         var delegate: SimulatorTunnelProviderDelegate! {
             get {
-                lock.lock()
-                defer { lock.unlock() }
-
-                return _delegate
+                lock.withLock {
+                    _delegate
+                }
             }
             set {
-                lock.lock()
-                _delegate = newValue
-                lock.unlock()
+                lock.withLock {
+                    _delegate = newValue
+                }
             }
         }
 

--- a/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProviderManager.swift
+++ b/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProviderManager.swift
@@ -18,87 +18,80 @@
         private let lock = NSLock()
         private var tunnelInfo: SimulatorTunnelInfo
         private var identifier: String {
-            lock.lock()
-            defer { lock.unlock() }
-
-            return tunnelInfo.identifier
+            lock.withLock {
+                tunnelInfo.identifier
+            }
         }
 
         var isOnDemandEnabled: Bool {
             get {
-                lock.lock()
-                defer { lock.unlock() }
-
-                return tunnelInfo.isOnDemandEnabled
+                lock.withLock {
+                    tunnelInfo.isOnDemandEnabled
+                }
             }
             set {
-                lock.lock()
-                tunnelInfo.isOnDemandEnabled = newValue
-                lock.unlock()
+                lock.withLock {
+                    tunnelInfo.isOnDemandEnabled = newValue
+                }
             }
         }
 
         var onDemandRules: [NEOnDemandRule] {
             get {
-                lock.lock()
-                defer { lock.unlock() }
-
-                return tunnelInfo.onDemandRules
+                lock.withLock {
+                    tunnelInfo.onDemandRules
+                }
             }
             set {
-                lock.lock()
-                tunnelInfo.onDemandRules = newValue
-                lock.unlock()
+                lock.withLock {
+                    tunnelInfo.onDemandRules = newValue
+                }
             }
         }
 
         var isEnabled: Bool {
             get {
-                lock.lock()
-                defer { lock.unlock() }
-
-                return tunnelInfo.isEnabled
+                lock.withLock {
+                    tunnelInfo.isEnabled
+                }
             }
             set {
-                lock.lock()
-                tunnelInfo.isEnabled = newValue
-                lock.unlock()
+                lock.withLock {
+                    tunnelInfo.isEnabled = newValue
+                }
             }
         }
 
         var protocolConfiguration: NEVPNProtocol? {
             get {
-                lock.lock()
-                defer { lock.unlock() }
-
-                return tunnelInfo.protocolConfiguration
+                lock.withLock {
+                    tunnelInfo.protocolConfiguration
+                }
             }
             set {
-                lock.lock()
-                tunnelInfo.protocolConfiguration = newValue
-                lock.unlock()
+                lock.withLock {
+                    tunnelInfo.protocolConfiguration = newValue
+                }
             }
         }
 
         var localizedDescription: String? {
             get {
-                lock.lock()
-                defer { lock.unlock() }
-
-                return tunnelInfo.localizedDescription
+                lock.withLock {
+                    return tunnelInfo.localizedDescription
+                }
             }
             set {
-                lock.lock()
-                tunnelInfo.localizedDescription = newValue
-                lock.unlock()
+                lock.withLock {
+                    tunnelInfo.localizedDescription = newValue
+                }
             }
         }
 
         var connection: SimulatorVPNConnection {
-            lock.lock()
-            defer { lock.unlock() }
-
-            return tunnelInfo.connection
+            lock.withLock {
+                tunnelInfo.connection
+            }
         }
 
         static func loadAllFromPreferences(
@@ -107,12 +100,11 @@
                 Error?
             ) -> Void
         ) {
-            Self.tunnelsLock.lock()
-            let tunnelProviders = tunnels.map { tunnelInfo in
-                SimulatorTunnelProviderManager(tunnelInfo: tunnelInfo)
+            let tunnelProviders = Self.tunnelsLock.withLock {
+                tunnels.map { tunnelInfo in
+                    SimulatorTunnelProviderManager(tunnelInfo: tunnelInfo)
+                }
             }
-            Self.tunnelsLock.unlock()
-
             completionHandler(tunnelProviders, nil)
         }
 
@@ -136,45 +128,39 @@
         func loadFromPreferences(completionHandler: (Error?) -> Void) {
             var error: NEVPNError?
 
-            Self.tunnelsLock.lock()
-
-            if let savedTunnel = Self.tunnels.first(where: { $0.identifier == self.identifier }) {
-                tunnelInfo = savedTunnel
-            } else {
-                error = NEVPNError(.configurationInvalid)
+            Self.tunnelsLock.withLock {
+                if let savedTunnel = Self.tunnels.first(where: { $0.identifier == self.identifier }) {
+                    tunnelInfo = savedTunnel
+                } else {
+                    error = NEVPNError(.configurationInvalid)
+                }
             }
-
-            Self.tunnelsLock.unlock()
 
             completionHandler(error)
         }
 
         func saveToPreferences(completionHandler: ((Error?) -> Void)?) {
-            Self.tunnelsLock.lock()
+            Self.tunnelsLock.withLock {
+                if let index = Self.tunnels.firstIndex(where: { $0.identifier == self.identifier }) {
+                    Self.tunnels[index] = tunnelInfo
+                } else {
+                    Self.tunnels.append(tunnelInfo)
+                }
 
-            if let index = Self.tunnels.firstIndex(where: { $0.identifier == self.identifier }) {
-                Self.tunnels[index] = tunnelInfo
-            } else {
-                Self.tunnels.append(tunnelInfo)
             }
-
-            Self.tunnelsLock.unlock()
-
             completionHandler?(nil)
         }
 
         func removeFromPreferences(completionHandler: ((Error?) -> Void)?) {
             var error: NEVPNError?
 
-            Self.tunnelsLock.lock()
-
-            if let index = Self.tunnels.firstIndex(where: { $0.identifier == self.identifier }) {
-                Self.tunnels.remove(at: index)
-            } else {
-                error = NEVPNError(.configurationReadWriteFailed)
+            Self.tunnelsLock.withLock {
+                if let index = Self.tunnels.firstIndex(where: { $0.identifier == self.identifier }) {
+                    Self.tunnels.remove(at: index)
+                } else {
+                    error = NEVPNError(.configurationReadWriteFailed)
+                }
             }
-
-            Self.tunnelsLock.unlock()
 
             completionHandler?(error)
         }

--- a/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorVPNConnection.swift
+++ b/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorVPNConnection.swift
@@ -23,62 +23,55 @@
 
         private(set) var status: NEVPNStatus {
             get {
-                lock.lock()
-                defer { lock.unlock() }
-
-                return _status
+                lock.withLock {
+                    _status
+                }
             }
             set {
-                lock.lock()
+                lock.withLock {
+                    if _status != newValue {
+                        _status = newValue
 
-                if _status != newValue {
-                    _status = newValue
-
-                    // Send notification while holding the lock. This should enable the receiver
-                    // to fetch the `SimulatorVPNConnection.status` before the concurrent code gets
-                    // opportunity to change it again.
-                    postStatusDidChangeNotification()
+                        // Send notification while holding the lock. This should enable the receiver
+                        // to fetch the `SimulatorVPNConnection.status` before the concurrent code gets
+                        // opportunity to change it again.
+                        postStatusDidChangeNotification()
+                    }
                 }
-
-                lock.unlock()
             }
         }
 
         var reasserting: Bool {
             get {
-                lock.lock()
-                defer { lock.unlock() }
-
-                return _reasserting
+                lock.withLock {
+                    _reasserting
+                }
             }
             set {
-                lock.lock()
+                lock.withLock {
+                    if _reasserting != newValue {
+                        _reasserting = newValue
 
-                if _reasserting != newValue {
-                    _reasserting = newValue
-
-                    if newValue {
-                        status = .reasserting
-                    } else {
-                        status = .connected
+                        if newValue {
+                            status = .reasserting
+                        } else {
+                            status = .connected
+                        }
                     }
                 }
-
-                lock.unlock()
             }
         }
 
         private(set) var connectedDate: Date? {
             get {
-                lock.lock()
-                defer { lock.unlock() }
-
-                return _connectedDate
+                lock.withLock {
+                    _connectedDate
+                }
             }
             set {
-                lock.lock()
-                _connectedDate = newValue
-                lock.unlock()
+                lock.withLock {
+                    _connectedDate = newValue
+                }
             }
         }
 

--- a/ios/MullvadVPN/TunnelManager/Tunnel.swift
+++ b/ios/MullvadVPN/TunnelManager/Tunnel.swift
@@ -80,10 +80,9 @@ final class Tunnel: TunnelProtocol, Equatable, @unchecked Sendable {
     /// It's set to `distantPast` when the VPN connection was established prior to being observed
     /// by the class.
     var startDate: Date? {
-        lock.lock()
-        defer { lock.unlock() }
-
-        return _startDate
+        lock.withLock {
+            _startDate
+        }
     }
 
     /// Tunnel connection status.
@@ -208,29 +207,25 @@ final class Tunnel: TunnelProtocol, Equatable, @unchecked Sendable {
     }
 
     private func handleVPNStatus(_ status: NEVPNStatus) {
-        switch status {
-        case .connecting:
-            lock.lock()
-            _startDate = Date()
-            lock.unlock()
+        lock.withLock {
+            switch status {
+            case .connecting:
+                _startDate = Date()
 
-        case .connected, .reasserting:
-            lock.lock()
-            if _startDate == nil {
-                _startDate = .distantPast
+            case .connected, .reasserting:
+                if _startDate == nil {
+                    _startDate = .distantPast
+                }
+
+            case .disconnecting:
+                break
+
+            case .disconnected, .invalid:
+                _startDate = nil
+
+            @unknown default:
+                break
             }
-            lock.unlock()
-
-        case .disconnecting:
-            break
-
-        case .disconnected, .invalid:
-            lock.lock()
-            _startDate = nil
-            lock.unlock()
-
-        @unknown default:
-            break
         }
     }
 

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -118,27 +118,25 @@ final class TunnelManager: @unchecked Sendable {
     // MARK: - Periodic private key rotation
 
     func startPeriodicPrivateKeyRotation() {
-        nslock.lock()
-        defer { nslock.unlock() }
+        nslock.withLock {
+            guard !isRunningPeriodicPrivateKeyRotation, deviceState.isLoggedIn else { return }
 
-        guard !isRunningPeriodicPrivateKeyRotation, deviceState.isLoggedIn else { return }
+            logger.debug("Start periodic private key rotation.")
 
-        logger.debug("Start periodic private key rotation.")
-
-        isRunningPeriodicPrivateKeyRotation = true
-        updatePrivateKeyRotationTimer()
+            isRunningPeriodicPrivateKeyRotation = true
+            updatePrivateKeyRotationTimer()
+        }
     }
 
     func stopPeriodicPrivateKeyRotation() {
-        nslock.lock()
-        defer { nslock.unlock() }
+        nslock.withLock {
+            guard isRunningPeriodicPrivateKeyRotation else { return }
 
-        guard isRunningPeriodicPrivateKeyRotation else { return }
+            logger.debug("Stop periodic private key rotation.")
 
-        logger.debug("Stop periodic private key rotation.")
-
-        isRunningPeriodicPrivateKeyRotation = false
-        updatePrivateKeyRotationTimer()
+            isRunningPeriodicPrivateKeyRotation = false
+            updatePrivateKeyRotationTimer()
+        }
     }
 
     func startOrStopPeriodicPrivateKeyRotation() {
@@ -150,39 +148,37 @@ final class TunnelManager: @unchecked Sendable {
     }
 
     func getNextKeyRotationDate() -> Date? {
-        nslock.lock()
-        defer { nslock.unlock() }
-
-        return deviceState.deviceData.flatMap { WgKeyRotation(data: $0).nextRotationDate }
+        nslock.withLock {
+            deviceState.deviceData.flatMap { WgKeyRotation(data: $0).nextRotationDate }
+        }
     }
 
     private func updatePrivateKeyRotationTimer() {
-        nslock.lock()
-        defer { nslock.unlock() }
+        nslock.withLock {
+            privateKeyRotationTimer?.cancel()
+            privateKeyRotationTimer = nil
+            nextKeyRotationDate = nil
 
-        privateKeyRotationTimer?.cancel()
-        privateKeyRotationTimer = nil
-        nextKeyRotationDate = nil
+            guard isRunningPeriodicPrivateKeyRotation,
+                let scheduleDate = getNextKeyRotationDate()
+            else { return }
+            nextKeyRotationDate = scheduleDate
 
-        guard isRunningPeriodicPrivateKeyRotation,
-            let scheduleDate = getNextKeyRotationDate()
-        else { return }
-        nextKeyRotationDate = scheduleDate
+            let timer = DispatchSource.makeTimerSource(queue: .main)
 
-        let timer = DispatchSource.makeTimerSource(queue: .main)
-
-        timer.setEventHandler { [weak self] in
-            _ = self?.rotatePrivateKey { _ in
-                // no-op
+            timer.setEventHandler { [weak self] in
+                _ = self?.rotatePrivateKey { _ in
+                    // no-op
+                }
             }
+
+            timer.schedule(wallDeadline: .now() + scheduleDate.timeIntervalSinceNow)
+            timer.activate()
+
+            privateKeyRotationTimer = timer
+
+            logger.debug("Schedule next private key rotation at \(scheduleDate.logFormatted).")
         }
-
-        timer.schedule(wallDeadline: .now() + scheduleDate.timeIntervalSinceNow)
-        timer.activate()
-
-        privateKeyRotationTimer = timer
-
-        logger.debug("Schedule next private key rotation at \(scheduleDate.logFormatted).")
     }
 
     // MARK: - Public methods
@@ -604,171 +600,161 @@ final class TunnelManager: @unchecked Sendable {
     // MARK: - TunnelInteractor
 
     var isConfigurationLoaded: Bool {
-        nslock.lock()
-        defer { nslock.unlock() }
-
-        return _isConfigurationLoaded
+        nslock.withLock {
+            _isConfigurationLoaded
+        }
     }
 
     fileprivate var tunnel: (any TunnelProtocol)? {
-        nslock.lock()
-        defer { nslock.unlock() }
-
-        return _tunnel
+        nslock.withLock {
+            _tunnel
+        }
     }
 
     var tunnelStatus: TunnelStatus {
-        nslock.lock()
-        defer { nslock.unlock() }
-
-        return _tunnelStatus
+        nslock.withLock {
+            _tunnelStatus
+        }
     }
 
     var settings: LatestTunnelSettings {
-        nslock.lock()
-        defer { nslock.unlock() }
-
-        return _tunnelSettings
+        nslock.withLock {
+            _tunnelSettings
+        }
     }
 
     var deviceState: DeviceState {
-        nslock.lock()
-        defer { nslock.unlock() }
-
-        return _deviceState
+        nslock.withLock {
+            _deviceState
+        }
     }
 
     fileprivate func setConfigurationLoaded() {
-        nslock.lock()
-        defer { nslock.unlock() }
+        nslock.withLock {
+            guard !_isConfigurationLoaded else {
+                return
+            }
 
-        guard !_isConfigurationLoaded else {
-            return
-        }
+            _isConfigurationLoaded = true
 
-        _isConfigurationLoaded = true
-
-        DispatchQueue.main.async {
-            self.observerList.notify { observer in
-                observer.tunnelManagerDidLoadConfiguration(self)
+            DispatchQueue.main.async {
+                self.observerList.notify { observer in
+                    observer.tunnelManagerDidLoadConfiguration(self)
+                }
             }
         }
     }
 
     fileprivate func setTunnel(_ tunnel: (any TunnelProtocol)?, shouldRefreshTunnelState: Bool) {
-        nslock.lock()
-        defer { nslock.unlock() }
+        nslock.withLock {
+            if let tunnel {
+                subscribeVPNStatusObserver(tunnel: tunnel)
+            } else {
+                unsubscribeVPNStatusObserver()
+            }
 
-        if let tunnel {
-            subscribeVPNStatusObserver(tunnel: tunnel)
-        } else {
-            unsubscribeVPNStatusObserver()
-        }
+            _tunnel = tunnel
 
-        _tunnel = tunnel
-
-        // Update the existing state
-        if shouldRefreshTunnelState {
-            logger.debug("Refresh tunnel status for new tunnel.")
-            refreshTunnelStatus()
+            // Update the existing state
+            if shouldRefreshTunnelState {
+                logger.debug("Refresh tunnel status for new tunnel.")
+                refreshTunnelStatus()
+            }
         }
     }
 
     fileprivate func setTunnelStatus(_ block: @Sendable (inout TunnelStatus) -> Void) -> TunnelStatus {
-        nslock.lock()
-        defer { nslock.unlock() }
+        nslock.withLock {
+            var newTunnelStatus = _tunnelStatus
+            block(&newTunnelStatus)
 
-        var newTunnelStatus = _tunnelStatus
-        block(&newTunnelStatus)
+            guard _tunnelStatus != newTunnelStatus else {
+                return newTunnelStatus
+            }
 
-        guard _tunnelStatus != newTunnelStatus else {
+            logger.info("Status: \(newTunnelStatus).")
+
+            _tunnelStatus = newTunnelStatus
+
+            // Packet tunnel may have attempted or rotated the key.
+            // In that case we have to reload device state from Keychain as it's likely was modified by packet tunnel.
+            let newPacketTunnelKeyRotation = _tunnelStatus.observedState.connectionState?.lastKeyRotation
+            if lastPacketTunnelKeyRotation != newPacketTunnelKeyRotation {
+                lastPacketTunnelKeyRotation = newPacketTunnelKeyRotation
+                refreshDeviceState()
+            }
+            // Handle unrecoverable blocked states
+            if case let .error(blockedStateReason) = _tunnelStatus.state,
+                !blockedStateReason.recoverableError()
+            {
+                handleBlockedState(reason: blockedStateReason)
+            }
+
+            DispatchQueue.main.async {
+                self.observerList.notify { [tunnelStatus = self.tunnelStatus] observer in
+                    observer
+                        .tunnelManager(self, didUpdateTunnelStatus: tunnelStatus)
+                }
+            }
+
             return newTunnelStatus
         }
-
-        logger.info("Status: \(newTunnelStatus).")
-
-        _tunnelStatus = newTunnelStatus
-
-        // Packet tunnel may have attempted or rotated the key.
-        // In that case we have to reload device state from Keychain as it's likely was modified by packet tunnel.
-        let newPacketTunnelKeyRotation = _tunnelStatus.observedState.connectionState?.lastKeyRotation
-        if lastPacketTunnelKeyRotation != newPacketTunnelKeyRotation {
-            lastPacketTunnelKeyRotation = newPacketTunnelKeyRotation
-            refreshDeviceState()
-        }
-        // Handle unrecoverable blocked states
-        if case let .error(blockedStateReason) = _tunnelStatus.state,
-            !blockedStateReason.recoverableError()
-        {
-            handleBlockedState(reason: blockedStateReason)
-        }
-
-        DispatchQueue.main.async {
-            self.observerList.notify { [tunnelStatus = self.tunnelStatus] observer in
-                observer
-                    .tunnelManager(self, didUpdateTunnelStatus: tunnelStatus)
-            }
-        }
-
-        return newTunnelStatus
     }
 
     fileprivate func setSettings(_ settings: LatestTunnelSettings, persist: Bool) {
-        nslock.lock()
-        defer { nslock.unlock() }
+        nslock.withLock {
+            let shouldCallDelegate = _tunnelSettings != settings && _isConfigurationLoaded
 
-        let shouldCallDelegate = _tunnelSettings != settings && _isConfigurationLoaded
+            _tunnelSettings = settings
 
-        _tunnelSettings = settings
-
-        if persist {
-            do {
-                try settingsManager.writeSettings(settings)
-            } catch {
-                logger.error(
-                    error: error,
-                    message: "Failed to write settings."
-                )
+            if persist {
+                do {
+                    try settingsManager.writeSettings(settings)
+                } catch {
+                    logger.error(
+                        error: error,
+                        message: "Failed to write settings."
+                    )
+                }
             }
-        }
 
-        if shouldCallDelegate {
-            DispatchQueue.main.async {
-                self.observerList.notify { observer in
-                    observer.tunnelManager(self, didUpdateTunnelSettings: settings)
+            if shouldCallDelegate {
+                DispatchQueue.main.async {
+                    self.observerList.notify { observer in
+                        observer.tunnelManager(self, didUpdateTunnelSettings: settings)
+                    }
                 }
             }
         }
     }
 
     func setDeviceState(_ deviceState: DeviceState, persist: Bool) {
-        nslock.lock()
-        defer { nslock.unlock() }
+        nslock.withLock {
+            let shouldCallDelegate = _deviceState != deviceState && _isConfigurationLoaded
+            let previousDeviceState = _deviceState
 
-        let shouldCallDelegate = _deviceState != deviceState && _isConfigurationLoaded
-        let previousDeviceState = _deviceState
+            _deviceState = deviceState
 
-        _deviceState = deviceState
-
-        if persist {
-            do {
-                try settingsManager.writeDeviceState(deviceState)
-            } catch {
-                logger.error(
-                    error: error,
-                    message: "Failed to write device state."
-                )
-            }
-        }
-
-        if shouldCallDelegate {
-            DispatchQueue.main.async {
-                self.observerList.notify { observer in
-                    observer.tunnelManager(
-                        self,
-                        didUpdateDeviceState: deviceState,
-                        previousDeviceState: previousDeviceState
+            if persist {
+                do {
+                    try settingsManager.writeDeviceState(deviceState)
+                } catch {
+                    logger.error(
+                        error: error,
+                        message: "Failed to write device state."
                     )
+                }
+            }
+
+            if shouldCallDelegate {
+                DispatchQueue.main.async {
+                    self.observerList.notify { observer in
+                        observer.tunnelManager(
+                            self,
+                            didUpdateDeviceState: deviceState,
+                            previousDeviceState: previousDeviceState
+                        )
+                    }
                 }
             }
         }
@@ -794,62 +780,59 @@ final class TunnelManager: @unchecked Sendable {
     }
 
     fileprivate func prepareForVPNConfigurationDeletion() {
-        nslock.lock()
-        defer { nslock.unlock() }
-
-        // Unregister from receiving VPN connection status changes
-        unsubscribeVPNStatusObserver()
+        nslock.withLock {
+            // Unregister from receiving VPN connection status changes
+            unsubscribeVPNStatusObserver()
+        }
     }
 
     private func didReconnectTunnel(error: Error?) {
-        nslock.lock()
-        defer { nslock.unlock() }
+        nslock.withLock {
+            if let error, !error.isOperationCancellationError {
+                logger.error(error: error, message: "Failed to reconnect the tunnel.")
+            }
 
-        if let error, !error.isOperationCancellationError {
-            logger.error(error: error, message: "Failed to reconnect the tunnel.")
-        }
+            // Refresh tunnel status only when connecting,reasserting or error to pick up the next relay,
+            // since both states may persist for a long period of time until the tunnel is fully
+            // connected.
+            switch tunnelStatus.state {
+            case .connecting, .reconnecting, .error:
+                logger.debug("Refresh tunnel status due to reconnect.")
+                refreshTunnelStatus()
 
-        // Refresh tunnel status only when connecting,reasserting or error to pick up the next relay,
-        // since both states may persist for a long period of time until the tunnel is fully
-        // connected.
-        switch tunnelStatus.state {
-        case .connecting, .reconnecting, .error:
-            logger.debug("Refresh tunnel status due to reconnect.")
-            refreshTunnelStatus()
-
-        default:
-            break
+            default:
+                break
+            }
         }
     }
 
     private func subscribeVPNStatusObserver(tunnel: any TunnelProtocol) {
-        nslock.lock()
-        defer { nslock.unlock() }
+        nslock.withLock {
+            unsubscribeVPNStatusObserver()
 
-        unsubscribeVPNStatusObserver()
+            statusObserver =
+                tunnel
+                .addBlockObserver(queue: internalQueue) { [weak self] tunnel, status in
+                    guard let self else { return }
 
-        statusObserver =
-            tunnel
-            .addBlockObserver(queue: internalQueue) { [weak self] tunnel, status in
-                guard let self else { return }
+                    // Save the NEVPNStatus so we can reject stale IPC updates
+                    self._lastNEVPNStatus = status
+                    self.logger.debug("VPN connection status changed to \(status).")
 
-                // Save the NEVPNStatus so we can reject stale IPC updates
-                self._lastNEVPNStatus = status
-                self.logger.debug("VPN connection status changed to \(status).")
+                    // Control polling based on NEVPNStatus directly (the source of truth),
+                    // not the derived tunnelStatus.state which can be stale.
+                    self.updatePollingFromVPNStatus(status)
 
-                // Control polling based on NEVPNStatus directly (the source of truth),
-                // not the derived tunnelStatus.state which can be stale.
-                self.updatePollingFromVPNStatus(status)
+                    // Update tunnel status for all state changes to ensure UI reflects
+                    // disconnecting and disconnected states immediately.
+                    self.updateTunnelStatus(status)
+                }
 
-                // Update tunnel status for all state changes to ensure UI reflects
-                // disconnecting and disconnected states immediately.
-                self.updateTunnelStatus(status)
-            }
-
-        // Save and start polling for the current status since the observer
-        // only fires on status changes, not for the initial state.
-        _lastNEVPNStatus = tunnel.status
-        updatePollingFromVPNStatus(tunnel.status)
+            // Save and start polling for the current status since the observer
+            // only fires on status changes, not for the initial state.
+            _lastNEVPNStatus = tunnel.status
+            updatePollingFromVPNStatus(tunnel.status)
+        }
     }
 
     private func startNetworkMonitor() {
@@ -880,28 +863,26 @@ final class TunnelManager: @unchecked Sendable {
     }
 
     private func unsubscribeVPNStatusObserver() {
-        nslock.lock()
-        defer { nslock.unlock() }
-
-        statusObserver?.invalidate()
-        statusObserver = nil
+        nslock.withLock {
+            statusObserver?.invalidate()
+            statusObserver = nil
+        }
     }
 
     private func refreshTunnelStatus() {
-        nslock.lock()
-        defer { nslock.unlock() }
+        nslock.withLock {
+            guard let connectionStatus = _tunnel?.status else { return }
 
-        guard let connectionStatus = _tunnel?.status else { return }
-
-        switch connectionStatus {
-        case .connecting, .reasserting, .connected:
-            // Active states: fetch via IPC
-            fetchAndUpdateTunnelStatus()
-        case .disconnected, .disconnecting, .invalid:
-            // Down states: update directly
-            updateTunnelStatus(connectionStatus)
-        @unknown default:
-            break
+            switch connectionStatus {
+            case .connecting, .reasserting, .connected:
+                // Active states: fetch via IPC
+                fetchAndUpdateTunnelStatus()
+            case .disconnected, .disconnecting, .invalid:
+                // Down states: update directly
+                updateTunnelStatus(connectionStatus)
+            @unknown default:
+                break
+            }
         }
     }
 
@@ -937,25 +918,24 @@ final class TunnelManager: @unchecked Sendable {
     /// For active states, fetches detailed status via IPC.
     /// For down states, updates state directly without IPC.
     private func updateTunnelStatus(_ connectionStatus: NEVPNStatus) {
-        nslock.lock()
-        defer { nslock.unlock() }
+        nslock.withLock {
+            switch connectionStatus {
+            case .connecting, .reasserting, .connected:
+                // Active states: fetch details via IPC
+                fetchAndUpdateTunnelStatus()
 
-        switch connectionStatus {
-        case .connecting, .reasserting, .connected:
-            // Active states: fetch details via IPC
-            fetchAndUpdateTunnelStatus()
+            case .disconnecting:
+                handleDisconnectingStateDirectly()
 
-        case .disconnecting:
-            handleDisconnectingStateDirectly()
+            case .disconnected:
+                handleDisconnectedStateDirectly()
 
-        case .disconnected:
-            handleDisconnectedStateDirectly()
+            case .invalid:
+                setDisconnectedState(networkPathStatus: networkMonitor?.currentPath.status)
 
-        case .invalid:
-            setDisconnectedState(networkPathStatus: networkMonitor?.currentPath.status)
-
-        @unknown default:
-            logger.debug("Unknown NEVPNStatus: \(connectionStatus.rawValue)")
+            @unknown default:
+                logger.debug("Unknown NEVPNStatus: \(connectionStatus.rawValue)")
+            }
         }
     }
 
@@ -1472,9 +1452,7 @@ private struct TunnelInteractorProxy: TunnelInteractor {
             // Only reconnect if relays are now available
             guard !cachedRelays.isEmpty else { return }
 
-            nslock.lock()
-            let currentStatus = _tunnelStatus
-            nslock.unlock()
+            let currentStatus = nslock.withLock { _tunnelStatus }
 
             // If tunnel is active, trigger reconnect to re-evaluate with new relays
             if currentStatus.state.isSecured {

--- a/ios/MullvadVPN/TunnelManager/TunnelStore.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelStore.swift
@@ -45,33 +45,29 @@ final class TunnelStore: TunnelStoreProtocol, TunnelStatusObserver, @unchecked S
     }
 
     func getPersistentTunnels() -> [TunnelType] {
-        lock.lock()
-        defer { lock.unlock() }
-
-        return persistentTunnels
+        lock.withLock {
+            persistentTunnels
+        }
     }
 
     private func setPersistentTunnelsFromManagers(_ managers: [TunnelProviderManagerType]) {
-        self.lock.lock()
-        defer {
-            self.lock.unlock()
-        }
-
-        self.persistentTunnels.forEach { tunnel in
-            tunnel.removeObserver(self)
-        }
-
-        self.persistentTunnels =
-            managers.map { manager in
-                let tunnel = Tunnel(tunnelProvider: manager, backgroundTaskProvider: self.application)
-                tunnel.addObserver(self)
-
-                self.logger.debug(
-                    "Loaded persistent tunnel: \(tunnel.logFormat()) with status: \(tunnel.status)."
-                )
-
-                return tunnel
+        lock.withLock {
+            self.persistentTunnels.forEach { tunnel in
+                tunnel.removeObserver(self)
             }
+
+            self.persistentTunnels =
+                managers.map { manager in
+                    let tunnel = Tunnel(tunnelProvider: manager, backgroundTaskProvider: self.application)
+                    tunnel.addObserver(self)
+
+                    self.logger.debug(
+                        "Loaded persistent tunnel: \(tunnel.logFormat()) with status: \(tunnel.status)."
+                    )
+
+                    return tunnel
+                }
+        }
     }
 
     func loadPersistentTunnels() async throws {
@@ -80,26 +76,24 @@ final class TunnelStore: TunnelStoreProtocol, TunnelStatusObserver, @unchecked S
     }
 
     func createNewTunnel() -> TunnelType {
-        lock.lock()
-        defer { lock.unlock() }
+        lock.withLock {
+            let tunnelProviderManager = TunnelProviderManagerType()
+            let tunnel = TunnelType(tunnelProvider: tunnelProviderManager, backgroundTaskProvider: application)
+            tunnel.addObserver(self)
 
-        let tunnelProviderManager = TunnelProviderManagerType()
-        let tunnel = TunnelType(tunnelProvider: tunnelProviderManager, backgroundTaskProvider: application)
-        tunnel.addObserver(self)
+            newTunnels = newTunnels.filter { $0.value != nil }
+            newTunnels.append(WeakBox(tunnel))
 
-        newTunnels = newTunnels.filter { $0.value != nil }
-        newTunnels.append(WeakBox(tunnel))
+            logger.debug("Create new tunnel: \(tunnel.logFormat()).")
 
-        logger.debug("Create new tunnel: \(tunnel.logFormat()).")
-
-        return tunnel
+            return tunnel
+        }
     }
 
     func tunnel(_ tunnel: any TunnelProtocol, didReceiveStatus status: NEVPNStatus) {
-        lock.lock()
-        defer { lock.unlock() }
-
-        handleTunnelStatus(tunnel: tunnel as! TunnelType, status: status)
+        lock.withLock {
+            handleTunnelStatus(tunnel: tunnel as! TunnelType, status: status)
+        }
     }
 
     private func handleTunnelStatus(tunnel: TunnelType, status: NEVPNStatus) {
@@ -120,13 +114,12 @@ final class TunnelStore: TunnelStoreProtocol, TunnelStatusObserver, @unchecked S
     }
 
     private func refreshStatus() {
-        lock.lock()
-        defer { lock.unlock() }
+        lock.withLock {
+            let allTunnels = persistentTunnels + newTunnels.compactMap { $0.value }
 
-        let allTunnels = persistentTunnels + newTunnels.compactMap { $0.value }
-
-        for tunnel in allTunnels {
-            handleTunnelStatus(tunnel: tunnel, status: tunnel.status)
+            for tunnel in allTunnels {
+                handleTunnelStatus(tunnel: tunnel, status: tunnel.status)
+            }
         }
     }
 }

--- a/ios/MullvadVPNTests/MullvadTypes/MockFileCache.swift
+++ b/ios/MullvadVPNTests/MullvadTypes/MockFileCache.swift
@@ -20,36 +20,32 @@ final class MockFileCache<Content: Codable & Equatable>: FileCacheProtocol {
 
     /// Returns internal state.
     func getState() -> State {
-        stateLock.lock()
-        defer { stateLock.unlock() }
-
-        return state
+        stateLock.withLock {
+            state
+        }
     }
 
     func read() throws -> Content {
-        stateLock.lock()
-        defer { stateLock.unlock() }
-
-        switch state {
-        case .fileNotFound:
-            throw CocoaError(.fileReadNoSuchFile)
-        case let .exists(content):
-            return content
+        try stateLock.withLock {
+            switch state {
+            case .fileNotFound:
+                throw CocoaError(.fileReadNoSuchFile)
+            case let .exists(content):
+                return content
+            }
         }
     }
 
     func write(_ content: Content) throws {
-        stateLock.lock()
-        defer { stateLock.unlock() }
-
-        state = .exists(content)
+        stateLock.withLock {
+            state = .exists(content)
+        }
     }
 
     func clear() throws {
-        stateLock.lock()
-        defer { stateLock.unlock() }
-
-        state = .fileNotFound
+        stateLock.withLock {
+            state = .fileNotFound
+        }
     }
 
     enum State: Equatable {

--- a/ios/MullvadVPNTests/MullvadVPN/PacketTunnel/DeviceCheck/DeviceCheckOperationTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/PacketTunnel/DeviceCheck/DeviceCheckOperationTests.swift
@@ -419,15 +419,15 @@ private class MockDeviceStateAccessor: DeviceStateAccessorProtocol {
     }
 
     func read() throws -> DeviceState {
-        stateLock.lock()
-        defer { stateLock.unlock() }
-        return state
+        stateLock.withLock {
+            state
+        }
     }
 
     func write(_ deviceState: DeviceState) throws {
-        stateLock.lock()
-        defer { stateLock.unlock() }
-        state = deviceState
+        stateLock.withLock {
+            state = deviceState
+        }
     }
 }
 

--- a/ios/Operations/AsyncOperation.swift
+++ b/ios/Operations/AsyncOperation.swift
@@ -69,45 +69,45 @@ open class AsyncOperation: Operation, @unchecked Sendable {
     /// Operation state.
     @objc private var state: State {
         get {
-            stateLock.lock()
-            defer { stateLock.unlock() }
-            return _state
+            stateLock.withLock {
+                _state
+            }
         }
         set(newState) {
             willChangeValue(for: \.state)
-            stateLock.lock()
-            assert(_state < newState)
-            _state = newState
-            stateLock.unlock()
+            stateLock.withLock {
+                assert(_state < newState)
+                _state = newState
+            }
             didChangeValue(for: \.state)
         }
     }
 
     private var _isCancelled: Bool {
         get {
-            stateLock.lock()
-            defer { stateLock.unlock() }
-            return __isCancelled
+            stateLock.withLock {
+                __isCancelled
+            }
         }
         set {
             willChangeValue(for: \.isCancelled)
-            stateLock.lock()
-            __isCancelled = newValue
-            stateLock.unlock()
+            stateLock.withLock {
+                __isCancelled = newValue
+            }
             didChangeValue(for: \.isCancelled)
         }
     }
 
     private var _error: Error? {
         get {
-            stateLock.lock()
-            defer { stateLock.unlock() }
-            return __error
+            stateLock.withLock {
+                __error
+            }
         }
         set {
-            stateLock.lock()
-            defer { stateLock.unlock() }
-            __error = newValue
+            stateLock.withLock {
+                __error = newValue
+            }
         }
     }
 
@@ -116,25 +116,24 @@ open class AsyncOperation: Operation, @unchecked Sendable {
     }
 
     dynamic override public final var isReady: Bool {
-        stateLock.lock()
-        defer { stateLock.unlock() }
+        stateLock.withLock {
+            // super.isReady should turn true when all dependencies are satisfied.
+            guard super.isReady else {
+                return false
+            }
 
-        // super.isReady should turn true when all dependencies are satisfied.
-        guard super.isReady else {
-            return false
-        }
+            // Mark operation ready when cancelled, so that operation queue could flush it faster.
+            guard !__isCancelled else {
+                return true
+            }
 
-        // Mark operation ready when cancelled, so that operation queue could flush it faster.
-        guard !__isCancelled else {
-            return true
-        }
+            switch _state {
+            case .initialized, .pending, .evaluatingConditions:
+                return false
 
-        switch _state {
-        case .initialized, .pending, .evaluatingConditions:
-            return false
-
-        case .ready, .executing, .finished:
-            return true
+            case .ready, .executing, .finished:
+                return true
+            }
         }
     }
 
@@ -159,17 +158,16 @@ open class AsyncOperation: Operation, @unchecked Sendable {
     private var _observers: [OperationObserver] = []
 
     public final var observers: [OperationObserver] {
-        operationLock.lock()
-        defer { operationLock.unlock() }
-
-        return _observers
+        operationLock.withLock {
+            _observers
+        }
     }
 
     public final func addObserver(_ observer: OperationObserver) {
-        operationLock.lock()
-        assert(state < .executing)
-        _observers.append(observer)
-        operationLock.unlock()
+        operationLock.withLock {
+            assert(state < .executing)
+            _observers.append(observer)
+        }
         observer.didAttach(to: self)
     }
 
@@ -178,17 +176,16 @@ open class AsyncOperation: Operation, @unchecked Sendable {
     private var _conditions: [OperationCondition] = []
 
     public final var conditions: [OperationCondition] {
-        operationLock.lock()
-        defer { operationLock.unlock() }
-        return _conditions
+        operationLock.withLock {
+            _conditions
+        }
     }
 
     public func addCondition(_ condition: OperationCondition) {
-        operationLock.lock()
-        defer { operationLock.unlock() }
-
-        assert(state < .evaluatingConditions)
-        _conditions.append(condition)
+        operationLock.withLock {
+            assert(state < .evaluatingConditions)
+            _conditions.append(condition)
+        }
     }
 
     private func evaluateConditions() {
@@ -218,17 +215,16 @@ open class AsyncOperation: Operation, @unchecked Sendable {
     }
 
     private func didEvaluateConditions(_ results: [Bool]) {
-        operationLock.lock()
-        defer { operationLock.unlock() }
+        operationLock.withLock {
+            guard state < .ready else { return }
 
-        guard state < .ready else { return }
+            let conditionsSatisfied = results.allSatisfy { $0 }
+            if !conditionsSatisfied {
+                cancel()
+            }
 
-        let conditionsSatisfied = results.allSatisfy { $0 }
-        if !conditionsSatisfied {
-            cancel()
+            state = .ready
         }
-
-        state = .ready
     }
 
     // MARK: -
@@ -302,19 +298,19 @@ open class AsyncOperation: Operation, @unchecked Sendable {
     }
 
     override public final func cancel() {
-        operationLock.lock()
-        if !_isCancelled {
-            _isCancelled = true
+        operationLock.withLock {
+            if !_isCancelled {
+                _isCancelled = true
 
-            // Notify observers only when executing, otherwise `_start()` will take care of doing this as soon
-            // as operation is ready to execute.
-            if state == .executing {
-                dispatchQueue.async {
-                    self.notifyCancellation()
+                // Notify observers only when executing, otherwise `_start()` will take care of doing this as soon
+                // as operation is ready to execute.
+                if state == .executing {
+                    dispatchQueue.async {
+                        self.notifyCancellation()
+                    }
                 }
             }
         }
-        operationLock.unlock()
 
         super.cancel()
     }
@@ -339,35 +335,32 @@ open class AsyncOperation: Operation, @unchecked Sendable {
     // MARK: - Private
 
     internal func didEnqueue() {
-        operationLock.lock()
-        defer { operationLock.unlock() }
+        operationLock.withLock {
+            guard state == .initialized else {
+                return
+            }
 
-        guard state == .initialized else {
-            return
+            state = .pending
         }
-
-        state = .pending
     }
 
     private func checkReadiness() {
-        operationLock.lock()
-        defer { operationLock.unlock() }
-
-        if state == .pending, !_isCancelled, super.isReady {
-            evaluateConditions()
+        operationLock.withLock {
+            if state == .pending, !_isCancelled, super.isReady {
+                evaluateConditions()
+            }
         }
     }
 
     private func tryFinish(error: Error?) -> Bool {
-        operationLock.lock()
-        defer { operationLock.unlock() }
+        operationLock.withLock {
+            guard state < .finished else { return false }
 
-        guard state < .finished else { return false }
+            _error = error
+            state = .finished
 
-        _error = error
-        state = .finished
-
-        return true
+            return true
+        }
     }
 
     private func notifyCancellation() {

--- a/ios/Operations/AsyncOperationQueue.swift
+++ b/ios/Operations/AsyncOperationQueue.swift
@@ -59,51 +59,49 @@ private final class ExclusivityManager: @unchecked Sendable {
     private init() {}
 
     func addOperation(_ operation: AsyncOperation, categories: Set<String>) {
-        nslock.lock()
-        defer { nslock.unlock() }
+        nslock.withLock {
+            for category in categories {
+                var operations = operationsByCategory[category] ?? []
 
-        for category in categories {
-            var operations = operationsByCategory[category] ?? []
+                if let lastOperation = operations.last {
+                    operation.addDependency(lastOperation)
+                }
 
-            if let lastOperation = operations.last {
-                operation.addDependency(lastOperation)
-            }
+                operations.append(operation)
 
-            operations.append(operation)
+                operationsByCategory[category] = operations
 
-            operationsByCategory[category] = operations
-
-            operation.onFinish { [weak self] op, _ in
-                self?.removeOperation(op, categories: categories)
+                operation.onFinish { [weak self] op, _ in
+                    self?.removeOperation(op, categories: categories)
+                }
             }
         }
     }
 
     private func removeOperation(_ operation: Operation, categories: Set<String>) {
-        nslock.lock()
-        defer { nslock.unlock() }
-
-        for category in categories {
-            guard var operations = operationsByCategory[category] else {
-                continue
-            }
-
-            if let index = operations.firstIndex(of: operation) {
-                // Break the successor's back-pointer so finished operations can be
-                // released immediately. Without this, addDependency chains every op
-                // to its predecessor — under load, releasing the tail triggers a
-                // recursive deinit cascade that overflows the stack.
-                let nextIndex = operations.index(after: index)
-                if nextIndex < operations.endIndex {
-                    operations[nextIndex].removeDependency(operation)
+        nslock.withLock {
+            for category in categories {
+                guard var operations = operationsByCategory[category] else {
+                    continue
                 }
-                operations.remove(at: index)
-            }
 
-            if operations.isEmpty {
-                operationsByCategory.removeValue(forKey: category)
-            } else {
-                operationsByCategory[category] = operations
+                if let index = operations.firstIndex(of: operation) {
+                    // Break the successor's back-pointer so finished operations can be
+                    // released immediately. Without this, addDependency chains every op
+                    // to its predecessor — under load, releasing the tail triggers a
+                    // recursive deinit cascade that overflows the stack.
+                    let nextIndex = operations.index(after: index)
+                    if nextIndex < operations.endIndex {
+                        operations[nextIndex].removeDependency(operation)
+                    }
+                    operations.remove(at: index)
+                }
+
+                if operations.isEmpty {
+                    operationsByCategory.removeValue(forKey: category)
+                } else {
+                    operationsByCategory[category] = operations
+                }
             }
         }
     }

--- a/ios/Operations/ResultOperation.swift
+++ b/ios/Operations/ResultOperation.swift
@@ -19,46 +19,39 @@ open class ResultOperation<Success: Sendable>: AsyncOperation, OutputOperation, 
     private var pendingFinish = false
 
     public var result: Result<Success, Error>? {
-        nslock.lock()
-        defer { nslock.unlock() }
-
-        return _output.map { .success($0) } ?? error.map { .failure($0) }
+        nslock.withLock {
+            _output.map { .success($0) } ?? error.map { .failure($0) }
+        }
     }
 
     public var output: Success? {
-        nslock.lock()
-        defer { nslock.unlock() }
-
-        return _output
+        nslock.withLock {
+            _output
+        }
     }
 
     public var completionQueue: DispatchQueue? {
         get {
-            nslock.lock()
-            defer { nslock.unlock() }
-
-            return _completionQueue
+            nslock.withLock { _completionQueue }
         }
         set {
-            nslock.lock()
-            defer { nslock.unlock() }
-
-            _completionQueue = newValue
+            nslock.withLock {
+                _completionQueue = newValue
+            }
         }
     }
 
     public var completionHandler: CompletionHandler? {
         get {
-            nslock.lock()
-            defer { nslock.unlock() }
-
-            return _completionHandler
+            nslock.withLock {
+                return _completionHandler
+            }
         }
         set {
-            nslock.lock()
-            defer { nslock.unlock() }
-            if !pendingFinish {
-                _completionHandler = newValue
+            nslock.withLock {
+                if !pendingFinish {
+                    _completionHandler = newValue
+                }
             }
         }
     }

--- a/ios/PacketTunnelCore/Pinger/TunnelPinger.swift
+++ b/ios/PacketTunnelCore/Pinger/TunnelPinger.swift
@@ -68,21 +68,20 @@ public final class TunnelPinger: PingerProtocol, @unchecked Sendable {
     public func send() throws -> PingerSendResult {
         let sequenceNumber = nextSequenceNumber()
 
-        stateLock.lock()
-        defer { stateLock.unlock() }
-        guard destAddress != nil else { throw WireGuardAdapterError.invalidState }
-        // NOTE: we cheat here by returning the destination address we were passed, rather than parsing it from the packet on the other side of the FFI boundary.
-        try pingProvider.sendICMPPing(seqNumber: sequenceNumber)
+        return try stateLock.withLock {
+            guard destAddress != nil else { throw WireGuardAdapterError.invalidState }
+            // NOTE: we cheat here by returning the destination address we were passed, rather than parsing it from the packet on the other side of the FFI boundary.
+            try pingProvider.sendICMPPing(seqNumber: sequenceNumber)
 
-        return PingerSendResult(sequenceNumber: UInt16(sequenceNumber))
+            return PingerSendResult(sequenceNumber: UInt16(sequenceNumber))
+        }
     }
 
     private func nextSequenceNumber() -> UInt16 {
-        stateLock.lock()
-        let (nextValue, _) = sequenceNumber.addingReportingOverflow(1)
-        sequenceNumber = nextValue
-        stateLock.unlock()
-
-        return nextValue
+        stateLock.withLock {
+            let (nextValue, _) = sequenceNumber.addingReportingOverflow(1)
+            sequenceNumber = nextValue
+            return nextValue
+        }
     }
 }

--- a/ios/PacketTunnelCore/TunnelMonitor/TunnelMonitor.swift
+++ b/ios/PacketTunnelCore/TunnelMonitor/TunnelMonitor.swift
@@ -74,51 +74,47 @@ public final class TunnelMonitor: TunnelMonitorProtocol, @unchecked Sendable {
     }
 
     public func start(probeAddress: IPv4Address) {
-        nslock.lock()
-        defer { nslock.unlock() }
+        nslock.withLock {
+            if case .stopped = state.connectionState {
+                logger.debug("Start with address: \(probeAddress).")
+            } else {
+                _stop(forRestart: true)
+                logger.debug("Restart with address: \(probeAddress).")
+            }
 
-        if case .stopped = state.connectionState {
-            logger.debug("Start with address: \(probeAddress).")
-        } else {
-            _stop(forRestart: true)
-            logger.debug("Restart with address: \(probeAddress).")
+            self.probeAddress = probeAddress
+            state.connectionState = .pendingStart
+
+            startMonitoring()
         }
-
-        self.probeAddress = probeAddress
-        state.connectionState = .pendingStart
-
-        startMonitoring()
     }
 
     public func stop() {
-        nslock.lock()
-        defer { nslock.unlock() }
-
-        _stop()
+        nslock.withLock {
+            _stop()
+        }
     }
 
     public func onWake() {
-        nslock.lock()
-        defer { nslock.unlock() }
+        nslock.withLock {
+            logger.trace("Wake up.")
 
-        logger.trace("Wake up.")
+            switch state.connectionState {
+            case .connecting, .connected:
+                startConnectivityCheckTimer()
 
-        switch state.connectionState {
-        case .connecting, .connected:
-            startConnectivityCheckTimer()
-
-        case .waitingConnectivity, .pendingStart, .stopped, .recovering:
-            break
+            case .waitingConnectivity, .pendingStart, .stopped, .recovering:
+                break
+            }
         }
     }
 
     public func onSleep() {
-        nslock.lock()
-        defer { nslock.unlock() }
+        nslock.withLock {
+            logger.trace("Prepare to sleep.")
 
-        logger.trace("Prepare to sleep.")
-
-        stopConnectivityCheckTimer()
+            stopConnectivityCheckTimer()
+        }
     }
 
     public func handleNetworkPathUpdate(_ networkPath: Network.NWPath.Status) {
@@ -173,54 +169,53 @@ public final class TunnelMonitor: TunnelMonitorProtocol, @unchecked Sendable {
     }
 
     private func checkConnectivity() {
-        nslock.lock()
-        defer { nslock.unlock() }
+        nslock.withLock {
+            guard let newStats = getStats(),
+                state.connectionState == .connecting || state.connectionState == .connected
+            else { return }
 
-        guard let newStats = getStats(),
-            state.connectionState == .connecting || state.connectionState == .connected
-        else { return }
+            // Check if counters were reset.
+            let isStatsReset =
+                newStats.bytesReceived < state.netStats.bytesReceived || newStats.bytesSent < state.netStats.bytesSent
 
-        // Check if counters were reset.
-        let isStatsReset =
-            newStats.bytesReceived < state.netStats.bytesReceived || newStats.bytesSent < state.netStats.bytesSent
-
-        guard !isStatsReset else {
-            logger.trace("Stats was being reset.")
-            state.netStats = newStats
-            return
-        }
-
-        #if DEBUG
-            logCounters(currentStats: state.netStats, newStats: newStats)
-        #endif
-
-        let now = Date()
-        state.updateNetStats(newStats: newStats, now: now)
-
-        let timeout = state.getPingTimeout()
-        let evaluation = state.evaluateConnection(now: now, pingTimeout: timeout)
-
-        if evaluation != .ok {
-            logger.trace("Evaluation: \(evaluation)")
-        }
-
-        switch evaluation {
-        case .ok:
-            break
-
-        case .pingTimeout:
-            startConnectionRecovery()
-
-        case .suspendHeartbeat:
-            state.isHeartbeatSuspended = true
-
-        case .sendHeartbeatPing, .retryHeartbeatPing, .sendNextPing, .sendInitialPing,
-            .inboundTrafficTimeout, .trafficTimeout:
-            if state.isHeartbeatSuspended {
-                state.isHeartbeatSuspended = false
-                state.timeoutReference = now
+            guard !isStatsReset else {
+                logger.trace("Stats was being reset.")
+                state.netStats = newStats
+                return
             }
-            sendPing(now: now)
+
+            #if DEBUG
+                logCounters(currentStats: state.netStats, newStats: newStats)
+            #endif
+
+            let now = Date()
+            state.updateNetStats(newStats: newStats, now: now)
+
+            let timeout = state.getPingTimeout()
+            let evaluation = state.evaluateConnection(now: now, pingTimeout: timeout)
+
+            if evaluation != .ok {
+                logger.trace("Evaluation: \(evaluation)")
+            }
+
+            switch evaluation {
+            case .ok:
+                break
+
+            case .pingTimeout:
+                startConnectionRecovery()
+
+            case .suspendHeartbeat:
+                state.isHeartbeatSuspended = true
+
+            case .sendHeartbeatPing, .retryHeartbeatPing, .sendNextPing, .sendInitialPing,
+                .inboundTrafficTimeout, .trafficTimeout:
+                if state.isHeartbeatSuspended {
+                    state.isHeartbeatSuspended = false
+                    state.timeoutReference = now
+                }
+                sendPing(now: now)
+            }
         }
     }
 
@@ -262,36 +257,35 @@ public final class TunnelMonitor: TunnelMonitorProtocol, @unchecked Sendable {
     }
 
     private func didReceivePing(from sender: IPAddress, sequenceNumber: UInt16) {
-        nslock.lock()
-        defer { nslock.unlock() }
+        nslock.withLock {
+            guard let probeAddress else { return }
 
-        guard let probeAddress else { return }
+            if sender.rawValue != probeAddress.rawValue {
+                logger.trace("Got reply from unknown sender: \(sender), expected: \(probeAddress).")
+            }
 
-        if sender.rawValue != probeAddress.rawValue {
-            logger.trace("Got reply from unknown sender: \(sender), expected: \(probeAddress).")
-        }
+            let now = Date()
+            guard let pingTimestamp = state.setPingReplyReceived(sequenceNumber, now: now) else {
+                logger.trace("Got unknown ping sequence: \(sequenceNumber).")
+                return
+            }
 
-        let now = Date()
-        guard let pingTimestamp = state.setPingReplyReceived(sequenceNumber, now: now) else {
-            logger.trace("Got unknown ping sequence: \(sequenceNumber).")
-            return
-        }
+            logger.trace(
+                {
+                    let time = now.timeIntervalSince(pingTimestamp) * 1000
+                    let message = String(
+                        format: "Received reply icmp_seq=%d, time=%.2f ms.",
+                        sequenceNumber,
+                        time
+                    )
+                    return Logger.Message(stringLiteral: message)
+                }())
 
-        logger.trace(
-            {
-                let time = now.timeIntervalSince(pingTimestamp) * 1000
-                let message = String(
-                    format: "Received reply icmp_seq=%d, time=%.2f ms.",
-                    sequenceNumber,
-                    time
-                )
-                return Logger.Message(stringLiteral: message)
-            }())
-
-        if case .connecting = state.connectionState {
-            state.connectionState = .connected
-            state.retryAttempt = 0
-            sendConnectionEstablishedEvent()
+            if case .connecting = state.connectionState {
+                state.connectionState = .connected
+                state.retryAttempt = 0
+                sendConnectionEstablishedEvent()
+            }
         }
     }
 

--- a/ios/disable_nslock.sh
+++ b/ios/disable_nslock.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 [file path]"
+    exit 1
+}
+
+if [[ $# -lt 1 ]]; then
+    usage
+fi
+
+if [[ "$(uname -m)" == arm64 ]]; then
+    export PATH="/opt/homebrew/bin:$PATH"
+fi
+ISSUES=$(rg --column -tswift '(\b(NSRecursiveLock|NSCondition|os_unfair_lock(_t|_lock)?|pthread_mutex_t|DispatchSemaphore)\b)|(\.lock\(\)|\.unlock\(\))\B' "$1" | cut -d' ' -f1)
+
+for issue in ${ISSUES};
+do echo "${issue}" warning: This usage of locking is not recommended and will soon be a compilation error. Please use withLock constructs or a native synchronisation primitive.
+done
+exit 0


### PR DESCRIPTION
This PR adds a script that runs when the project builds.
The script runs a `ripgrep` command that will look (and warn about) for all uses of the following classes:
- `NSRecursiveLock`
- `NSCondition`
- `os_unfair_lock_t`
- `os_unfair_lock_lock`
- `pthread_mutex_t`
- `DispatchSemaphore`
- `.lock()` statements
- `.unlock()` statements

In the future, we plan to make those warnings turn int error when we are done moving away from traditional locking mechanisms in favor of modern structured concurrency.

I tried to remove as many warnings as possible for the trivial cases so this PR wouldn't introduce hundreds of warnings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10963)
<!-- Reviewable:end -->
