### PR TITLE
Cancel navigation when scrolling vpn settings view

### DIFF
--- a/ios/MullvadVPN/Views/SegmentedListItem/SegmentedListItem.swift
+++ b/ios/MullvadVPN/Views/SegmentedListItem/SegmentedListItem.swift
@@ -94,6 +94,7 @@ struct SegmentedListItem<Leading: View>: View {
             .padding(.leading, 16)
             .padding(.trailing, trailing == nil ? 16 : 0)
             .background(Color.colorForIndentationLevel(level))
+            .simultaneousGesture(TapGesture())  // Cancels tap gesture when scrolling.
             .sizeOfView {
                 segmentHeight = $0.height
             }
@@ -113,6 +114,7 @@ struct SegmentedListItem<Leading: View>: View {
                     segmentHeight = $0.height
                 }
             }
+            .simultaneousGesture(TapGesture())  // Cancels tap gesture when scrolling.
 
             if onSelect != nil {
                 switch userInteraction {


### PR DESCRIPTION
**What is being observed?**

If long-pressing on a list item in VPN settings, then dragging slight down, then releasing, the view will navigate to the item rather than cancel interaction. The resulting view also yields a jumpy entry.

Simulator Screen Recording - iPhone 17 Pro - 2026-08-20 at 11.40.52.mov: https://uploads.linear.app/f76f897f-1150-435f-bbf2-da1f324458b8/349397f5-7c26-40dd-8ffb-98c7294eb47b/ebb1be2b-f2ab-497d-bdc5-48171fe7c77b

**Acceptance criteria**

- Upon release, the view should not navigate but stay on VPN settings screen
- Upon drag, selected list item should be (visually) deselected.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10995)
<!-- Reviewable:end -->
