### PR TITLE
Remove macOS 13 from desktop E2E nightly runs

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -23,7 +23,7 @@ on:
           Default images:\n
           `ubuntu2204 ubuntu2404 ubuntu2504 ubuntu2510 \
           debian13 fedora42 fedora43 windows10 windows11 \
-          macos13 macos14 macos15 macos26`."
+          macos14 macos15 macos26`."
         default: ''
         required: false
         type: string
@@ -75,7 +75,7 @@ jobs:
         shell: bash
         run: |
           all='["macos12","macos13","macos14","macos15","macos26"]'
-          default='["macos13","macos14","macos15","macos26"]'
+          default='["macos14","macos15","macos26"]'
           oses="${{ github.event.inputs.oses }}"
           if [[ -z "$oses" || "$oses" == "null" ]]; then
             selected="$default"


### PR DESCRIPTION
macOS 13 is not officially supported by us: https://github.com/mullvad/mullvadvpn-app/blob/main/docs/supported-platforms.md#macos. We can still trigger E2E test runs manually if needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11027)
<!-- Reviewable:end -->
