### PR TITLE
Fix exit hop not being clickable if a filter chip was showing

### DIFF
--- a/android/lib/feature/location/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/location/impl/SelectLocationScreen.kt
+++ b/android/lib/feature/location/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/location/impl/SelectLocationScreen.kt
@@ -912,7 +912,7 @@ private fun SelectionContainer(
                     constrain(filters) {
                         linkTo(start = parent.start, end = parent.end)
                         bottom.linkTo(parent.top)
-                        visibility = Visibility.Invisible
+                        visibility = Visibility.Gone
                     }
                 }
 


### PR DESCRIPTION
If the filter list was just set to invisible it would "steal" the clicks from the exit hop. Setting it to `gone` fixes this.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10981)
<!-- Reviewable:end -->
