### PR TITLE
Fix searchfield bugs

### DIFF
--- a/ios/MullvadVPN/Extensions/Image+Assets.swift
+++ b/ios/MullvadVPN/Extensions/Image+Assets.swift
@@ -1,12 +1,7 @@
 import SwiftUI
 
 extension Image {
-    static var mullvadIconClose: some View {
-        Image("IconClose")
-            .resizable()
-            .frame(width: 25, height: 25)
-    }
-
+    static let mullvadIconClose = Image("IconClose")
     static let mullvadLogoImage = Image("LogoIcon")
     static let mullvadLogoText = Image("LogoText")
     static let mullvadIconSettings = Image("IconSettings")

--- a/ios/MullvadVPN/View controllers/DeviceList/DeviceListView.swift
+++ b/ios/MullvadVPN/View controllers/DeviceList/DeviceListView.swift
@@ -67,7 +67,7 @@ struct DeviceListView: View {
                                     .frame(width: 24, height: 24)
                                     .accessibilityIdentifier(.deviceRemovalProgressView)
                             } else {
-                                Image.mullvadIconClose
+                                ResizableImageView(image: .mullvadIconCross, dimension: .height(24))
                             }
                         }
                     }

--- a/ios/MullvadVPN/View controllers/SelectLocation/Views/FloatingSearchBar.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/Views/FloatingSearchBar.swift
@@ -21,7 +21,8 @@ struct FloatingSearchBar: View {
                     isFocused: isFocused,
                     borderStyle: .constant(.none),
                     appearance: InputViewAppearance(
-                        cornerRadius: 28.0,
+                        clearButtonImage: .mullvadIconClose,
+                        cornerRadius: 24.0,
                         backgroundColor: Color.mullvadContainerBackground,
                         height: 48.0,
                         spacing: 0
@@ -58,6 +59,7 @@ struct FloatingSearchBar: View {
                         .frame(width: 48, height: 48)
                         .background(Color.mullvadContainerBackground)
                         .clipShape(Circle())
+                        .padding(.leading, 12)
                 }
                 .accessibilityLabel(Text("Close search"))
                 .accessibilityIdentifier(.closeSearchButton)
@@ -72,7 +74,7 @@ struct FloatingSearchBar: View {
                     searchIcon
                         .frame(width: 48, height: 48)
                         .background {
-                            RoundedRectangle(cornerRadius: 28)
+                            RoundedRectangle(cornerRadius: 24)
                                 .fill(Color.mullvadContainerBackground)
                                 .matchedGeometryEffect(id: AnimationID.searchBackground, in: animation)
                         }

--- a/ios/MullvadVPN/Views/List/MullvadListActionItemView.swift
+++ b/ios/MullvadVPN/Views/List/MullvadListActionItemView.swift
@@ -107,7 +107,7 @@ struct MullvadListActionItemView<Icon: View>: View {
                 content: { item in
                     MullvadListActionItemView(item: item) {
                         if item.pressed != nil {
-                            Image.mullvadIconClose
+                            ResizableImageView(image: .mullvadIconCross, dimension: .height(24))
                         }
                     }
                 }

--- a/ios/MullvadVPN/Views/Textfield/ConfigurableTextField.swift
+++ b/ios/MullvadVPN/Views/Textfield/ConfigurableTextField.swift
@@ -179,7 +179,7 @@ struct ConfigurableTextField: View {
             Button {
                 text = ""
             } label: {
-                ResizableImageView(image: .mullvadIconCross, dimension: .width(24.0))
+                ResizableImageView(image: appearance.clearButtonImage, dimension: .width(24.0))
             }
             .buttonStyle(.plain)
             .padding(.horizontal, 8.0)

--- a/ios/MullvadVPN/Views/Textfield/InputViewAppearance.swift
+++ b/ios/MullvadVPN/Views/Textfield/InputViewAppearance.swift
@@ -10,11 +10,12 @@ import SwiftUI
 struct InputViewAppearance {
     var titleFont: Font = .mullvadTinySemiBold
     var font: Font = .mullvadSmall
-    var foregroundColor: Color = Color.MullvadTextField.textInput
-    var placeholderColor: Color = Color.MullvadTextField.inputPlaceholder
+    var foregroundColor: Color = .MullvadTextField.textInput
+    var placeholderColor: Color = .MullvadTextField.inputPlaceholder
+    var clearButtonImage: Image = .mullvadIconCross
     var cornerRadius: CGFloat = 4.0
     var messageFont: Font = .mullvadTiny
-    var backgroundColor: Color = Color.MullvadTextField.background
+    var backgroundColor: Color = .MullvadTextField.background
     var height: CGFloat
     var spacing: CGFloat = 4.0
 }


### PR DESCRIPTION
**What is being observed?**

The search field is a bit wonky. There's no gap between the close button and the text field. Further, when text has been entered into the control, the icon used to clear all text should be different.

https://www.figma.com/design/y8E9RxixW4KbawGRbvoMFV/iOS---Master--Source-of-Truth-?node-id=6272-77366&t=wfchruJNifmDvJ8a-1

**Reproduction steps**

- Open location view
- Click on search button
- Observe discrepancy

**What needs to be done to fix this?**

- Add padding between the field and the close button
- Ensure that the correct clear icon is used to clear text from search field
- Ensure that no other component is changed (such as the login entry field)

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10978)
<!-- Reviewable:end -->
