### PR TITLE
Fix panic when migrating settings without an entry location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix IPv6 obfuscation relay selection when the relay's WireGuard endpoint only has IPv4.
 - Fix the device sometimes being incorrectly marked as revoked when the API rejects an expired
   access token.
+- Fix daemon crashing on startup when migrating settings that contain no WireGuard entry location.
 
 #### Linux
 - Parse the `resolv.conf` format using `resolv-conf` crate. This will lead to fewer false negatives

--- a/mullvad-daemon/src/migrations/v15.rs
+++ b/mullvad-daemon/src/migrations/v15.rs
@@ -29,7 +29,7 @@ fn migrate_entry_location(settings: &mut serde_json::Value) -> Option<()> {
         .and_then(|normal_relay_settings| normal_relay_settings.get_mut("wireguard_constraints"))
         .and_then(|wireguard_constraints| wireguard_constraints.as_object_mut())?;
 
-    let entry_location_value = &wireguard_constraints[WIREGUARD_ENTRY_LOCATION_KEY];
+    let entry_location_value = wireguard_constraints.get(WIREGUARD_ENTRY_LOCATION_KEY)?;
 
     let bad_entry_location = json!({ "only": {
         "location": {


### PR DESCRIPTION
Previously, the V15 migration indexed the `wireguard_constraints` object with `entry_location`, which panics if the key is absent. It now returns early instead, leaving such settings untouched.

Fix DES-3188

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11017)
<!-- Reviewable:end -->
