### PR TITLE
Always pin the LE root when fetching version metadata

### DIFF
--- a/mullvad-release-android/src/client/api.rs
+++ b/mullvad-release-android/src/client/api.rs
@@ -31,7 +31,7 @@ impl HttpVersionInfoProvider {
     }
 
     async fn get_releases_inner(&self) -> anyhow::Result<AndroidReleases> {
-        let raw_json = Self::get(&self.url, None, self.resolve).await?;
+        let raw_json = Self::get(&self.url, self.resolve).await?;
         serde_json::from_slice(&raw_json).context("Failed to deserialize Android releases")
     }
 
@@ -39,7 +39,6 @@ impl HttpVersionInfoProvider {
     pub async fn get_latest_versions_file() -> anyhow::Result<String> {
         Self::get(
             &format!("{}{}", defaults::METADATA_URL, "latest.json"),
-            None,
             None,
         )
         .await
@@ -49,23 +48,17 @@ impl HttpVersionInfoProvider {
 
     /// Perform a simple GET request, with a size limit, and return it as bytes
     ///
+    /// Version metadata is always fetched over TLS 1.3 with the Let's Encrypt
+    /// root as the only accepted trust anchor.
+    ///
     /// # Arguments
     /// `url` - URL to fetch
-    /// `pinned_certificate` - Optional pinned certificate for TLS verification
     /// `resolve` - Optional host to resolve (to the IP) without DNS
-    async fn get(
-        url: &str,
-        pinned_certificate: Option<reqwest::Certificate>,
-        resolve: Option<(&'static str, IpAddr)>,
-    ) -> anyhow::Result<Vec<u8>> {
-        let mut req_builder = reqwest::Client::builder();
-        req_builder = req_builder.min_tls_version(reqwest::tls::Version::TLS_1_3);
-
-        if let Some(pinned_certificate) = pinned_certificate {
-            req_builder = req_builder
-                .tls_built_in_root_certs(false)
-                .add_root_certificate(pinned_certificate);
-        }
+    async fn get(url: &str, resolve: Option<(&'static str, IpAddr)>) -> anyhow::Result<Vec<u8>> {
+        let mut req_builder = reqwest::Client::builder()
+            .min_tls_version(reqwest::tls::Version::TLS_1_3)
+            .tls_built_in_root_certs(false)
+            .add_root_certificate(defaults::PINNED_CERTIFICATE.clone());
 
         // Resolve name without DNS
         if let Some((host, addr)) = resolve {

--- a/mullvad-release-android/src/client/defaults.rs
+++ b/mullvad-release-android/src/client/defaults.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 /// Default URL for the `releases`-API.
 ///
 /// Note that this is just a proxy to _some_ of the files in [METADATA_URL].
@@ -5,3 +7,12 @@ pub const RELEASES_URL: &str = "https://api.mullvad.net/app/releases/";
 
 /// Default URL for version metadata repository.
 pub const METADATA_URL: &str = "https://releases.mullvad.net/android/metadata/";
+
+/// Accepted root certificate for the hosts above. Only this certificate is
+/// trusted when fetching version metadata.
+///
+/// This is the Let's Encrypt root-certificate.
+pub static PINNED_CERTIFICATE: LazyLock<reqwest::Certificate> = LazyLock::new(|| {
+    const CERT_BYTES: &[u8] = include_bytes!("../../../mullvad-api/le_root_cert.pem");
+    reqwest::Certificate::from_pem(CERT_BYTES).expect("invalid cert")
+});

--- a/mullvad-update/src/client/api.rs
+++ b/mullvad-update/src/client/api.rs
@@ -50,8 +50,6 @@ pub struct HttpVersionInfoProvider {
     url: String,
     /// Optional host to resolve (to the IP) without DNS
     resolve: Option<(&'static str, IpAddr)>,
-    /// Accepted root certificate. Defaults are used unless specified
-    pinned_certificate: Option<reqwest::Certificate>,
     /// If set, the response metadata will be serialized and written to this path
     dump_to_path: Option<PathBuf>,
 }
@@ -95,7 +93,6 @@ impl HttpVersionInfoProvider {
         HttpVersionInfoProvider {
             url: format!("{}/{}", base_url, platform.filename()),
             resolve: Some((API_HOST_DEFAULT, API_IP_DEFAULT)),
-            pinned_certificate: Some(defaults::PINNED_CERTIFICATE.clone()),
             dump_to_path: None,
         }
     }
@@ -140,7 +137,7 @@ impl HttpVersionInfoProvider {
         &self,
         deserialize_fn: impl FnOnce(&[u8]) -> anyhow::Result<SignedResponse>,
     ) -> anyhow::Result<SignedResponse> {
-        let raw_json = Self::get(&self.url, self.pinned_certificate.clone(), self.resolve).await?;
+        let raw_json = Self::get(&self.url, self.resolve).await?;
         let signed_response = deserialize_fn(&raw_json)?;
         if let Some(path) = &self.dump_to_path {
             fs::write(path, raw_json)
@@ -152,39 +149,28 @@ impl HttpVersionInfoProvider {
 
     /// Retrieve the `latest.json` file.
     ///
-    /// - `pinned_certificate` will be set to the LE root certificate.
     /// - DNS will be used to look up the URL.
     /// - The JSON response is not signed.
     pub async fn get_latest_versions_file() -> anyhow::Result<String> {
-        Self::get(
-            &format!("{}/latest.json", defaults::METADATA_URL),
-            Some(defaults::PINNED_CERTIFICATE.clone()),
-            None,
-        )
-        .await
-        .and_then(|raw_json: Vec<u8>| Ok(String::from_utf8(raw_json)?))
-        .context("Failed to get latest.json file")
+        Self::get(&format!("{}/latest.json", defaults::METADATA_URL), None)
+            .await
+            .and_then(|raw_json: Vec<u8>| Ok(String::from_utf8(raw_json)?))
+            .context("Failed to get latest.json file")
     }
 
     /// Perform a simple GET request, with a size limit, and return it as bytes
     ///
+    /// Version metadata is always fetched over TLS 1.3 with the Let's Encrypt
+    /// root as the only accepted trust anchor.
+    ///
     /// # Arguments
     /// `url` - URL to fetch
-    /// `pinned_certificate` - Optional pinned certificate for TLS verification
     /// `resolve` - Optional host to resolve (to the IP) without DNS
-    async fn get(
-        url: &str,
-        pinned_certificate: Option<reqwest::Certificate>,
-        resolve: Option<(&'static str, IpAddr)>,
-    ) -> anyhow::Result<Vec<u8>> {
-        let mut req_builder = reqwest::Client::builder();
-        req_builder = req_builder.min_tls_version(reqwest::tls::Version::TLS_1_3);
-
-        if let Some(pinned_certificate) = pinned_certificate {
-            req_builder = req_builder
-                .tls_built_in_root_certs(false)
-                .add_root_certificate(pinned_certificate);
-        }
+    async fn get(url: &str, resolve: Option<(&'static str, IpAddr)>) -> anyhow::Result<Vec<u8>> {
+        let mut req_builder = reqwest::Client::builder()
+            .min_tls_version(reqwest::tls::Version::TLS_1_3)
+            .tls_built_in_root_certs(false)
+            .add_root_certificate(defaults::PINNED_CERTIFICATE.clone());
 
         // Resolve name without DNS
         if let Some((host, addr)) = resolve {
@@ -268,7 +254,6 @@ mod test {
         // Construct query and provider
         let info_provider = HttpVersionInfoProvider {
             url,
-            pinned_certificate: None,
             resolve: Some(resolve),
             dump_to_path: Some(temp_dump.clone()),
         };


### PR DESCRIPTION
mullvad-update took the pinned certificate as an Option, so an unpinned metadata fetcher could be constructed by mistake. Every caller already passed the Let's Encrypt root, so require it instead of accepting it.

mullvad-release-android passed nothing at all, and nothing it downloads is signed, so TLS was its only integrity control. It talks to the same two hosts, which chain to the same root, so pin it there too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11036)
<!-- Reviewable:end -->
