### PR TITLE
Fix: quick-settings tile reports success after remote log-off

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/app/tile/MullvadTileService.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/app/tile/MullvadTileService.kt
@@ -48,7 +48,6 @@ class MullvadTileService : TileService() {
     }
 
     override fun onClick() {
-        // Workaround for the reported bug: https://issuetracker.google.com/issues/236862865
         suspend fun isUnlockStatusPropagatedWithinTimeout(
             unlockTimeoutMillis: Long,
             unlockCheckDelayMillis: Long,
@@ -89,7 +88,6 @@ class MullvadTileService : TileService() {
     @SuppressLint("StartActivityAndCollapseDeprecated")
     private fun toggleTunnel() {
         val isSetup = applicationContext.prepareVpnSafe().isRight()
-        // TODO This logic should be more advanced, we should ensure user has an account setup etc.
         if (isSetup) {
             Logger.i("TileService: VPN service is setup")
 
@@ -104,8 +102,6 @@ class MullvadTileService : TileService() {
                         }
                 }
 
-            // Always start as foreground, e.g if app is dead we won't be allowed to start if not
-            // in foreground.
             startForegroundService(intent)
         } else {
             Logger.i("TileService: VPN service not setup, starting main activity")
@@ -169,13 +165,8 @@ class MullvadTileService : TileService() {
                     }
                 }
 
-                is TunnelState.Error -> {
-                    if (tunnelState.errorState.isBlocking) {
-                        Tile.STATE_ACTIVE
-                    } else {
-                        Tile.STATE_INACTIVE
-                    }
-                }
+                is TunnelState.Error ->
+                    Tile.STATE_INACTIVE
             }
         } else {
             Tile.STATE_INACTIVE

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/app/tile/MullvadTileService.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/app/tile/MullvadTileService.kt
@@ -48,6 +48,7 @@ class MullvadTileService : TileService() {
     }
 
     override fun onClick() {
+        // Workaround for the reported bug: https://issuetracker.google.com/issues/236862865
         suspend fun isUnlockStatusPropagatedWithinTimeout(
             unlockTimeoutMillis: Long,
             unlockCheckDelayMillis: Long,
@@ -88,6 +89,7 @@ class MullvadTileService : TileService() {
     @SuppressLint("StartActivityAndCollapseDeprecated")
     private fun toggleTunnel() {
         val isSetup = applicationContext.prepareVpnSafe().isRight()
+        // TODO This logic should be more advanced, we should ensure user has an account setup etc.
         if (isSetup) {
             Logger.i("TileService: VPN service is setup")
 
@@ -102,6 +104,8 @@ class MullvadTileService : TileService() {
                         }
                 }
 
+            // Always start as foreground, e.g if app is dead we won't be allowed to start if not
+            // in foreground.
             startForegroundService(intent)
         } else {
             Logger.i("TileService: VPN service not setup, starting main activity")


### PR DESCRIPTION
When the VPN gets logged off from another device, the tunnel tears down into a blocking `TunnelState.Error` (auth failed). The quick-settings tile was mapping that blocking error to `Tile.STATE_ACTIVE`, so it showed the highlighted icon with a "connected" subtitle -- even though the tunnel is not actually connected.

The app already renders this exact state as "blocked", so the tile should match it. A blocking error means the VPN is active but blocked, i.e. not connected, so the tile now reports it as inactive.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10990)
<!-- Reviewable:end -->
