### PR TITLE
Revert "Merge branch 'remove-network-manager-minor-check'"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,6 @@ Line wrap the file at 100 chars.                                              Th
 - Add explicit log levels for `mullvad log set-level` command: `off`, `error`, `warn`, `info`,
   `debug` and `trace`.
 
-#### Linux
-- Add back support for managing DNS via NetworkManager.
-
 ### Changed
 - Clicking on the tray icon will toggle the window instead of just showing it
 - Old `mullvad log set-level` command has been renamed to `mullvad log set-rust-log`.

--- a/talpid-dbus/src/network_manager.rs
+++ b/talpid-dbus/src/network_manager.rs
@@ -52,6 +52,7 @@ const MINIMUM_SUPPORTED_MAJOR_VERSION: u32 = 1;
 const MINIMUM_SUPPORTED_MINOR_VERSION: u32 = 16;
 
 const MAXIMUM_SUPPORTED_MAJOR_VERSION: u32 = 1;
+const MAXIMUM_SUPPORTED_MINOR_VERSION: u32 = 26;
 
 const NM_DEVICE_STATE_CHANGED: &str = "StateChanged";
 
@@ -222,7 +223,10 @@ impl NetworkManager {
     }
 
     fn ensure_nm_is_old_enough_for_dns(major_version: u32, minor_version: u32) -> Result<()> {
-        if major_version > MAXIMUM_SUPPORTED_MAJOR_VERSION {
+        if major_version > MAXIMUM_SUPPORTED_MAJOR_VERSION
+            || (minor_version > MAXIMUM_SUPPORTED_MINOR_VERSION
+                && major_version >= MAXIMUM_SUPPORTED_MAJOR_VERSION)
+        {
             Err(Error::NMTooNewFroDns(major_version, minor_version))
         } else {
             Ok(())
@@ -735,5 +739,6 @@ mod test {
         NetworkManager::ensure_nm_is_new_enough_for_wireguard(1, 16).unwrap();
         NetworkManager::ensure_nm_is_old_enough_for_dns(1, 26).unwrap();
         assert!(NetworkManager::ensure_nm_is_new_enough_for_wireguard(1, 14).is_err());
+        assert!(NetworkManager::ensure_nm_is_old_enough_for_dns(1, 28).is_err());
     }
 }


### PR DESCRIPTION
Revert https://github.com/mullvad/mullvadvpn-app/pull/10966. The PR introduced a regression where the entry relay wireguard peer would not have its 'psk' set after ephemeral peer negotiation. We'll have to investigate this before adding back DNS via NM support.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11003)
<!-- Reviewable:end -->
