### PR TITLE
Validate multiplexer handshake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6778,6 +6778,7 @@ name = "tunnel-obfuscation"
 version = "0.0.0"
 dependencies = [
  "async-trait",
+ "blake2",
  "bytes",
  "criterion",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ license = "GPL-3.0-or-later"
 [workspace.dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
+blake2 = "0.10.6"
 bytes = "1.11.1"
 chrono = { version = "0.4.26", default-features = false }
 clap = { version = "4.4.18", features = ["cargo", "derive"] }

--- a/talpid-wireguard/src/obfuscation.rs
+++ b/talpid-wireguard/src/obfuscation.rs
@@ -30,7 +30,11 @@ use tunnel_obfuscation::{
 #[derive(Debug, Clone)]
 pub enum ObfuscationSettings {
     Single(tunnel_obfuscation::Settings),
-    Multiplexer(Vec<tunnel_obfuscation::multiplexer::Transport>),
+    Multiplexer {
+        transports: Vec<tunnel_obfuscation::multiplexer::Transport>,
+        /// Public key of the local WireGuard instance
+        client_public_key: PublicKey,
+    },
 }
 
 impl ObfuscationSettings {
@@ -38,7 +42,7 @@ impl ObfuscationSettings {
     pub fn single(&self) -> Option<&tunnel_obfuscation::Settings> {
         match self {
             ObfuscationSettings::Single(settings) => Some(settings),
-            ObfuscationSettings::Multiplexer(_) => None,
+            ObfuscationSettings::Multiplexer { .. } => None,
         }
     }
 
@@ -46,7 +50,7 @@ impl ObfuscationSettings {
     pub fn packet_overhead(&self) -> u16 {
         match self {
             ObfuscationSettings::Single(settings) => settings.packet_overhead(),
-            ObfuscationSettings::Multiplexer(transports) => {
+            ObfuscationSettings::Multiplexer { transports, .. } => {
                 multiplexer::packet_overhead(transports)
             }
         }
@@ -76,10 +80,14 @@ pub async fn spawn_local_socket_obfuscator(
                 .await
                 .map_err(Error::ObfuscationError)?
         }
-        ObfuscationSettings::Multiplexer(transports) => {
+        ObfuscationSettings::Multiplexer {
+            transports,
+            client_public_key,
+        } => {
             let (selected_transport_tx, selected_transport) = oneshot::channel();
             let settings = multiplexer::Settings {
                 transports,
+                client_public_key,
                 selected_transport: selected_transport_tx,
             };
             // The multiplexer connects to one out of several endpoints, and only commits to one
@@ -168,7 +176,10 @@ pub fn settings_from_config(
                 );
                 transports.push(multiplexer::Transport::Obfuscated(settings));
             }
-            ObfuscationSettings::Multiplexer(transports)
+            ObfuscationSettings::Multiplexer {
+                transports,
+                client_public_key,
+            }
         }
     }
 }

--- a/tunnel-obfuscation/Cargo.toml
+++ b/tunnel-obfuscation/Cargo.toml
@@ -20,6 +20,7 @@ name = "multiplexer_throughput"
 
 [dependencies]
 async-trait = { workspace = true }
+blake2 = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }

--- a/tunnel-obfuscation/benches/multiplexer_throughput.rs
+++ b/tunnel-obfuscation/benches/multiplexer_throughput.rs
@@ -7,13 +7,19 @@
 //!
 //! The difference is what the multiplexer costs on top of the obfuscator itself.
 
+use blake2::{
+    Blake2s256, Blake2sMac, Digest,
+    digest::{Mac, consts::U16},
+};
 use core::hint::black_box;
 use criterion::{Criterion, criterion_group, criterion_main};
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{net::SocketAddr, ops::Range, sync::Arc, time::Duration};
 use talpid_net::bypass::NoopBypass;
 use talpid_types::net::{obfuscation::LwoVersion, wireguard::PublicKey};
 use tokio::{net::UdpSocket, sync::oneshot};
 use tunnel_obfuscation::{LocalSocketObfuscator, lwo, multiplexer};
+
+const SESSION: u32 = 1;
 
 /// Control: plain UDP send and receive, with nothing in between.
 fn bench_plain_udp(c: &mut Criterion) {
@@ -60,6 +66,7 @@ fn bench_multiplexer_lwo(c: &mut Criterion) {
             transports: vec![multiplexer::Transport::Obfuscated(lwo_settings(
                 relay.local_addr().unwrap(),
             ))],
+            client_public_key: keys().0,
             selected_transport: selected_tx,
         };
         let multiplexer = multiplexer::Multiplexer::new(Arc::new(NoopBypass), settings)
@@ -72,7 +79,7 @@ fn bench_multiplexer_lwo(c: &mut Criterion) {
 
         // Reply, so that the multiplexer commits to this transport and enters connected mode.
         let (client_key, _) = keys();
-        let mut response = wg_data_packet();
+        let mut response = handshake_response(SESSION, &client_key).to_vec();
         lwo::obfuscate_thread_local(&mut response, client_key.as_bytes());
         let mut buf = vec![0u8; 65535];
         loop {
@@ -119,7 +126,8 @@ async fn warm_up(endpoint: SocketAddr, relay: &UdpSocket) -> (UdpSocket, SocketA
     let wg = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     wg.connect(endpoint).await.unwrap();
 
-    let packet = wg_data_packet();
+    // A handshake initiation, so that the multiplexer will recognize the response to it.
+    let packet = handshake_initiation(SESSION);
     let mut buf = vec![0u8; 65535];
     loop {
         wg.send(&packet).await.unwrap();
@@ -161,6 +169,58 @@ fn keys() -> (PublicKey, PublicKey) {
     let client = PublicKey::from_base64("8Ka2l4T0tVrSR5pkcsvRG++mBlxfuf8XOxpqBkOCikU=").unwrap();
     let server = PublicKey::from_base64("4EkA4c160oQgN/YaNR9GN3gLMevXEfx5hnlc9jYmw14=").unwrap();
     (client, server)
+}
+
+// First byte of each type of message.
+const HANDSHAKE_INITIATION: u8 = 1;
+const HANDSHAKE_RESPONSE: u8 = 2;
+
+// Handshake messages are a fixed size, so anything else is not one.
+const HANDSHAKE_INITIATION_SIZE: usize = 148;
+const HANDSHAKE_RESPONSE_SIZE: usize = 92;
+
+// Field offsets. `mac1` sits at the end of a response and covers every byte before it.
+const SENDER_INDEX: Range<usize> = 4..8;
+const RESPONSE_RECEIVER_INDEX: Range<usize> = 8..12;
+const RESPONSE_MAC1: Range<usize> = 60..76;
+
+/// Build a handshake initiation carrying `sender_index`. Only the fields that identify the
+/// handshake are filled in.
+fn handshake_initiation(sender_index: u32) -> [u8; HANDSHAKE_INITIATION_SIZE] {
+    let mut packet = [0u8; HANDSHAKE_INITIATION_SIZE];
+    packet[0] = HANDSHAKE_INITIATION;
+    packet[SENDER_INDEX].copy_from_slice(&sender_index.to_le_bytes());
+    packet
+}
+
+/// Build a handshake response to the initiation that carried `receiver_index`, with a `mac1` that
+/// accepts for `client_public_key`.
+fn handshake_response(
+    receiver_index: u32,
+    client_public_key: &PublicKey,
+) -> [u8; HANDSHAKE_RESPONSE_SIZE] {
+    let mut packet = [0u8; HANDSHAKE_RESPONSE_SIZE];
+    packet[0] = HANDSHAKE_RESPONSE;
+    packet[RESPONSE_RECEIVER_INDEX].copy_from_slice(&receiver_index.to_le_bytes());
+    let mac = mac1(&mac1_key(client_public_key)).chain_update(&packet[..RESPONSE_MAC1.start]);
+    packet[RESPONSE_MAC1].copy_from_slice(&mac.finalize().into_bytes());
+    packet
+}
+
+/// Keyed BLAKE2s with a 16 byte output.
+type Mac1 = Blake2sMac<U16>;
+
+/// The key that `mac1` of a message addressed to `public_key` is computed with.
+fn mac1_key(public_key: &PublicKey) -> [u8; 32] {
+    Blake2s256::new()
+        .chain_update(b"mac1----")
+        .chain_update(public_key.as_bytes())
+        .finalize()
+        .into()
+}
+
+fn mac1(key: &[u8; 32]) -> Mac1 {
+    <Mac1 as Mac>::new_from_slice(key).expect("the mac1 key is 32 bytes")
 }
 
 criterion_group!(

--- a/tunnel-obfuscation/src/lib.rs
+++ b/tunnel-obfuscation/src/lib.rs
@@ -12,6 +12,7 @@ pub mod shadowsocks;
 pub mod socket;
 pub mod transport;
 pub mod udp2tcp;
+pub(crate) mod wireguard;
 
 pub use transport::ObfuscatedTransport;
 

--- a/tunnel-obfuscation/src/lwo/mod.rs
+++ b/tunnel-obfuscation/src/lwo/mod.rs
@@ -10,7 +10,14 @@ use talpid_net::bypass::{BypassSocket, SocketBypass};
 use talpid_types::net::{obfuscation::LwoVersion, wireguard::PublicKey};
 use tokio::net::UdpSocket;
 
-use crate::{socket::create_remote_socket, transport::ObfuscatedTransport};
+use crate::{
+    socket::create_remote_socket,
+    transport::ObfuscatedTransport,
+    wireguard::{
+        COOKIE_REPLY, COOKIE_REPLY_SIZE, DATA, DATA_OVERHEAD_SIZE, HANDSHAKE_INITIATION,
+        HANDSHAKE_INITIATION_SIZE, HANDSHAKE_RESPONSE, HANDSHAKE_RESPONSE_SIZE,
+    },
+};
 
 #[derive(Debug, Clone)]
 pub struct Settings {
@@ -136,18 +143,6 @@ impl ObfuscatedTransport for Lwo {
     }
 }
 
-// WG message types, copied from gotatun
-type MessageType = u8;
-const HANDSHAKE_INIT: MessageType = 1;
-const HANDSHAKE_RESP: MessageType = 2;
-const COOKIE_REPLY: MessageType = 3;
-const DATA: MessageType = 4;
-
-const HANDSHAKE_INIT_SZ: usize = 148;
-const HANDSHAKE_RESP_SZ: usize = 92;
-const COOKIE_REPLY_SZ: usize = 64;
-const DATA_OVERHEAD_SZ: usize = 32;
-
 /// Bit to set in the second byte of the WG header to enable LWO
 const OBFUSCATION_BIT: u8 = 0b10000000;
 
@@ -186,10 +181,10 @@ const fn is_obfuscated(reserved_byte: u8) -> bool {
 fn header_mut(packet: &mut [u8], key_byte: u8) -> Option<&mut [u8]> {
     let &header_type = packet.first()?;
     match header_type ^ key_byte {
-        HANDSHAKE_INIT => packet.get_mut(..HANDSHAKE_INIT_SZ),
-        HANDSHAKE_RESP => packet.get_mut(..HANDSHAKE_RESP_SZ),
-        COOKIE_REPLY => packet.get_mut(..COOKIE_REPLY_SZ),
-        DATA => packet.get_mut(..DATA_OVERHEAD_SZ),
+        HANDSHAKE_INITIATION => packet.get_mut(..HANDSHAKE_INITIATION_SIZE),
+        HANDSHAKE_RESPONSE => packet.get_mut(..HANDSHAKE_RESPONSE_SIZE),
+        COOKIE_REPLY => packet.get_mut(..COOKIE_REPLY_SIZE),
+        DATA => packet.get_mut(..DATA_OVERHEAD_SIZE),
         _ => None,
     }
 }
@@ -229,9 +224,9 @@ mod test {
     }
 
     fn fake_packet() -> Vec<u8> {
-        let mut packet = vec![0u8; DATA_OVERHEAD_SZ + 100];
+        let mut packet = vec![0u8; DATA_OVERHEAD_SIZE + 100];
         packet[0] = DATA;
-        rand::rng().fill_bytes(&mut packet[DATA_OVERHEAD_SZ..]);
+        rand::rng().fill_bytes(&mut packet[DATA_OVERHEAD_SIZE..]);
         packet
     }
 
@@ -246,8 +241,8 @@ mod test {
         obfuscate(&mut rng, &mut packet, &key);
         assert_ne!(packet, original_packet);
         assert_eq!(
-            packet[DATA_OVERHEAD_SZ..],
-            original_packet[DATA_OVERHEAD_SZ..],
+            packet[DATA_OVERHEAD_SIZE..],
+            original_packet[DATA_OVERHEAD_SIZE..],
             "payload should be unchanged"
         );
 
@@ -347,8 +342,8 @@ mod test {
         tokio::spawn(lwo.run());
 
         // Send a handshake initiation, verify it arrives padded and deobfuscates to the original
-        let mut packet = vec![0u8; HANDSHAKE_INIT_SZ];
-        packet[0] = HANDSHAKE_INIT;
+        let mut packet = vec![0u8; HANDSHAKE_INITIATION_SIZE];
+        packet[0] = HANDSHAKE_INITIATION;
         rand::rng().fill_bytes(&mut packet[4..]);
 
         wg_socket
@@ -358,18 +353,21 @@ mod test {
 
         let mut buf = vec![0u8; 1500];
         let (n, addr) = endpoint.recv_from(&mut buf).await.unwrap();
-        assert!(n > HANDSHAKE_INIT_SZ, "handshake should have been padded");
+        assert!(
+            n > HANDSHAKE_INITIATION_SIZE,
+            "handshake should have been padded"
+        );
         assert_eq!(
             v2::deobfuscate(&mut buf[..n], key),
             v2::Verdict::Lwo {
-                trim_to: Some(HANDSHAKE_INIT_SZ)
+                trim_to: Some(HANDSHAKE_INITIATION_SIZE)
             }
         );
-        assert_eq!(&buf[..HANDSHAKE_INIT_SZ], packet);
+        assert_eq!(&buf[..HANDSHAKE_INITIATION_SIZE], packet);
 
         // Send a padded handshake response back, verify the client trims it
-        let mut response = vec![0u8; HANDSHAKE_RESP_SZ];
-        response[0] = HANDSHAKE_RESP;
+        let mut response = vec![0u8; HANDSHAKE_RESPONSE_SIZE];
+        response[0] = HANDSHAKE_RESPONSE;
         rand::rng().fill_bytes(&mut response[4..]);
 
         let mut obfuscated = v2::pad(&response).expect("a handshake is padded");

--- a/tunnel-obfuscation/src/lwo/v2.rs
+++ b/tunnel-obfuscation/src/lwo/v2.rs
@@ -8,21 +8,13 @@
 
 use rand::{Rng, RngCore};
 
-// WG message types
-type MessageType = u8;
-const HANDSHAKE_INIT: MessageType = 1;
-const HANDSHAKE_RESP: MessageType = 2;
-const COOKIE_REPLY: MessageType = 3;
-const DATA: MessageType = 4;
+use crate::wireguard::{
+    COOKIE_REPLY, DATA, DATA_OVERHEAD_SIZE, HANDSHAKE_INITIATION, HANDSHAKE_INITIATION_SIZE,
+    HANDSHAKE_RESPONSE, HANDSHAKE_RESPONSE_SIZE,
+};
 
-/// Protected (obfuscated) area of a handshake initiation. Also its plaintext size.
-const HANDSHAKE_INIT_SZ: usize = 148;
-/// Protected (obfuscated) area of a handshake response. Also its plaintext size.
-const HANDSHAKE_RESP_SZ: usize = 92;
 /// Protected (obfuscated) area of a data packet.
-const DATA_PROTECTED_SZ: usize = 16;
-/// Minimum size of a valid data packet.
-const DATA_MIN_SZ: usize = 32;
+const DATA_PROTECTED_SIZE: usize = 16;
 
 /// Maximum number of random padding bytes appended to outgoing handshake packets.
 const MAX_PADDING: usize = 256;
@@ -67,7 +59,7 @@ pub enum Verdict {
 fn takes_padding(packet: &[u8]) -> bool {
     matches!(
         packet.first(),
-        Some(&HANDSHAKE_INIT) | Some(&HANDSHAKE_RESP)
+        Some(&HANDSHAKE_INITIATION) | Some(&HANDSHAKE_RESPONSE)
     )
 }
 
@@ -96,9 +88,9 @@ pub fn obfuscate(packet: &mut [u8], key: &[u8; 32]) {
         return;
     };
     let protected_len = match message_type {
-        HANDSHAKE_INIT => HANDSHAKE_INIT_SZ,
-        HANDSHAKE_RESP => HANDSHAKE_RESP_SZ,
-        DATA => DATA_PROTECTED_SZ,
+        HANDSHAKE_INITIATION => HANDSHAKE_INITIATION_SIZE,
+        HANDSHAKE_RESPONSE => HANDSHAKE_RESPONSE_SIZE,
+        DATA => DATA_PROTECTED_SIZE,
         // Cookie replies must not be obfuscated. Unknown types are left alone.
         _ => return,
     };
@@ -121,7 +113,7 @@ pub fn obfuscate(packet: &mut [u8], key: &[u8; 32]) {
 pub fn deobfuscate(packet: &mut [u8], key: &[u8; 32]) -> Verdict {
     // The shortest valid LWO v2 packet is a 32-byte data packet, but byte 1 decides whether the
     // packet claims LWO v2 at all.
-    if packet.len() < DATA_MIN_SZ {
+    if packet.len() < DATA_OVERHEAD_SIZE {
         return match packet.get(1) {
             Some(&reserved) if claims_lwo(reserved) => Verdict::Invalid,
             _ => Verdict::Plain,
@@ -141,17 +133,23 @@ pub fn deobfuscate(packet: &mut [u8], key: &[u8; 32]) -> Verdict {
 
     let message_type = packet[0] ^ key[0].wrapping_add(len_mix);
     let (protected_len, valid_len, trim_to) = match message_type {
-        HANDSHAKE_INIT => (
-            HANDSHAKE_INIT_SZ,
-            (HANDSHAKE_INIT_SZ..=HANDSHAKE_INIT_SZ + MAX_PADDING).contains(&packet.len()),
-            Some(HANDSHAKE_INIT_SZ),
+        HANDSHAKE_INITIATION => (
+            HANDSHAKE_INITIATION_SIZE,
+            (HANDSHAKE_INITIATION_SIZE..=HANDSHAKE_INITIATION_SIZE + MAX_PADDING)
+                .contains(&packet.len()),
+            Some(HANDSHAKE_INITIATION_SIZE),
         ),
-        HANDSHAKE_RESP => (
-            HANDSHAKE_RESP_SZ,
-            (HANDSHAKE_RESP_SZ..=HANDSHAKE_RESP_SZ + MAX_PADDING).contains(&packet.len()),
-            Some(HANDSHAKE_RESP_SZ),
+        HANDSHAKE_RESPONSE => (
+            HANDSHAKE_RESPONSE_SIZE,
+            (HANDSHAKE_RESPONSE_SIZE..=HANDSHAKE_RESPONSE_SIZE + MAX_PADDING)
+                .contains(&packet.len()),
+            Some(HANDSHAKE_RESPONSE_SIZE),
         ),
-        DATA => (DATA_PROTECTED_SZ, packet.len() >= DATA_MIN_SZ, None),
+        DATA => (
+            DATA_PROTECTED_SIZE,
+            packet.len() >= DATA_OVERHEAD_SIZE,
+            None,
+        ),
         // Cookie replies are never LWO v2 packets. They must be plain.
         COOKIE_REPLY => return Verdict::Invalid,
         // Unknown WireGuard type.
@@ -215,28 +213,31 @@ mod test {
 
     #[test]
     fn handshake_init_roundtrip() {
-        let original = fake_packet(HANDSHAKE_INIT, HANDSHAKE_INIT_SZ);
+        let original = fake_packet(HANDSHAKE_INITIATION, HANDSHAKE_INITIATION_SIZE);
         let mut packet = original.clone();
 
         pad_and_obfuscate(&mut packet);
         let padded_len = packet.len();
-        assert!((HANDSHAKE_INIT_SZ + 1..=HANDSHAKE_INIT_SZ + MAX_PADDING).contains(&padded_len));
+        assert!(
+            (HANDSHAKE_INITIATION_SIZE + 1..=HANDSHAKE_INITIATION_SIZE + MAX_PADDING)
+                .contains(&padded_len)
+        );
         assert!(claims_lwo(packet[1]));
-        assert_ne!(packet[..HANDSHAKE_INIT_SZ], original[..]);
+        assert_ne!(packet[..HANDSHAKE_INITIATION_SIZE], original[..]);
 
         let verdict = deobfuscate(&mut packet, &KEY);
         assert_eq!(
             verdict,
             Verdict::Lwo {
-                trim_to: Some(HANDSHAKE_INIT_SZ)
+                trim_to: Some(HANDSHAKE_INITIATION_SIZE)
             }
         );
-        assert_eq!(packet[..HANDSHAKE_INIT_SZ], original[..]);
+        assert_eq!(packet[..HANDSHAKE_INITIATION_SIZE], original[..]);
     }
 
     #[test]
     fn handshake_resp_roundtrip() {
-        let original = fake_packet(HANDSHAKE_RESP, HANDSHAKE_RESP_SZ);
+        let original = fake_packet(HANDSHAKE_RESPONSE, HANDSHAKE_RESPONSE_SIZE);
         let mut packet = original.clone();
 
         pad_and_obfuscate(&mut packet);
@@ -245,23 +246,23 @@ mod test {
         assert_eq!(
             verdict,
             Verdict::Lwo {
-                trim_to: Some(HANDSHAKE_RESP_SZ)
+                trim_to: Some(HANDSHAKE_RESPONSE_SIZE)
             }
         );
-        assert_eq!(packet[..HANDSHAKE_RESP_SZ], original[..]);
+        assert_eq!(packet[..HANDSHAKE_RESPONSE_SIZE], original[..]);
     }
 
     #[test]
     fn data_roundtrip() {
-        let original = fake_packet(DATA, DATA_MIN_SZ + 100);
+        let original = fake_packet(DATA, DATA_OVERHEAD_SIZE + 100);
         let mut packet = original.clone();
 
         pad_and_obfuscate(&mut packet);
         assert_eq!(packet.len(), original.len(), "data packets are not padded");
         assert!(claims_lwo(packet[1]));
         assert_eq!(
-            packet[DATA_PROTECTED_SZ..],
-            original[DATA_PROTECTED_SZ..],
+            packet[DATA_PROTECTED_SIZE..],
+            original[DATA_PROTECTED_SIZE..],
             "payload beyond the protected area should be unchanged"
         );
 
@@ -284,7 +285,7 @@ mod test {
 
     #[test]
     fn plain_wireguard_passes_through() {
-        let original = fake_packet(DATA, DATA_MIN_SZ + 100);
+        let original = fake_packet(DATA, DATA_OVERHEAD_SIZE + 100);
         let mut packet = original.clone();
         assert_eq!(deobfuscate(&mut packet, &KEY), Verdict::Plain);
         assert_eq!(packet, original);
@@ -293,7 +294,7 @@ mod test {
     #[test]
     fn tampered_packet_is_dropped() {
         for byte in 1..4 {
-            let mut packet = fake_packet(DATA, DATA_MIN_SZ + 100);
+            let mut packet = fake_packet(DATA, DATA_OVERHEAD_SIZE + 100);
             obfuscate(&mut packet, &KEY);
             packet[byte] ^= 0x01;
             // Flipping a bit in byte 1 may also clear the marker, making the packet plain.
@@ -323,17 +324,17 @@ mod test {
     #[test]
     fn invalid_lengths_are_dropped() {
         // A data packet shorter than 32 bytes claiming LWO.
-        let mut short_data = fake_packet(DATA, DATA_MIN_SZ - 1);
+        let mut short_data = fake_packet(DATA, DATA_OVERHEAD_SIZE - 1);
         obfuscate(&mut short_data, &KEY);
         // Force the marker in case the length made the packet skip obfuscation.
         short_data[1] = marker_byte(&KEY, short_data.len() as u8);
         assert_eq!(deobfuscate(&mut short_data, &KEY), Verdict::Invalid);
 
         // An over-padded handshake initiation.
-        let len = HANDSHAKE_INIT_SZ + MAX_PADDING + 1;
-        let mut oversized = fake_packet(HANDSHAKE_INIT, len);
+        let len = HANDSHAKE_INITIATION_SIZE + MAX_PADDING + 1;
+        let mut oversized = fake_packet(HANDSHAKE_INITIATION, len);
         let len_mix = len as u8;
-        oversized[0] = HANDSHAKE_INIT ^ KEY[0].wrapping_add(len_mix);
+        oversized[0] = HANDSHAKE_INITIATION ^ KEY[0].wrapping_add(len_mix);
         oversized[1] = marker_byte(&KEY, len_mix);
         oversized[2] = obfuscation_byte(&KEY, len_mix, 2);
         oversized[3] = obfuscation_byte(&KEY, len_mix, 3);
@@ -343,7 +344,7 @@ mod test {
     #[test]
     fn length_is_mixed_into_obfuscation() {
         // The same plaintext at two different padded lengths obfuscate differently.
-        let original = fake_packet(DATA, DATA_MIN_SZ + 100);
+        let original = fake_packet(DATA, DATA_OVERHEAD_SIZE + 100);
 
         let mut a = original.clone();
         obfuscate(&mut a, &KEY);
@@ -352,7 +353,7 @@ mod test {
         b.push(0);
         obfuscate(&mut b, &KEY);
 
-        assert_ne!(a[..DATA_PROTECTED_SZ], b[..DATA_PROTECTED_SZ]);
+        assert_ne!(a[..DATA_PROTECTED_SIZE], b[..DATA_PROTECTED_SIZE]);
 
         // And a packet deobfuscated at the wrong length does not validate.
         let mut truncated = a.clone();

--- a/tunnel-obfuscation/src/multiplexer.rs
+++ b/tunnel-obfuscation/src/multiplexer.rs
@@ -31,12 +31,14 @@ use std::{
 use async_trait::async_trait;
 use futures::{StreamExt, stream::FuturesUnordered};
 use talpid_net::bypass::SocketBypass;
+use talpid_types::net::wireguard::PublicKey;
 use tokio::{net::UdpSocket, sync::oneshot};
 use tokio_util::task::AbortOnDropHandle;
 
 use crate::{
     direct::Direct,
     transport::{MAX_DATAGRAM_SIZE, ObfuscatedTransport},
+    wireguard::{HandshakeFilter, Received},
 };
 
 /// How long to wait before spawning the next transport in the queue.
@@ -53,7 +55,8 @@ type TransportId = usize;
 ///
 /// The multiplexer operates in two phases:
 /// 1. **Discovery Phase**: Spawn transports progressively and fan out traffic to all of them
-/// 2. **Connected Phase**: Once a transport responds, switch to forwarding to that transport only
+/// 2. **Connected Phase**: Once a transport responds with a valid handshake response, switch to
+///    forwarding to that transport only
 pub struct Multiplexer {
     /// Local UDP socket that WireGuard connects to
     client_socket: UdpSocket,
@@ -61,6 +64,8 @@ pub struct Multiplexer {
     client_socket_addr: SocketAddr,
     /// Queue of transports to spawn (in priority order)
     pending: VecDeque<Transport>,
+    /// Public key of the local WireGuard instance.
+    client_public_key: PublicKey,
     /// Notified with the selected transport
     selected_transport_tx: SelectedTransportTx,
     bypass: Arc<dyn SocketBypass>,
@@ -96,6 +101,7 @@ impl Multiplexer {
             client_socket,
             client_socket_addr,
             pending: VecDeque::from(settings.transports),
+            client_public_key: settings.client_public_key,
             selected_transport_tx: settings.selected_transport,
             bypass,
         })
@@ -110,6 +116,7 @@ impl Multiplexer {
         let Self {
             client_socket,
             pending,
+            client_public_key,
             selected_transport_tx,
             bypass,
             ..
@@ -120,7 +127,13 @@ impl Multiplexer {
         client_socket.connect(wg_addr).await?;
         log::debug!("Local WireGuard instance connected from {wg_addr}");
 
-        let discovery = run_discovery(&client_socket, pending, bypass, selected_transport_tx);
+        let discovery = run_discovery(
+            &client_socket,
+            pending,
+            bypass,
+            &client_public_key,
+            selected_transport_tx,
+        );
         let Some(transport) = discovery.await? else {
             return Ok(());
         };
@@ -142,6 +155,7 @@ async fn run_discovery(
     client_socket: &UdpSocket,
     mut pending: VecDeque<Transport>,
     bypass: Arc<dyn SocketBypass>,
+    client_public_key: &PublicKey,
     selected_transport_tx: SelectedTransportTx,
 ) -> io::Result<Option<Arc<dyn ObfuscatedTransport>>> {
     enum Event {
@@ -155,6 +169,7 @@ async fn run_discovery(
 
     let mut running: Vec<RunningTransport> = vec![];
     let mut initial_packets: Vec<Box<[u8]>> = vec![];
+    let mut handshakes = HandshakeFilter::new(client_public_key);
 
     let mut wg_buf = vec![0u8; MAX_DATAGRAM_SIZE];
     let mut scratch = vec![0u8; MAX_DATAGRAM_SIZE];
@@ -188,6 +203,7 @@ async fn run_discovery(
                     return Err(io::Error::other("Too many initial packets"));
                 }
                 initial_packets.push(Box::from(packet));
+                handshakes.record_initiation(packet);
 
                 // Fan out the latest WG packet to all currently spawned transports.
                 for (id, running) in running.iter().enumerate() {
@@ -203,21 +219,38 @@ async fn run_discovery(
                 log::error!("Dropping transport {id}, which failed to receive traffic: {err}");
                 running.remove(id);
             }
-            Event::Transport(id, Ok(n)) => {
-                // A response means this transport reached the server, so use it from now on.
-                let selected = running.swap_remove(id);
-                log::debug!(
-                    "Selecting {:?} as the valid transport configuration",
-                    selected.config
-                );
-                client_socket.send(&selected.buf[..n]).await?;
+            Event::Transport(id, Ok(n)) => match handshakes.classify(&running[id].buf[..n]) {
+                // Not an answer to anything WireGuard sent. Whatever it is, it is no reason to
+                // believe this transport reaches the relay.
+                Received::Unrecognized => {
+                    log::debug!("Ignoring unsolicited packet from transport {id}");
+                }
 
-                // Announce the selected transport, so that the firewall can be restricted to
-                // the endpoint it committed to.
-                let _ = selected_transport_tx.send(selected.config);
+                // The relay is rate limiting us. WireGuard needs the cookie in order to retry the
+                // initiation with a valid `mac2`, but reaching a rate limiter is not proof that
+                // this transport carries a handshake, so keep fanning out.
+                Received::CookieReply => {
+                    log::debug!("Forwarding cookie reply from transport {id}");
+                    client_socket.send(&running[id].buf[..n]).await?;
+                }
 
-                return Ok(Some(selected.transport));
-            }
+                // A handshake response means this transport reached the relay, so use it from
+                // now on.
+                Received::HandshakeResponse => {
+                    let selected = running.swap_remove(id);
+                    log::debug!(
+                        "Selecting {:?} as the valid transport configuration",
+                        selected.config
+                    );
+                    client_socket.send(&selected.buf[..n]).await?;
+
+                    // Announce the selected transport, so that the firewall can be restricted to
+                    // the endpoint it committed to.
+                    let _ = selected_transport_tx.send(selected.config);
+
+                    return Ok(Some(selected.transport));
+                }
+            },
 
             Event::Spawn => {
                 let Some(config) = pending.pop_front() else {
@@ -336,6 +369,8 @@ pub struct Settings {
     /// Spawn these transports progressively and select
     /// the first one that successfully establishes a connection.
     pub transports: Vec<Transport>,
+    /// Public key of the local WireGuard instance.
+    pub client_public_key: PublicKey,
     /// Notified with the selected transport, once one has been selected. The value is only ever
     /// set once, as the multiplexer never reconsiders its choice.
     pub selected_transport: SelectedTransportTx,
@@ -387,12 +422,28 @@ impl crate::LocalSocketObfuscator for Multiplexer {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
-    use crate::LocalSocketObfuscator;
+    use crate::{
+        LocalSocketObfuscator,
+        wireguard::{handshake_initiation, handshake_response},
+    };
     use talpid_net::bypass::NoopBypass;
     use talpid_types::net::obfuscation::LwoVersion;
 
-    /// Test whether the multiplexer works with a direct transports
+    /// The index that the handshakes in these tests are for.
+    const SESSION: u32 = 7;
+
+    fn client_key() -> PublicKey {
+        PublicKey::from_base64("8Ka2l4T0tVrSR5pkcsvRG++mBlxfuf8XOxpqBkOCikU=").unwrap()
+    }
+
+    fn server_key() -> PublicKey {
+        PublicKey::from_base64("4EkA4c160oQgN/YaNR9GN3gLMevXEfx5hnlc9jYmw14=").unwrap()
+    }
+
+    /// Test whether the multiplexer works with direct transports
     #[tokio::test(start_paused = true)]
     async fn test_multiplexer_direct_forwarding() {
         let server_socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
@@ -401,13 +452,14 @@ mod tests {
         let server_socket2 = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let server_addr2 = server_socket2.local_addr().unwrap();
 
-        // Create multiplexer pointing to a single direct transport
+        // Create multiplexer pointing to direct transports
         let (selected_tx, selected_rx) = oneshot::channel();
         let settings = Settings {
             transports: vec![
                 Transport::Direct(server_addr),
                 Transport::Direct(server_addr2),
             ],
+            client_public_key: client_key(),
             selected_transport: selected_tx,
         };
 
@@ -423,11 +475,10 @@ mod tests {
             boxed_multiplexer.run().await
         });
 
-        // Send a test packet from client to multiplexer and verify that it is received
-        // NOTE: This may have to be an actual WireGuard handshake packet in the future
-        let test_data = b"Ping!";
+        // Send a handshake initiation from client to multiplexer and verify that it is received
+        let test_data = handshake_initiation(SESSION);
         client_socket
-            .send_to(test_data, multiplexer_endpoint)
+            .send_to(&test_data, multiplexer_endpoint)
             .await
             .unwrap();
 
@@ -441,10 +492,15 @@ mod tests {
             server_socket2.recv_from(&mut server_buf).await.unwrap();
         assert_eq!(&server_buf[..bytes_received], test_data);
 
-        // Send a response back from the first server
-        let response_data = b"Pong!";
+        // A packet that answers nothing must neither select a transport nor be forwarded. If it
+        // were forwarded, the client would read it below instead of the handshake response.
+        server_socket.send_to(b"Pong!", client_addr).await.unwrap();
+        tokio::task::yield_now().await;
+
+        // Send a handshake response back from the first server
+        let response_data = handshake_response(SESSION, &client_key());
         server_socket
-            .send_to(response_data, client_addr)
+            .send_to(&response_data, client_addr)
             .await
             .unwrap();
 
@@ -489,14 +545,75 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    async fn test_multiplexer_ignores_invalid_handshake_responses() {
+        let liar = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let liar_addr = liar.local_addr().unwrap();
+
+        let relay = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let relay_addr = relay.local_addr().unwrap();
+
+        let (selected_tx, mut selected_rx) = oneshot::channel();
+        let settings = Settings {
+            transports: vec![Transport::Direct(liar_addr), Transport::Direct(relay_addr)],
+            client_public_key: client_key(),
+            selected_transport: selected_tx,
+        };
+
+        let multiplexer = Multiplexer::new(Arc::new(NoopBypass), settings)
+            .await
+            .unwrap();
+        let multiplexer_endpoint = multiplexer.endpoint();
+        tokio::spawn(Box::new(multiplexer).run());
+
+        let wg_socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        wg_socket
+            .send_to(&handshake_initiation(SESSION), multiplexer_endpoint)
+            .await
+            .unwrap();
+
+        let mut buf = vec![0u8; 1024];
+        let (_, liar_client_addr) = liar.recv_from(&mut buf).await.unwrap();
+        let (_, relay_client_addr) = relay.recv_from(&mut buf).await.unwrap();
+
+        // None of these answers the initiation that was sent.
+        let junk = b"Pong!".to_vec();
+        let wrong_session = handshake_response(SESSION + 1, &client_key()).to_vec();
+        let wrong_key = handshake_response(SESSION, &server_key()).to_vec();
+        let mut tampered = handshake_response(SESSION, &client_key()).to_vec();
+        tampered[12] ^= 1;
+
+        for packet in [junk, wrong_session, wrong_key, tampered] {
+            liar.send_to(&packet, liar_client_addr).await.unwrap();
+            // Time only advances once every task is idle, so this drains the multiplexer.
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            assert_matches!(
+                selected_rx.try_recv(),
+                Err(oneshot::error::TryRecvError::Empty),
+                "a packet that answers no initiation selected a transport",
+            );
+        }
+
+        // This one does.
+        let response = handshake_response(SESSION, &client_key()).to_vec();
+        relay.send_to(&response, relay_client_addr).await.unwrap();
+
+        // WireGuard should see the valid response, and nothing the liar sent before it.
+        let (n, _) = wg_socket.recv_from(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], &response[..]);
+
+        let selected = selected_rx.await.unwrap();
+        assert_matches!(
+            selected, Transport::Direct(addr) if addr == relay_addr,
+            "the transport that answered the handshake should have been selected, got {selected:?}",
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn test_multiplexer_obfuscated_transport() {
         use crate::lwo;
-        use talpid_types::net::wireguard::PublicKey;
 
-        let client_key =
-            PublicKey::from_base64("8Ka2l4T0tVrSR5pkcsvRG++mBlxfuf8XOxpqBkOCikU=").unwrap();
-        let server_key =
-            PublicKey::from_base64("4EkA4c160oQgN/YaNR9GN3gLMevXEfx5hnlc9jYmw14=").unwrap();
+        let client_key = client_key();
+        let server_key = server_key();
 
         let server_socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
 
@@ -509,6 +626,7 @@ mod tests {
                 // TODO: support v2
                 version: LwoVersion::V1,
             }))],
+            client_public_key: client_key.clone(),
             selected_transport: selected_tx,
         };
 
@@ -520,9 +638,8 @@ mod tests {
 
         let wg_socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
 
-        // A WireGuard data packet, which LWO obfuscates the header of
-        let mut packet = vec![0u8; 32 + 100];
-        packet[0] = 4;
+        // A WireGuard handshake initiation, which LWO obfuscates the header of
+        let packet = handshake_initiation(SESSION).to_vec();
 
         wg_socket
             .send_to(&packet, multiplexer_endpoint)
@@ -537,8 +654,7 @@ mod tests {
         assert_eq!(&server_buf[..n], &packet[..]);
 
         // The multiplexer should deobfuscate the response and hand it to WireGuard verbatim
-        let mut response = packet.clone();
-        response[4] = 0xab;
+        let response = handshake_response(SESSION, &client_key).to_vec();
         let mut obfuscated_response = response.clone();
         lwo::obfuscate(
             &mut rand::rng(),
@@ -562,7 +678,7 @@ mod tests {
         ));
 
         // The transport should now be selected: traffic keeps flowing in connected mode
-        packet[4] = 0xcd;
+        let packet = handshake_initiation(SESSION + 1).to_vec();
         wg_socket
             .send_to(&packet, multiplexer_endpoint)
             .await

--- a/tunnel-obfuscation/src/wireguard.rs
+++ b/tunnel-obfuscation/src/wireguard.rs
@@ -1,0 +1,224 @@
+//! Some WireGuard helpers.
+//!
+//! See the [WireGuard whitepaper](https://www.wireguard.com/papers/wireguard.pdf).
+
+use std::{collections::HashSet, ops::Range};
+
+use blake2::{
+    Blake2s256, Blake2sMac,
+    digest::{Digest, Mac, consts::U16},
+};
+use talpid_types::net::wireguard::PublicKey;
+
+// First byte of each type of message.
+pub const HANDSHAKE_INITIATION: u8 = 1;
+pub const HANDSHAKE_RESPONSE: u8 = 2;
+pub const COOKIE_REPLY: u8 = 3;
+pub const DATA: u8 = 4;
+
+// Handshake messages are a fixed size, so anything else is not one.
+pub const HANDSHAKE_INITIATION_SIZE: usize = 148;
+pub const HANDSHAKE_RESPONSE_SIZE: usize = 92;
+pub const COOKIE_REPLY_SIZE: usize = 64;
+// Everything a data message carries besides its payload: the header and the tag.
+pub const DATA_OVERHEAD_SIZE: usize = 32;
+
+// Field offsets. `mac1` sits at the end of a response and covers every byte before it.
+const SENDER_INDEX: Range<usize> = 4..8;
+const RESPONSE_RECEIVER_INDEX: Range<usize> = 8..12;
+const COOKIE_RECEIVER_INDEX: Range<usize> = 4..8;
+const RESPONSE_MAC1: Range<usize> = 60..76;
+
+/// Keyed BLAKE2s with a 16 byte output.
+type Mac1 = Blake2sMac<U16>;
+
+/// What a packet received from the remote turned out to be.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Received {
+    /// Response with a valid `mac1`.
+    HandshakeResponse,
+    /// Cookie reply.
+    CookieReply,
+    /// Not an answer to any initiation the filter has seen.
+    Unrecognized,
+}
+
+/// Recognizes the answers to the initiations passed to [Self::record_initiation].
+///
+/// This rejects packets that are not potential responses to a handshake initiation from the
+/// given client.
+pub struct HandshakeFilter {
+    /// The `mac1` key, precomputed since it is the same for every packet.
+    mac1_key: [u8; 32],
+    /// `sender_index` of every initiation recorded so far.
+    initiations: HashSet<u32>,
+}
+
+impl HandshakeFilter {
+    /// `client_public_key` is the key of the local WireGuard instance, which is what a responder
+    /// addressing it computes `mac1` with.
+    pub fn new(client_public_key: &PublicKey) -> Self {
+        Self {
+            mac1_key: mac1_key(client_public_key),
+            initiations: HashSet::new(),
+        }
+    }
+
+    /// Note `packet` if it is a handshake initiation, so that its answer can be recognized.
+    pub fn record_initiation(&mut self, packet: &[u8]) {
+        if packet.len() == HANDSHAKE_INITIATION_SIZE && packet[0] == HANDSHAKE_INITIATION {
+            self.initiations.insert(index(packet, SENDER_INDEX));
+        }
+    }
+
+    pub fn classify(&self, packet: &[u8]) -> Received {
+        let answers_an_initiation =
+            |field: Range<usize>| self.initiations.contains(&index(packet, field));
+
+        match (packet.first(), packet.len()) {
+            (Some(&HANDSHAKE_RESPONSE), HANDSHAKE_RESPONSE_SIZE)
+                if answers_an_initiation(RESPONSE_RECEIVER_INDEX) && self.verify_mac1(packet) =>
+            {
+                Received::HandshakeResponse
+            }
+            // A cookie reply carries no `mac1`, so the index is all there is to check.
+            (Some(&COOKIE_REPLY), COOKIE_REPLY_SIZE)
+                if answers_an_initiation(COOKIE_RECEIVER_INDEX) =>
+            {
+                Received::CookieReply
+            }
+            _ => Received::Unrecognized,
+        }
+    }
+
+    fn verify_mac1(&self, response: &[u8]) -> bool {
+        mac1(&self.mac1_key)
+            .chain_update(&response[..RESPONSE_MAC1.start])
+            .verify_slice(&response[RESPONSE_MAC1])
+            .is_ok()
+    }
+}
+
+/// The key that `mac1` of a message addressed to `public_key` is computed with.
+fn mac1_key(public_key: &PublicKey) -> [u8; 32] {
+    Blake2s256::new()
+        .chain_update(b"mac1----")
+        .chain_update(public_key.as_bytes())
+        .finalize()
+        .into()
+}
+
+fn mac1(key: &[u8; 32]) -> Mac1 {
+    <Mac1 as Mac>::new_from_slice(key).expect("the mac1 key is 32 bytes")
+}
+
+fn index(packet: &[u8], field: Range<usize>) -> u32 {
+    u32::from_le_bytes(packet[field].try_into().expect("an index is 4 bytes"))
+}
+
+/// Build a handshake initiation carrying `sender_index`. Only the fields that identify the
+/// handshake are filled in.
+#[cfg(test)]
+pub fn handshake_initiation(sender_index: u32) -> [u8; HANDSHAKE_INITIATION_SIZE] {
+    let mut packet = [0u8; HANDSHAKE_INITIATION_SIZE];
+    packet[0] = HANDSHAKE_INITIATION;
+    packet[SENDER_INDEX].copy_from_slice(&sender_index.to_le_bytes());
+    packet
+}
+
+/// Build a handshake response to the initiation that carried `receiver_index`, with a `mac1` that
+/// [HandshakeFilter] accepts for `client_public_key`.
+#[cfg(test)]
+pub fn handshake_response(
+    receiver_index: u32,
+    client_public_key: &PublicKey,
+) -> [u8; HANDSHAKE_RESPONSE_SIZE] {
+    let mut packet = [0u8; HANDSHAKE_RESPONSE_SIZE];
+    packet[0] = HANDSHAKE_RESPONSE;
+    packet[RESPONSE_RECEIVER_INDEX].copy_from_slice(&receiver_index.to_le_bytes());
+    let mac = mac1(&mac1_key(client_public_key)).chain_update(&packet[..RESPONSE_MAC1.start]);
+    packet[RESPONSE_MAC1].copy_from_slice(&mac.finalize().into_bytes());
+    packet
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ID: u32 = 7;
+
+    fn client_key() -> PublicKey {
+        PublicKey::from_base64("8Ka2l4T0tVrSR5pkcsvRG++mBlxfuf8XOxpqBkOCikU=").unwrap()
+    }
+
+    fn other_key() -> PublicKey {
+        PublicKey::from_base64("4EkA4c160oQgN/YaNR9GN3gLMevXEfx5hnlc9jYmw14=").unwrap()
+    }
+
+    fn response(receiver_index: u32) -> Vec<u8> {
+        signed_by(receiver_index, &client_key())
+    }
+
+    fn signed_by(receiver_index: u32, key: &PublicKey) -> Vec<u8> {
+        handshake_response(receiver_index, key).to_vec()
+    }
+
+    fn cookie_reply(receiver_index: u32) -> Vec<u8> {
+        let mut packet = vec![0u8; COOKIE_REPLY_SIZE];
+        packet[0] = COOKIE_REPLY;
+        packet[COOKIE_RECEIVER_INDEX].copy_from_slice(&receiver_index.to_le_bytes());
+        packet
+    }
+
+    fn filter() -> HandshakeFilter {
+        let mut filter = HandshakeFilter::new(&client_key());
+        filter.record_initiation(&handshake_initiation(ID));
+        filter
+    }
+
+    #[test]
+    fn classifies_received_packets() {
+        // `mac1` covers the ephemeral key, so flipping a bit of it invalidates the response.
+        let mut tampered = response(ID);
+        tampered[12] ^= 1;
+        let mut too_long = response(ID);
+        too_long.push(0);
+        let mut data = vec![0u8; 1400];
+        data[0] = DATA;
+
+        use Received::*;
+        let classify = |packet: Vec<u8>| filter().classify(&packet);
+
+        // Answers to the initiation that was recorded
+        assert_eq!(classify(response(ID)), HandshakeResponse);
+        assert_eq!(classify(cookie_reply(ID)), CookieReply);
+
+        // Answers to an initiation that was never sent
+        assert_eq!(classify(response(ID + 1)), Unrecognized);
+        assert_eq!(classify(cookie_reply(ID + 1)), Unrecognized);
+
+        // Responses that do not carry a `mac1` we would compute
+        assert_eq!(classify(signed_by(ID, &other_key())), Unrecognized);
+        assert_eq!(classify(tampered), Unrecognized);
+
+        // Not a handshake response at all
+        assert_eq!(classify(too_long), Unrecognized);
+        assert_eq!(classify(data), Unrecognized);
+        assert_eq!(classify(vec![]), Unrecognized);
+        assert_eq!(classify(b"hello".to_vec()), Unrecognized);
+    }
+
+    #[test]
+    fn records_only_handshake_initiations() {
+        let mut short = handshake_initiation(ID).to_vec();
+        short.truncate(100);
+        let mut wrong_type = handshake_initiation(ID).to_vec();
+        wrong_type[0] = DATA;
+
+        for packet in [short, wrong_type] {
+            let mut filter = HandshakeFilter::new(&client_key());
+            filter.record_initiation(&packet);
+            assert_eq!(filter.classify(&response(ID)), Received::Unrecognized);
+        }
+    }
+}


### PR DESCRIPTION
Detect whether a valid handshake response has been received by the multiplexer instead before trusting any incoming obfuscated traffic.

This depends on the client's pubkey being semi-private as any correct `wg.mac1` for the expected session index is accepted. It also relies on the randomly generated index not colliding with that of previous handshakes using the same static key, which would allow for a replay attack. A replay attack could be used for DoS. It has no security implications.

Fix DES-1908.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10983)
<!-- Reviewable:end -->
