### PR TITLE
Exclude `.git` directory on copy

### DIFF
--- a/.github/workflows/ios-end-to-end-tests.yml
+++ b/.github/workflows/ios-end-to-end-tests.yml
@@ -129,7 +129,8 @@ jobs:
         run: |
           mkdir -p "$JOB_OUTPUTS_DIRECTORY/derived-data"
           cp -R ios/derived-data "$JOB_OUTPUTS_DIRECTORY"
-          cp -R . $JOB_OUTPUTS_DIRECTORY/mullvadvpn-app
+          rsync -a --exclude='.git' . "$JOB_OUTPUTS_DIRECTORY/mullvadvpn-app" \
+            --stats --human-readable
         shell: bash
         env:
           JOB_OUTPUTS_DIRECTORY: ${{ needs.set-up-outputs-directory.outputs.job_outputs_directory }}


### PR DESCRIPTION
This directory is copied in order to be able to build the ios-end-to-end-tests once, and then execute the suites in parallel.

As the `.git` folder has grown to a crazy size, this ensures it is not duplicated while we schedule IOS-1696.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10969)
<!-- Reviewable:end -->
