### PR TITLE
Add Windows support for shell completions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -370,16 +370,27 @@ done
 
 log_header "Preparing for packaging Mullvad VPN $PRODUCT_VERSION"
 
-if [[ "$(uname -s)" == "Darwin" || "$(uname -s)" == "Linux" ]]; then
+case "$(uname -s)" in
+Darwin|Linux)
     mkdir -p "build/shell-completions"
     for sh in bash zsh fish nushell; do
         log_info "Generating shell completion script for $sh..."
         cargo run --bin mullvad "${CARGO_ARGS[@]}" -- shell-completions "$sh" \
             "build/shell-completions/"
     done
-else
+    ;;
+MINGW*)
+    mkdir -p "build/shell-completions"
+    for sh in powershell nushell; do
+        log_info "Generating shell completion script for $sh..."
+        cargo run --bin mullvad "${CARGO_ARGS[@]}" -- shell-completions "$sh" \
+            "build/shell-completions/"
+    done
+    ;;
+*)
     mkdir -p "build"
-fi
+    ;;
+esac
 
 # Everything that goes into the installers and packages is in place by now, so give it all one
 # deterministic modification time. The packaging tools record these timestamps, and they would

--- a/desktop/packages/mullvad-vpn/tasks/distribution.cjs
+++ b/desktop/packages/mullvad-vpn/tasks/distribution.cjs
@@ -129,6 +129,8 @@ function newConfig() {
       target: [],
       artifactName: 'MullvadVPN-${version}_${arch}.${ext}',
       extraResources: [
+        { from: buildAssets('shell-completions/_mullvad.ps1'), to: '.' },
+        { from: buildAssets('shell-completions/mullvad.nu'), to: '.' },
         { from: distAssets(path.join('${env.DIST_SUBDIR}', 'mullvad.exe')), to: '.' },
         {
           from: distAssets(path.join('${env.DIST_SUBDIR}', 'mullvad-problem-report.exe')),

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -555,6 +555,17 @@ ManifestDPIAware true
 
 !define AddCLIToEnvironPath '!insertmacro "AddCLIToEnvironPath"'
 
+# Install Nushell completions in its machine-wide vendor autoload directory.
+!macro InstallShellCompletions
+
+	SetShellVarContext all
+	CreateDirectory "$LOCALAPPDATA\nushell\vendor\autoload"
+	CopyFiles /SILENT "$INSTDIR\resources\mullvad.nu" "$LOCALAPPDATA\nushell\vendor\autoload\mullvad.nu"
+
+!macroend
+
+!define InstallShellCompletions '!insertmacro "InstallShellCompletions"'
+
 #
 # RemoveCLIFromEnvironPath
 #
@@ -587,6 +598,15 @@ ManifestDPIAware true
 !macroend
 
 !define RemoveCLIFromEnvironPath '!insertmacro "RemoveCLIFromEnvironPath"'
+
+!macro RemoveShellCompletions
+
+	SetShellVarContext all
+	Delete "$LOCALAPPDATA\nushell\vendor\autoload\mullvad.nu"
+
+!macroend
+
+!define RemoveShellCompletions '!insertmacro "RemoveShellCompletions"'
 
 #
 # ClearFirewallRules
@@ -816,6 +836,7 @@ ManifestDPIAware true
 	${EndIf}
 
 	${AddCLIToEnvironPath}
+	${InstallShellCompletions}
 	${InstallTrayIcon}
 
 	Goto customInstall_skip_abort
@@ -1210,6 +1231,7 @@ ManifestDPIAware true
 	customRemoveFiles_final_cleanup:
 
 	${RemoveCLIFromEnvironPath}
+	${RemoveShellCompletions}
 
 	${If} $FullUninstall == 1
 		${ClearFirewallRules}

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -33,9 +33,11 @@ talpid-types = { path = "../talpid-types" }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread"] }
 
-[target.'cfg(all(unix, not(target_os = "android")))'.dependencies]
+[target.'cfg(any(windows, all(unix, not(target_os = "android"))))'.dependencies]
 clap_complete = { version = "4.4.8" }
 clap_complete_nushell = "4.6.2"
+
+[target.'cfg(all(unix, not(target_os = "android")))'.dependencies]
 nix = { workspace = true, features = ["signal"] }
 
 [target."cfg(windows)".build-dependencies]

--- a/mullvad-cli/src/main.rs
+++ b/mullvad-cli/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::Parser;
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(any(windows, all(unix, not(target_os = "android"))))]
 use clap::ValueEnum;
 
 mod cmds;
@@ -15,7 +15,7 @@ pub const BIN_NAME: &str = env!("CARGO_BIN_NAME");
 ///
 /// NOTE: this enum as a copy of [`clap_complete::Shell`],
 /// with Nushell added.
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(any(windows, all(unix, not(target_os = "android"))))]
 #[derive(Clone, ValueEnum, Debug)]
 enum CompletionShell {
     /// Bourne Again `SHell` (bash)
@@ -33,7 +33,7 @@ enum CompletionShell {
     Nushell,
 }
 
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(any(windows, all(unix, not(target_os = "android"))))]
 impl CompletionShell {
     fn generate_to(self, dir: &std::path::Path) -> std::io::Result<std::path::PathBuf> {
         use clap::CommandFactory;
@@ -161,7 +161,7 @@ enum Cli {
     Version,
 
     /// Generate completion scripts for the specified shell
-    #[cfg(all(unix, not(target_os = "android")))]
+    #[cfg(any(windows, all(unix, not(target_os = "android"))))]
     #[command(hide = true)]
     ShellCompletions {
         /// The shell to generate the script for
@@ -246,7 +246,7 @@ async fn main() -> Result<()> {
         Cli::ExportSettings { file } => patch::export(file).await,
         Cli::Log(cmd) => cmd.handle().await,
 
-        #[cfg(all(unix, not(target_os = "android")))]
+        #[cfg(any(windows, all(unix, not(target_os = "android"))))]
         Cli::ShellCompletions { shell, dir } => {
             use anyhow::Context;
             // FIXME: The shell completions include hidden commands (including "shell-completions")

--- a/test/test-runner/src/app.rs
+++ b/test/test-runner/src/app.rs
@@ -49,6 +49,7 @@ pub fn find_traces() -> Result<Vec<AppTrace>, Error> {
         // NOTE: Works as of `4116ebc` (Mullvad app).
         &settings_dir,
         &caches,
+        Path::new(r"C:\ProgramData\nushell\vendor\autoload\mullvad.nu"),
     ];
 
     Ok(existing_paths(&traces))


### PR DESCRIPTION
Add completion support for the CLI to Windows, for Powershell and Nushell.

TODO: The PS completions are not currently loaded automatically if using the `AllSigned execution policy`, as the `_mullvad.ps1` is unsigned. I'm not sure if it's worth the effort or if only Nushell should be supported.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11010)
<!-- Reviewable:end -->
