### PR TITLE
Support lwo_v2 in relay list

### DIFF
--- a/ios/MullvadMockData/MullvadREST/ServerRelaysResponse+Stubs.swift
+++ b/ios/MullvadMockData/MullvadREST/ServerRelaysResponse+Stubs.swift
@@ -153,7 +153,7 @@ public enum ServerRelaysResponseStubs {
                     includeInCountry: true,
                     daita: true,
                     shadowsocksExtraAddrIn: ["0.0.0.0"],
-                    features: .init(daita: .init(), quic: nil, lwo: nil)
+                    features: .init(daita: .init(), quic: nil, lwo: .init(), lwoV2: .init())
                 ),
                 REST.ServerRelay(
                     hostname: "es3-wireguard",
@@ -168,7 +168,7 @@ public enum ServerRelaysResponseStubs {
                     includeInCountry: true,
                     daita: true,
                     shadowsocksExtraAddrIn: ["0.0.0.0"],
-                    features: .init(daita: .init(), quic: nil, lwo: nil)
+                    features: .init(daita: .init(), quic: nil, lwo: nil, lwoV2: .init())
                 ),
                 REST.ServerRelay(
                     hostname: "es4-wireguard",

--- a/ios/MullvadREST/ApiHandlers/ServerRelaysResponse.swift
+++ b/ios/MullvadREST/ApiHandlers/ServerRelaysResponse.swift
@@ -70,9 +70,12 @@ extension REST {
                 // Intentionally left blank.
             }
 
+            public struct LWOV2: Codable, Equatable, Sendable {}
+
             public let daita: DAITA?
             public let quic: QUIC?
             public let lwo: LWO?
+            public var lwoV2: LWOV2?
         }
 
         public let hostname: String
@@ -100,6 +103,11 @@ extension REST {
 
         public var supportsLwo: Bool {
             features?.lwo != nil
+        }
+
+        /// LWOv2 requires GotaTun, and is advertised separately from ``supportsLwo``.
+        public var supportsLwoV2: Bool {
+            features?.lwoV2 != nil
         }
 
         /// Returns true if the relay has IPv6 addresses in shadowsocksExtraAddrIn

--- a/ios/MullvadRESTTests/ServerRelayTests.swift
+++ b/ios/MullvadRESTTests/ServerRelayTests.swift
@@ -36,7 +36,8 @@ class ServerRelayTests: XCTestCase {
                         "domain": "se-got-wg-881.blockerad.eu",
                         "token": "test"
                     },
-                    "lwo": {}
+                    "lwo": {},
+                    "lwo_v2": {}
                 }
             }
             """
@@ -68,10 +69,27 @@ class ServerRelayTests: XCTestCase {
                         domain: "se-got-wg-881.blockerad.eu",
                         token: "test"
                     ),
-                    lwo: .init()
+                    lwo: .init(),
+                    lwoV2: .init()
                 ),
                 isIPOverridden: nil
             ))
+    }
+
+    func testLwoVersionsAreDistinguished() {
+        let relayWithLwoV1 = mockServerRelay.override(features: .init(daita: nil, quic: nil, lwo: .init()))
+        let relayWithLwoV2 = mockServerRelay.override(
+            features: .init(daita: nil, quic: nil, lwo: .init(), lwoV2: .init())
+        )
+
+        XCTAssertTrue(relayWithLwoV1.supportsLwo)
+        XCTAssertFalse(relayWithLwoV1.supportsLwoV2)
+
+        XCTAssertTrue(relayWithLwoV2.supportsLwo)
+        XCTAssertTrue(relayWithLwoV2.supportsLwoV2)
+
+        XCTAssertFalse(mockServerRelay.supportsLwo)
+        XCTAssertFalse(mockServerRelay.supportsLwoV2)
     }
 
     func testCheckForDaitaWorksFromFeatures() {
@@ -126,13 +144,15 @@ class ServerRelayTests: XCTestCase {
             features: REST.ServerRelay.Features(
                 daita: REST.ServerRelay.Features.DAITA(),
                 quic: REST.ServerRelay.Features.QUIC(addrIn: [""], domain: "", token: ""),
-                lwo: REST.ServerRelay.Features.LWO()
+                lwo: REST.ServerRelay.Features.LWO(),
+                lwoV2: REST.ServerRelay.Features.LWOV2()
             )
         )
 
         XCTAssertNotNil(overrideRelay.features?.daita)
         XCTAssertNotNil(overrideRelay.features?.quic)
         XCTAssertNotNil(overrideRelay.features?.lwo)
+        XCTAssertNotNil(overrideRelay.features?.lwoV2)
     }
 
     var shadowSocksExtraAddrIn: [String] {

--- a/ios/MullvadVPNTests/MullvadREST/Relay/RelayObfuscatorTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/RelayObfuscatorTests.swift
@@ -353,6 +353,25 @@ final class RelayObfuscatorTests: XCTestCase {
         XCTAssertEqual(obfuscationResult.relays.wireguard.relays.count, relaysWithLwoSupport.count)
     }
 
+    func testObfuscateLwoSelectsOnlyLwoV1Relays() throws {
+        tunnelSettings.wireGuardObfuscation = WireGuardObfuscationSettings(
+            state: .lwo,
+            lwoPort: .custom(4000)
+        )
+
+        // LWOv2 requires GotaTun, so a relay only advertising it must not be selected.
+        XCTAssertTrue(sampleRelays.wireguard.relays.contains { $0.supportsLwoV2 && !$0.supportsLwo })
+
+        let obfuscationResult = try RelayObfuscator(
+            relays: sampleRelays,
+            tunnelSettings: tunnelSettings,
+            connectionAttemptCount: 0,
+            obfuscationBypass: IdentityObfuscationProvider()
+        ).obfuscate()
+
+        XCTAssertTrue(obfuscationResult.relays.wireguard.relays.allSatisfy { $0.supportsLwo })
+    }
+
     func testObfuscateLwoPortCustom() throws {
         tunnelSettings.wireGuardObfuscation = WireGuardObfuscationSettings(
             state: .lwo,


### PR DESCRIPTION
Adding support for LWOv2 in the relay list for the iOS app. This change will only allow the app to deserialize and serialize the new field in the relay list. The changes shouldn't affect relay selection or obfuscation - this will come later.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11007)
<!-- Reviewable:end -->
