### PR TITLE
Fix leaking settings subviews

### DIFF
--- a/ios/MullvadVPN/Coordinators/Settings/SettingsCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/SettingsCoordinator.swift
@@ -321,10 +321,22 @@ final class SettingsCoordinator: Coordinator, Presentable, Presenting, SettingsV
         switch viewController {
         case is SettingsViewController:
             return .root
-        case is ProblemReportViewController:
-            return .problemReport
+        case is UIHostingController<SettingsDAITAView<DAITATunnelSettingsViewModel>>:
+            return .daita
+        case is UIHostingController<SettingsMultihopView>:
+            return .multihop
+        case is UIHostingController<VPNSettingsNavigationView>:
+            return .vpnSettings
+        case is UIHostingController<IncludeAllNetworksSettingsView<IncludeAllNetworksSettingsViewModelImpl>>:
+            return .includeAllNetworks
         case is UIHostingController<ListAccessMethodView<ListAccessViewModelBridge>>:
             return .apiAccess
+        case is UIHostingController<NotificationSettingsView<NotificationSettingsViewModel>>:
+            return .notificationSettings
+        case is UIHostingController<ChangeLogView<ChangeLogViewModel>>:
+            return .changelog
+        case is ProblemReportViewController:
+            return .problemReport
         default:
             return nil
         }


### PR DESCRIPTION
Many settings sub menus and their view models were leaking since they never got removed when navigating back. That resulted in e.g. multiple reconnects when changing a setting after a few in and out navigations. This PR fixes that

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10993)
<!-- Reviewable:end -->
