### PR TITLE
Implement exponential-backoff in UITests

### DIFF
--- a/ios/MullvadVPNUITests/XCUIElement+Extensions.swift
+++ b/ios/MullvadVPNUITests/XCUIElement+Extensions.swift
@@ -144,22 +144,18 @@ extension XCUIElement {
         // 10 sec * 3 tries + 2 sec + 2 sec ^ 2 = 36
         case longerThanMullvadAPITimeout = 37
         case extremelyLong = 180
+    }
 
-        var pollInterval: TimeInterval {
-            switch self {
-            case .short, .default, .long, .veryLong: 0.2
-            case .longerThanMullvadAPITimeout: 0.5
-            case .extremelyLong: 1
-            }
-        }
+    private struct PollInterval {
+        static let minPollInterval: TimeInterval = 0.2
+        static let maxPollInterval: TimeInterval = 2
 
-        var maxIterations: Int {
-            switch self {
-            case .short, .default, .long, .veryLong, .longerThanMullvadAPITimeout: 100
-            // 1 check per second for 180 seconds < 200
-            case .extremelyLong: 200
-            }
-        }
+        static let pollMultiplier: Double = 1.5
+        // To accomodate the `extremelyLong` timeout, we allow for an upper bound of
+        // 100 iterations * 2 seconds.
+        // In practice the timeout gets precedence over the `maxPollInterval * maxIterations`,
+        // so it won't actually take 200s.
+        static let maxIterations: Int = 100
     }
 
     // This function actively polls the hierarchy on a set interval. This speeds up the waiting process
@@ -175,13 +171,14 @@ extension XCUIElement {
             return true
         }
 
+        var pollInterval = PollInterval.minPollInterval
         let timeoutDate = Date().addingTimeInterval(timeout.rawValue)
         let expectation = XCTestExpectation(description: description ?? "Waiting for condition to be met")
         var iterationCount = 0
 
         while Date() < timeoutDate {
             iterationCount += 1
-            if iterationCount > timeout.maxIterations {
+            if iterationCount > PollInterval.maxIterations {
                 return false
             }
 
@@ -190,7 +187,21 @@ extension XCUIElement {
                 return true
             }
 
-            RunLoop.current.run(until: Date().addingTimeInterval(timeout.pollInterval))
+            let remainingTime = timeoutDate.timeIntervalSinceNow
+
+            // If the next poll would exceed timeout, the remaining time gets priority
+            let effectivePollInterval = min(pollInterval, remainingTime)
+            if effectivePollInterval <= 0 { break }
+
+            // Calculates when the next poll should happen
+            let targetTime = Date().addingTimeInterval(effectivePollInterval)
+            RunLoop.current.run(until: targetTime)
+
+            // Multiply the current interval by 1.5, causing the next poll to wait longer
+            let dynamicInterval = max(PollInterval.minPollInterval, pollInterval * PollInterval.pollMultiplier)
+
+            // If the calculated interval is larger than our maximum allowed interval, honour maximum time between polls instead
+            pollInterval = min(dynamicInterval, PollInterval.maxPollInterval)
         }
 
         return false


### PR DESCRIPTION
Based on the article referenced in the [comment], we now implemented an exponential backoff, which will cause it to wait longer in-between checks for condition, up to a max of 2 seconds.

This should provide a nice balance between speed when waiting for something that should be fairly quick, and when waiting for an action that takes a bit longer, such as dialogs.

[comment]: https://eng.wealthfront.com/2025/03/17/how-we-sped-up-ios-end-to-end-tests-by-over-50-with-40-lines-of-code/

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10991)
<!-- Reviewable:end -->
