### PR TITLE
Show obfuscator type in feature indicator

### DIFF
--- a/ios/Assets/Localizable.xcstrings
+++ b/ios/Assets/Localizable.xcstrings
@@ -48699,6 +48699,7 @@
       }
     },
     "Obfuscation" : {
+      "extractionState" : "stale",
       "localizations" : {
         "da" : {
           "stringUnit" : {

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -26,8 +26,12 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - Require the post-quantum X25519MLKEM768 key exchange for TLS connections to the Mullvad API.
 
+### Added
+- Show obfuscation type in connection view.
+
+## [2026.5]
 ### Fixed
-- Locale-aware sorting of relay list on iOS
+- Locale-aware sorting of relay list on iOS.
 
 ## [2026.4 - 2026-08-11]
 ### Added

--- a/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
+++ b/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
@@ -288,6 +288,9 @@ public enum AccessibilityIdentifier: Equatable {
     case wireGuardObfuscationLwoTable
     case wireGuardObfuscationIncompatibilityAlert
 
+    // Feature indicators
+    case obfuscationFeatureIndicator
+
     // Error
     case unknown
 

--- a/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProviderHost.swift
+++ b/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProviderHost.swift
@@ -204,7 +204,8 @@
                         remotePort: selectedRelays.entry?.endpoint.socketAddress.port
                             ?? selectedRelays.exit.endpoint.socketAddress.port,
                         isPostQuantum: settings.tunnelQuantumResistance.isEnabled,
-                        isDaitaEnabled: settings.daita.isEnabled
+                        isDaitaEnabled: settings.daita.isEnabled,
+                        obfuscationMethod: selectedRelays.obfuscation
                     )
                 )
             } catch {
@@ -229,7 +230,8 @@
                         remotePort: selectedRelays.entry?.endpoint.socketAddress.port
                             ?? selectedRelays.exit.endpoint.socketAddress.port,
                         isPostQuantum: settings.tunnelQuantumResistance.isEnabled,
-                        isDaitaEnabled: settings.daita.isEnabled
+                        isDaitaEnabled: settings.daita.isEnabled,
+                        obfuscationMethod: selectedRelays.obfuscation
                     )
                 )
             } catch {

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ChipView/ChipFeature.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ChipView/ChipFeature.swift
@@ -36,6 +36,22 @@ enum FeatureType {
     #if NEVER_IN_PRODUCTION
         case gotaTun
     #endif
+
+    /// Accessibility identifier of the chip representing this feature, where one is needed
+    /// to tell the chip apart from its label.
+    var accessibilityId: AccessibilityIdentifier? {
+        switch self {
+        case .obfuscation:
+            .obfuscationFeatureIndicator
+        #if NEVER_IN_PRODUCTION
+            case .gotaTun:
+                nil
+        #endif
+        case .daita, .multihop, .quantumResistance, .dns, .ipOverrides, .includeAllNetworks, .localNetworkSharing,
+            .ipVersion:
+            nil
+        }
+    }
 }
 
 struct DaitaFeature: ChipFeature {
@@ -88,25 +104,47 @@ struct ObfuscationFeature: ChipFeature {
     let settings: LatestTunnelSettings
     let state: ObservedState
 
-    var actualObfuscationMethod: ObfuscationMethod {
-        state.connectionState.map { $0.obfuscationMethod } ?? .off
+    /// The obfuscation method in use, or `nil` while it is still undetermined.
+    ///
+    /// The setting names the method up front unless it is `.automatic`, in which case the relay
+    /// selector picks one per connection attempt and we have to wait for the tunnel to report it.
+    private var method: WireGuardObfuscationState? {
+        guard case .automatic = settings.wireGuardObfuscation.state else {
+            return settings.wireGuardObfuscation.state
+        }
+        return state.connectionState.map { connectionState -> WireGuardObfuscationState in
+            switch connectionState.obfuscationMethod {
+            case .off:
+                .off
+            case .udpOverTcp:
+                .udpOverTcp
+            case .shadowsocks:
+                .shadowsocks
+            case .quic:
+                .quic
+            case .lwo:
+                .lwo
+            }
+        }
     }
 
     var isEnabled: Bool {
-        actualObfuscationMethod.isEnabled
-    }
-
-    var isAutomatic: Bool {
-        settings.wireGuardObfuscation.state == .automatic
+        method?.isEnabled ?? false
     }
 
     var name: String {
-        // This just currently says "Obfuscation".
-        // To add an automaticity indicator (a trailing " (automatic)"
-        // or a colour/border style or whatever), use the `isAutomatic` field.
-        // To say what type of obfuscation it is,
-        // we can look at `actualObfuscationMethod`
-        NSLocalizedString("Obfuscation", comment: "")
+        switch method {
+        case .udpOverTcp, .on:
+            NSLocalizedString("UDP-over-TCP", comment: "")
+        case .shadowsocks:
+            NSLocalizedString("Shadowsocks", comment: "")
+        case .quic:
+            NSLocalizedString("QUIC", comment: "")
+        case .lwo:
+            NSLocalizedString("LWO", comment: "")
+        case .automatic, .off, nil:
+            ""
+        }
     }
 }
 

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ChipView/ChipView.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ChipView/ChipView.swift
@@ -45,6 +45,8 @@ struct ChipView: View {
                 )
                 .padding(borderWidth)
         )
+        .accessibilityIdentifier(item.id.accessibilityId)
+        .accessibilityLabel(item.name)
     }
 }
 

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ConnectionViewComponentPreview.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ConnectionViewComponentPreview.swift
@@ -18,35 +18,40 @@ import SwiftUI
 struct ConnectionViewComponentPreview<Content: View>: View {
     let settingsManager = SettingsManager()
     let showIndicators: Bool
-    let connectedTunnelStatus = TunnelStatus(
-        observedState: .connected(
-            ObservedConnectionState(
-                selectedRelays: RelaySelectorStub.selectedRelays,
-                relayConstraints: RelayConstraints(
-                    entryLocations: .any,
-                    exitLocations: .any,
-                    port: .any,
-                    entryFilter: .any,
-                    exitFilter: .any
-                ),
-                networkReachability: .reachable,
-                connectionAttemptCount: 0,
-                transportLayer: .udp,
-                remotePort: 80,
-                isPostQuantum: true,
-                isDaitaEnabled: true
-            )),
-        state:
-            .connected(
-                RelaySelectorStub.selectedRelays,
-                isPostQuantum: true,
-                isDaita: true
-            )
-    )
+    let connectedTunnelStatus: TunnelStatus
     let disconnectedTunnelStatus = TunnelStatus(
         observedState: .disconnected,
         state: .disconnected
     )
+
+    private static func makeConnectedTunnelStatus(obfuscationMethod: ObfuscationMethod) -> TunnelStatus {
+        TunnelStatus(
+            observedState: .connected(
+                ObservedConnectionState(
+                    selectedRelays: RelaySelectorStub.selectedRelays,
+                    relayConstraints: RelayConstraints(
+                        entryLocations: .any,
+                        exitLocations: .any,
+                        port: .any,
+                        entryFilter: .any,
+                        exitFilter: .any
+                    ),
+                    networkReachability: .reachable,
+                    connectionAttemptCount: 0,
+                    transportLayer: .udp,
+                    remotePort: 80,
+                    isPostQuantum: true,
+                    isDaitaEnabled: true,
+                    obfuscationMethod: obfuscationMethod
+                )),
+            state:
+                .connected(
+                    RelaySelectorStub.selectedRelays,
+                    isPostQuantum: true,
+                    isDaita: true
+                )
+        )
+    }
 
     private var tunnelSettings: LatestTunnelSettings {
         LatestTunnelSettings(
@@ -70,6 +75,10 @@ struct ConnectionViewComponentPreview<Content: View>: View {
     ) {
         self.showIndicators = showIndicators
         self.content = content
+        let connectedTunnelStatus = Self.makeConnectedTunnelStatus(
+            obfuscationMethod: showIndicators ? .udpOverTcp : .off
+        )
+        self.connectedTunnelStatus = connectedTunnelStatus
         viewModel = ConnectionViewViewModel(
             tunnelStatus: isConnected ? connectedTunnelStatus : disconnectedTunnelStatus,
             relayConstraints: RelayConstraints(),

--- a/ios/MullvadVPNUITests/Pages/TunnelControlPage.swift
+++ b/ios/MullvadVPNUITests/Pages/TunnelControlPage.swift
@@ -16,6 +16,20 @@ class TunnelControlPage: Page {
         let ipAddress: String
         let port: String
         let protocolName: String
+        /// Label of the obfuscation feature indicator, `nil` when no obfuscation is in use.
+        let obfuscation: String?
+
+        func isSameEndpoint(as other: ConnectionAttempt?) -> Bool {
+            ipAddress == other?.ipAddress && port == other?.port && protocolName == other?.protocolName
+        }
+    }
+
+    /// Labels of the obfuscation feature indicator, one per obfuscation method.
+    enum ObfuscationIndicator {
+        static let udpOverTcp = "UDP-over-TCP"
+        static let shadowsocks = "Shadowsocks"
+        static let quic = "QUIC"
+        static let lwo = "LWO"
     }
 
     /// Strips the accessibility label prefix (e.g. "In ") from a combined row label,
@@ -44,6 +58,7 @@ class TunnelControlPage: Page {
         let pollingInterval = TimeInterval(0.5)  // How often to check for changes
 
         let inAddressRow = app.staticTexts[AccessibilityIdentifier.connectionPanelInAddressRow]
+        let obfuscationIndicator = app.buttons[AccessibilityIdentifier.obfuscationFeatureIndicator]
 
         while Date().timeIntervalSince(startTime) < timeout {
             let expectation = XCTestExpectation(description: "Wait for connection attempts")
@@ -72,10 +87,11 @@ class TunnelControlPage: Page {
             let connectionAttempt = ConnectionAttempt(
                 ipAddress: ipAddress,
                 port: port,
-                protocolName: protocolName
+                protocolName: protocolName,
+                obfuscation: obfuscationIndicator.exists ? obfuscationIndicator.label : nil
             )
 
-            if connectionAttempt != lastConnectionAttempt {
+            if !connectionAttempt.isSameEndpoint(as: lastConnectionAttempt) {
                 connectionAttempts.append(connectionAttempt)
                 lastConnectionAttempt = connectionAttempt
 
@@ -155,16 +171,29 @@ class TunnelControlPage: Page {
         var connectionAttempts = waitForConnectionAttempts(5, timeout: 80)
         XCTAssertEqual(connectionAttempts.count, 5)
 
-        let expectedProtocols = [
-            "UDP",
-            "UDP",
-            "UDP",
-            "TCP",
-            "UDP",
+        // The automatic obfuscation order is off, Shadowsocks, QUIC, UDP-over-TCP, LWO.
+        // No indicator is shown for the unobfuscated attempt.
+        let expectedAttempts: [(protocolName: String, obfuscation: String?)] = [
+            ("UDP", nil),
+            ("UDP", ObfuscationIndicator.shadowsocks),
+            ("UDP", ObfuscationIndicator.quic),
+            ("TCP", ObfuscationIndicator.udpOverTcp),
+            ("UDP", ObfuscationIndicator.lwo),
         ]
-        for (attempt, expectedProtocol) in zip(connectionAttempts, expectedProtocols) {
-            XCTAssertEqual(attempt.protocolName, expectedProtocol)
+        for (attempt, expected) in zip(connectionAttempts, expectedAttempts) {
+            XCTAssertEqual(attempt.protocolName, expected.protocolName)
+            XCTAssertEqual(attempt.obfuscation, expected.obfuscation)
         }
+        return self
+    }
+
+    /// Verify that the obfuscation feature indicator names the expected obfuscation method.
+    /// Requires the connection panel to be expanded, otherwise the chip may be collapsed
+    /// behind the "more..." button.
+    @discardableResult func verifyObfuscationFeatureIndicator(_ expectedLabel: String) -> Self {
+        let indicator = app.buttons[AccessibilityIdentifier.obfuscationFeatureIndicator]
+        XCTAssertTrue(indicator.existsAfterWait(), "Obfuscation feature indicator not presented")
+        XCTAssertEqual(indicator.label, expectedLabel)
         return self
     }
 

--- a/ios/MullvadVPNUITests/RelayTests.swift
+++ b/ios/MullvadVPNUITests/RelayTests.swift
@@ -207,6 +207,7 @@ class RelayTests: LoggedInWithTimeUITestCase {
 
             let (connectedToIPAddress, _) = TunnelControlPage(app)
                 .tapRelayStatusExpandCollapseButton()
+                .verifyObfuscationFeatureIndicator(TunnelControlPage.ObfuscationIndicator.udpOverTcp)
                 .getInIPAddressAndPortFromConnectionStatus()
 
             try Networking.verifyCanAccessInternet()
@@ -269,6 +270,7 @@ class RelayTests: LoggedInWithTimeUITestCase {
 
             let (connectedToIPAddress, _) = TunnelControlPage(app)
                 .tapRelayStatusExpandCollapseButton()
+                .verifyObfuscationFeatureIndicator(TunnelControlPage.ObfuscationIndicator.shadowsocks)
                 .getInIPAddressAndPortFromConnectionStatus()
 
             try Networking.verifyCanAccessInternet()
@@ -331,6 +333,7 @@ class RelayTests: LoggedInWithTimeUITestCase {
 
             let (connectedToIPAddress, _) = TunnelControlPage(app)
                 .tapRelayStatusExpandCollapseButton()
+                .verifyObfuscationFeatureIndicator(TunnelControlPage.ObfuscationIndicator.lwo)
                 .getInIPAddressAndPortFromConnectionStatus()
 
             try Networking.verifyCanAccessInternet()
@@ -377,6 +380,8 @@ class RelayTests: LoggedInWithTimeUITestCase {
 
         TunnelControlPage(app)
             .waitForConnectedLabel()
+            .tapRelayStatusExpandCollapseButton()
+            .verifyObfuscationFeatureIndicator(TunnelControlPage.ObfuscationIndicator.udpOverTcp)
 
         try Networking.verifyCanAccessInternet()
 
@@ -411,6 +416,8 @@ class RelayTests: LoggedInWithTimeUITestCase {
 
         TunnelControlPage(app)
             .waitForConnectedLabel()
+            .tapRelayStatusExpandCollapseButton()
+            .verifyObfuscationFeatureIndicator(TunnelControlPage.ObfuscationIndicator.shadowsocks)
 
         try Networking.verifyCanAccessInternet()
 
@@ -458,6 +465,7 @@ class RelayTests: LoggedInWithTimeUITestCase {
 
             let (connectedToIPAddress, _) = TunnelControlPage(app)
                 .tapRelayStatusExpandCollapseButton()
+                .verifyObfuscationFeatureIndicator(TunnelControlPage.ObfuscationIndicator.quic)
                 .getInIPAddressAndPortFromConnectionStatus()
 
             let (relayIPAddress, _) = TunnelControlPage(app)
@@ -523,6 +531,8 @@ class RelayTests: LoggedInWithTimeUITestCase {
 
         TunnelControlPage(app)
             .waitForConnectedLabel()
+            .tapRelayStatusExpandCollapseButton()
+            .verifyObfuscationFeatureIndicator(TunnelControlPage.ObfuscationIndicator.lwo)
 
         try Networking.verifyCanAccessInternet()
 

--- a/ios/PacketTunnelCore/Actor/ObservedState.swift
+++ b/ios/PacketTunnelCore/Actor/ObservedState.swift
@@ -39,10 +39,11 @@ public struct ObservedConnectionState: Equatable, Codable, Sendable {
     public let isPostQuantum: Bool
     public let isDaitaEnabled: Bool
 
-    /// The obfuscation method, derived from the selected relays' ingress endpoint.
-    public var obfuscationMethod: ObfuscationMethod {
-        selectedRelays.obfuscation
-    }
+    /// The obfuscation method the tunnel actually connected with.
+    ///
+    /// When the obfuscation setting is `.automatic` this is the method the relay selector
+    /// resolved for this particular connection attempt, not the setting itself.
+    public let obfuscationMethod: ObfuscationMethod
 
     public var isNetworkReachable: Bool {
         networkReachability != .unreachable
@@ -57,7 +58,8 @@ public struct ObservedConnectionState: Equatable, Codable, Sendable {
         remotePort: UInt16,
         lastKeyRotation: Date? = nil,
         isPostQuantum: Bool,
-        isDaitaEnabled: Bool
+        isDaitaEnabled: Bool,
+        obfuscationMethod: ObfuscationMethod
     ) {
         self.selectedRelays = selectedRelays
         self.relayConstraints = relayConstraints
@@ -68,6 +70,7 @@ public struct ObservedConnectionState: Equatable, Codable, Sendable {
         self.lastKeyRotation = lastKeyRotation
         self.isPostQuantum = isPostQuantum
         self.isDaitaEnabled = isDaitaEnabled
+        self.obfuscationMethod = obfuscationMethod
     }
 }
 
@@ -118,7 +121,8 @@ extension State.ConnectionData {
             remotePort: remotePort,
             lastKeyRotation: lastKeyRotation,
             isPostQuantum: isPostQuantum,
-            isDaitaEnabled: isDaitaEnabled
+            isDaitaEnabled: isDaitaEnabled,
+            obfuscationMethod: connectedEndpoint.obfuscation
         )
     }
 }

--- a/ios/PacketTunnelCore/GotaTun/GotaTunActor.swift
+++ b/ios/PacketTunnelCore/GotaTun/GotaTunActor.swift
@@ -611,7 +611,8 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
             remotePort: selectedRelays.ingress.endpoint.socketAddress.port,
             lastKeyRotation: lastKeyRotation,
             isPostQuantum: config.isPostQuantum,
-            isDaitaEnabled: config.isDaitaEnabled
+            isDaitaEnabled: config.isDaitaEnabled,
+            obfuscationMethod: selectedRelays.obfuscation,
         )
     }
 

--- a/ios/PacketTunnelCoreTests/EphemeralPeerExchangingPipelineTests.swift
+++ b/ios/PacketTunnelCoreTests/EphemeralPeerExchangingPipelineTests.swift
@@ -219,7 +219,8 @@ final class EphemeralPeerExchangingPipelineTests: XCTestCase {
             transportLayer: .udp,
             remotePort: 1234,
             isPostQuantum: enablePostQuantum,
-            isDaitaEnabled: enableDaita
+            isDaitaEnabled: enableDaita,
+            obfuscationMethod: .off
         )
     }
 }


### PR DESCRIPTION
We've been out of spec with the design for a while on this one - we should show the user what type of obfuscation is in use. The way to do this is to infer the current state from the tunnel state whenever possible. If there is no tunnel state, we can infer the method from settings - unless it is `.automatic` - in which case no feature indicator is shown until a tunnel status update is received.

This allows us to extend UI tests to assert what obfuscation should be used - so far we've been only checking ports and if the protocol was UDP. We can still extend the tests to dump traffic to verify the actual obfuscation in use but that is out of scope here.  This also means that feature indicators no longer use the same accessibility label and name - the same obfuscation indicator can contain different values but will still be identified by the same ID.

The tunnel state for the preview was also getting a bit unwieldy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11008)
<!-- Reviewable:end -->
