### PR TITLE
Try extremely long timeout for purchase tests

### DIFF
--- a/ios/MullvadVPNUITests/Pages/PaymentPage.swift
+++ b/ios/MullvadVPNUITests/Pages/PaymentPage.swift
@@ -113,13 +113,13 @@ class PaymentPage: Page {
     }
 
     @discardableResult func submitRenewSubscriptionSheet() -> Self {
-        springboard.buttons["Buy"].tapWhenHittable(timeout: .veryLong)
+        springboard.buttons["Buy"].tapWhenHittable(timeout: .extremelyLong)
 
         return self
     }
 
     @discardableResult func submitPurchaseFinishedAlert() -> Self {
-        springboard.buttons["OK"].tapWhenHittable(timeout: .veryLong)
+        springboard.buttons["OK"].tapWhenHittable(timeout: .extremelyLong)
 
         return self
     }


### PR DESCRIPTION
Currently, the payment tests time out before the dialog finishes. Let's try and use the _extremely_ long timeout to see if this helps. If this hurts test run times too much - let's halve the timeout.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10980)
<!-- Reviewable:end -->
