### PR TITLE
Remove unneeded lint and disable linting when building previews

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -5643,7 +5643,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 58CE5E82224146470008646E /* Build configuration list for PBXNativeTarget "PacketTunnel" */;
 			buildPhases = (
-				580E3F222A9861990061809D /* Run SwiftLint */,
 				58CE5E75224146470008646E /* Sources */,
 				58CE5E76224146470008646E /* Frameworks */,
 				58CE5E77224146470008646E /* Resources */,
@@ -6187,25 +6186,6 @@
 
 /* Begin PBXShellScriptBuildPhase section */
 		580E3F212A9860F20061809D /* Run SwiftLint */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Run SwiftLint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "./format.sh lint\n";
-		};
-		580E3F222A9861990061809D /* Run SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;

--- a/ios/format.sh
+++ b/ios/format.sh
@@ -48,8 +48,10 @@ included_folders=(
 )
 cd "$script_dir"
 
-if [[ "$command" == "lint" ]]; then
-    swift format lint -r -p "$@" "${included_folders[@]}"
-elif [[ "$command" == "format" ]]; then
-    swift format format -r -p -i "$@" "${included_folders[@]}"
+if [[ "$ENABLE_PREVIEWS" == "NO" ]]; then
+    if [[ "$command" == "lint" ]]; then
+        swift format lint -r -p "$@" "${included_folders[@]}"
+    elif [[ "$command" == "format" ]]; then
+        swift format format -r -p -i "$@" "${included_folders[@]}"
+    fi
 fi


### PR DESCRIPTION
This PR removes an extra use of the `format.sh` script that was not needed when building the `PacketTunnel` target
It also disables the lint step when building SwiftUI previews which should speed up rendering them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10998)
<!-- Reviewable:end -->
