### PR TITLE
Clarify Linux version mismatch message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Linux
 - Parse the `resolv.conf` format using `resolv-conf` crate. This will lead to fewer false negatives
   when detecting if NetworkManager manages DNS.
+- Clarify that restarting the daemon can resolve an app and daemon version mismatch.
 
 #### Windows
 - Preserve the app's own theme colors when Windows high contrast (forced-colors) mode is

--- a/desktop/packages/mullvad-vpn/locales/messages.pot
+++ b/desktop/packages/mullvad-vpn/locales/messages.pot
@@ -787,6 +787,11 @@ msgstr ""
 
 #. Description for version list item when app is out of sync.
 msgctxt "app-info-view"
+msgid "App is out of sync. Please quit and restart the app or daemon."
+msgstr ""
+
+#. Description for version list item when app is out of sync.
+msgctxt "app-info-view"
 msgid "App is out of sync. Please quit and restart."
 msgstr ""
 
@@ -1487,6 +1492,10 @@ msgid "NEW VERSION INSTALLED"
 msgstr ""
 
 msgctxt "in-app-notifications"
+msgid "Please quit and restart the app or daemon."
+msgstr ""
+
+msgctxt "in-app-notifications"
 msgid "Please quit and restart the app."
 msgstr ""
 
@@ -1837,6 +1846,10 @@ msgstr ""
 
 msgctxt "notifications"
 msgid "Account is out of time"
+msgstr ""
+
+msgctxt "notifications"
+msgid "App is out of sync. Please quit and restart the app or daemon."
 msgstr ""
 
 msgctxt "notifications"

--- a/desktop/packages/mullvad-vpn/src/main/version.ts
+++ b/desktop/packages/mullvad-vpn/src/main/version.ts
@@ -63,6 +63,7 @@ export default class Version {
     // notify user about inconsistent version
     const notificationProvider = new InconsistentVersionNotificationProvider({
       consistent: versionInfo.isConsistent,
+      platform: process.platform,
     });
     if (notificationProvider.mayDisplay()) {
       this.delegate.notify(notificationProvider.getSystemNotification());

--- a/desktop/packages/mullvad-vpn/src/renderer/components/NotificationArea.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/NotificationArea.tsx
@@ -152,7 +152,10 @@ export default function NotificationArea(props: IProps) {
       disableSplitTunneling,
       splitTunnelingSupported,
     }),
-    new InconsistentVersionNotificationProvider({ consistent: version.consistent }),
+    new InconsistentVersionNotificationProvider({
+      consistent: version.consistent,
+      platform: window.env.platform,
+    }),
     new UnsupportedVersionNotificationProvider(version),
   ];
 

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-info/components/version-list-item/VersionListItem.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-info/components/version-list-item/VersionListItem.tsx
@@ -2,9 +2,23 @@ import { messages } from '../../../../../../shared/gettext';
 import { Icon } from '../../../../../lib/components';
 import { ListItem, ListItemProps } from '../../../../../lib/components/list-item';
 import { useVersionCurrent } from '../../../../../redux/hooks';
+import { isPlatform } from '../../../../../utils';
 import { useShowAlert, useShowFooter } from './hooks';
 
 export type VersionListItemProps = Omit<ListItemProps, 'children'>;
+
+function getOutOfSyncMessage() {
+  if (isPlatform('linux')) {
+    // TRANSLATORS: Description for version list item when app is out of sync.
+    return messages.pgettext(
+      'app-info-view',
+      'App is out of sync. Please quit and restart the app or daemon.',
+    );
+  }
+
+  // TRANSLATORS: Description for version list item when app is out of sync.
+  return messages.pgettext('app-info-view', 'App is out of sync. Please quit and restart.');
+}
 
 export function VersionListItem(props: VersionListItemProps) {
   const { current } = useVersionCurrent();
@@ -29,12 +43,7 @@ export function VersionListItem(props: VersionListItemProps) {
       </ListItem.Item>
       {showFooter && (
         <ListItem.Footer>
-          <ListItem.Footer.Text>
-            {
-              // TRANSLATORS: Description for version list item when app is out of sync.
-              messages.pgettext('app-info-view', 'App is out of sync. Please quit and restart.')
-            }
-          </ListItem.Footer.Text>
+          <ListItem.Footer.Text>{getOutOfSyncMessage()}</ListItem.Footer.Text>
         </ListItem.Footer>
       )}
     </ListItem>

--- a/desktop/packages/mullvad-vpn/src/shared/notifications/inconsistent-version.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/notifications/inconsistent-version.ts
@@ -10,6 +10,7 @@ import {
 
 interface InconsistentVersionNotificationContext {
   consistent: boolean;
+  platform: NodeJS.Platform;
 }
 
 export class InconsistentVersionNotificationProvider
@@ -23,8 +24,16 @@ export class InconsistentVersionNotificationProvider
     process.env.NODE_ENV !== 'development';
 
   public getSystemNotification(): SystemNotification {
+    const message =
+      this.context.platform === 'linux'
+        ? messages.pgettext(
+            'notifications',
+            'App is out of sync. Please quit and restart the app or daemon.',
+          )
+        : messages.pgettext('notifications', 'App is out of sync. Please quit and restart.');
+
     return {
-      message: messages.pgettext('notifications', 'App is out of sync. Please quit and restart.'),
+      message,
       category: SystemNotificationCategory.inconsistentVersion,
       severity: SystemNotificationSeverityType.high,
       presentOnce: { value: true, name: this.constructor.name },
@@ -33,10 +42,15 @@ export class InconsistentVersionNotificationProvider
   }
 
   public getInAppNotification(): InAppNotification {
+    const subtitle =
+      this.context.platform === 'linux'
+        ? messages.pgettext('in-app-notifications', 'Please quit and restart the app or daemon.')
+        : messages.pgettext('in-app-notifications', 'Please quit and restart the app.');
+
     return {
       indicator: 'error',
       title: messages.pgettext('in-app-notifications', 'APP IS OUT OF SYNC'),
-      subtitle: messages.pgettext('in-app-notifications', 'Please quit and restart the app.'),
+      subtitle,
     };
   }
 }

--- a/desktop/packages/mullvad-vpn/test/unit/notification-evaluation.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/unit/notification-evaluation.spec.ts
@@ -5,6 +5,7 @@ import { TunnelState } from '../../src/shared/daemon-rpc-types';
 import { ErrorStateCause } from '../../src/shared/daemon-rpc-types';
 import { FirewallPolicyErrorType } from '../../src/shared/daemon-rpc-types';
 import {
+  InconsistentVersionNotificationProvider,
   UnsupportedVersionNotificationProvider,
   UpdateAvailableNotificationProvider,
 } from '../../src/shared/notifications';
@@ -37,6 +38,34 @@ function createController() {
     showNotificationIcon: vi.fn(),
   });
 }
+
+describe('Inconsistent version notifications', () => {
+  it('should mention the daemon in inconsistent version notifications on Linux', () => {
+    const notification = new InconsistentVersionNotificationProvider({
+      consistent: false,
+      platform: 'linux',
+    });
+
+    expect(notification.getSystemNotification().message).toBe(
+      'App is out of sync. Please quit and restart the app or daemon.',
+    );
+    expect(notification.getInAppNotification().subtitle).toBe(
+      'Please quit and restart the app or daemon.',
+    );
+  });
+
+  it('should keep the existing inconsistent version notifications on other platforms', () => {
+    const notification = new InconsistentVersionNotificationProvider({
+      consistent: false,
+      platform: 'darwin',
+    });
+
+    expect(notification.getSystemNotification().message).toBe(
+      'App is out of sync. Please quit and restart.',
+    );
+    expect(notification.getInAppNotification().subtitle).toBe('Please quit and restart the app.');
+  });
+});
 
 describe('System notifications', () => {
   it('should evaluate unspupported version notification to show', () => {


### PR DESCRIPTION
## What

- mention restarting the daemon in version mismatch messages on Linux
- keep the existing messages on macOS and Windows
- update the translation template and changelog

## Why

Restarting only the app does not resolve a version mismatch when an older daemon is still running, so the current message can be misleading on Linux

Fixes #10925

## How

Pass the current platform to the inconsistent version notification provider and select the Linux-specific message in every place where the mismatch is shown

## Test

- `npm test`
- `npm run lint`
- `npm run -w mullvad-vpn type-check`
- `npm run -w mullvad-vpn build`
- `npm run -w mullvad-vpn build:test`
- `npm run -w mullvad-vpn e2e:no-build -- --reporter=line`
- `scripts/localization verify`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10974)
<!-- Reviewable:end -->
