### PR TITLE
Ignore `CVE-2024-21528` for 4 more months

### DIFF
--- a/desktop/osv-scanner.toml
+++ b/desktop/osv-scanner.toml
@@ -3,7 +3,7 @@
 # node-gettext: Prototype Pullution via the addTranslations function
 [[IgnoredVulns]]
 id = "CVE-2024-21528"  # GHSA-g974-hxvm-x689
-ignoreUntil = 2026-08-16  # The vulnerability is ignored for 4 months as no patch for the affected library exists and we can not address the vulnerability without migrating to another library, which is no minor feat.
+ignoreUntil = 2026-12-24  # The vulnerability is ignored for 4 months as no patch for the affected library exists and we can not address the vulnerability without migrating to another library, which is no minor feat.
 reason = "There is no fix yet and we don't send untrusted input to the first argument of addTranslations"
 
 # esbuild: esbuild allows arbitrary file read when running the development server on Windows


### PR DESCRIPTION
The affected library has not yet been patched, and we're currently understaffed when it comes to Electron devs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10997)
<!-- Reviewable:end -->
