### PR TITLE
Restructure MullvadStateView to centre content, place buttons on bottom

### DIFF
--- a/ios/MullvadVPN/Views/MullvadStateView.swift
+++ b/ios/MullvadVPN/Views/MullvadStateView.swift
@@ -163,40 +163,48 @@ final class StateViewModel: Identifiable, ObservableObject {
 // MARK: - Main State View
 struct MullvadStateView: View {
     @ObservedObject var viewModel: StateViewModel
+    @ScaledMetric private var actionHeight: CGFloat = 36.0
 
     var body: some View {
-        ScrollView {
-            VStack(spacing: 0) {
-                StateView(state: viewModel.style)
-                    .padding(.bottom, Layout.sectionSpacing)
+        ZStack {
+            ScrollView {
+                ZStack {
+                    Spacer().containerRelativeFrame([.horizontal, .vertical])
+                    VStack(spacing: 0) {
+                        Spacer()
+                        StateView(state: viewModel.style)
+                            .padding(.bottom, Layout.sectionSpacing)
 
-                StyledTextView(item: viewModel.title)
+                        StyledTextView(item: viewModel.title)
 
-                if let banner = viewModel.banner {
-                    ResizableImageView(image: banner, dimension: .width(.infinity))
-                        .padding(.bottom, Layout.bannerSpacing)
-                }
+                        if let banner = viewModel.banner {
+                            ResizableImageView(image: banner, dimension: .width(.infinity))
+                                .padding(.bottom, Layout.bannerSpacing)
+                        }
 
-                ForEach(viewModel.details) { item in
-                    StyledTextView(item: item)
-                }
+                        ForEach(viewModel.details) { item in
+                            StyledTextView(item: item)
+                        }
 
-                Spacer()
+                        Spacer()
 
-                if let explanation = viewModel.explanation {
-                    StyledTextView(item: explanation)
-                }
+                        if let explanation = viewModel.explanation {
+                            StyledTextView(item: explanation)
+                        }
 
-                VStack(spacing: 12) {
-                    ForEach(viewModel.actions) { action in
-                        ActionButton(action: action)
+                        Spacer().frame(height: actionHeight * CGFloat(viewModel.actions.count))
                     }
+                    .padding(.top, Layout.topPadding)
+                    .padding(.horizontal, Layout.horizontalPadding)
+                    .padding(.bottom, Layout.bottomPadding)
                 }
-                .padding(.top, 8)
             }
-            .padding(.top, Layout.topPadding)
-            .padding(.horizontal, Layout.horizontalPadding)
-            .padding(.bottom, Layout.bottomPadding)
+            VStack(spacing: 12) {
+                Spacer()
+                ForEach(viewModel.actions) { action in
+                    ActionButton(action: action)
+                }
+            }
         }
     }
 }

--- a/ios/MullvadVPN/Views/MullvadStateView.swift
+++ b/ios/MullvadVPN/Views/MullvadStateView.swift
@@ -191,12 +191,10 @@ struct MullvadStateView: View {
                         if let explanation = viewModel.explanation {
                             StyledTextView(item: explanation)
                         }
-
-                        Spacer().frame(height: actionHeight)
                     }
                     .padding(.top, Layout.topPadding)
                     .padding(.horizontal, Layout.horizontalPadding)
-                    .padding(.bottom, Layout.bottomPadding)
+                    .padding(.bottom, actionHeight)
                 }
             }
             VStack(spacing: 12) {
@@ -205,7 +203,9 @@ struct MullvadStateView: View {
                     ForEach(viewModel.actions) { action in
                         ActionButton(action: action)
                     }
-                }.sizeOfView { size in
+                }
+                .padding(.bottom, Layout.bottomPadding)
+                .sizeOfView { size in
                     self.actionHeight = size.height
                 }
             }

--- a/ios/MullvadVPN/Views/MullvadStateView.swift
+++ b/ios/MullvadVPN/Views/MullvadStateView.swift
@@ -163,7 +163,7 @@ final class StateViewModel: Identifiable, ObservableObject {
 // MARK: - Main State View
 struct MullvadStateView: View {
     @ObservedObject var viewModel: StateViewModel
-    @ScaledMetric private var actionHeight: CGFloat = 36.0
+    @State private var actionHeight: CGFloat = 0
 
     var body: some View {
         ZStack {
@@ -192,7 +192,7 @@ struct MullvadStateView: View {
                             StyledTextView(item: explanation)
                         }
 
-                        Spacer().frame(height: actionHeight * CGFloat(viewModel.actions.count))
+                        Spacer().frame(height: actionHeight)
                     }
                     .padding(.top, Layout.topPadding)
                     .padding(.horizontal, Layout.horizontalPadding)
@@ -201,8 +201,12 @@ struct MullvadStateView: View {
             }
             VStack(spacing: 12) {
                 Spacer()
-                ForEach(viewModel.actions) { action in
-                    ActionButton(action: action)
+                Group {
+                    ForEach(viewModel.actions) { action in
+                        ActionButton(action: action)
+                    }
+                }.sizeOfView { size in
+                    self.actionHeight = size.height
                 }
             }
         }


### PR DESCRIPTION
This fixes the multihop when-needed info view, centering it vertically and placing the button at the bottom:

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/f95632b8-da86-4de2-8c93-5c6f9e5566db" />

It does this by restructuring `MullvadStateView` (which this is an instance of), moving the action buttons outside of the `ScrollView` that contained them, and having them float over the scrolling content. This content is now centred if it is smaller than the scroll view.

As this is a change to `MullvadStateView`, it also affects other views that use it, such as the SettingsMigrationWizard, which now looks like:

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/6713edb0-be45-446a-989c-d603c332109d" />

(I discussed this change with @waahlnaden .)

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11013)
<!-- Reviewable:end -->
