### PR TITLE
Block private networks on tunnel device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@ Line wrap the file at 100 chars.                                              Th
 - Fix local privilege escalation attack in the uninstall script. This could be used by admin users
   to obtain root privileges during uninstall.
 
+### Security
+- Prevent LAN traffic from leaking into the tunnel when "local network sharing" is enabled.
+
 
 ## [2026.5-beta1] - 2026-08-31
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,6 +214,8 @@ quinn-proto.opt-level = 3
 quinn-udp.opt-level = 3
 shadowsocks.opt-level = 3
 shadowsocks-crypto.opt-level = 3
+talpid-types.opt-level = 3
+talpid-wireguard.opt-level = 3
 tunnel-obfuscation.opt-level = 3
 udp-over-tcp.opt-level = 3
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -143,6 +143,15 @@ All API connections use TLS 1.3 with certificate pinning. The app comes bundled 
 with servers having a valid certificate issued to `api.mullvad.net` and signed with this
 bundled certificate.
 
+#### Tunnel
+
+The networks that "Allow LAN" permits outside the tunnel are blocked outbound *on* the tunnel
+interface, with some exceptions where private ranges are used to communicate with relays, SOCKS
+proxies, etc. Current exceptions:
+
+* `10.0.0.0/8`, and
+* `fc00:bbbb:bbbb:bb01::/64`.
+
 ### Disconnected
 
 This is the default state that the `mullvad-daemon` starts in when the device boots, unless

--- a/talpid-core/src/firewall/linux.rs
+++ b/talpid-core/src/firewall/linux.rs
@@ -16,8 +16,8 @@ use std::{
 use talpid_cgroup::v2::CGroup2;
 use talpid_tunnel::TunnelMetadata;
 use talpid_types::net::{
-    ALLOWED_LAN_MULTICAST_NETS, ALLOWED_LAN_NETS, AllowedEndpoint, AllowedTunnelTraffic, Endpoint,
-    TransportProtocol,
+    ALLOWED_IN_TUNNEL_LAN_NETS, ALLOWED_LAN_MULTICAST_NETS, ALLOWED_LAN_NETS, AllowedEndpoint,
+    AllowedTunnelTraffic, Endpoint, TransportProtocol,
 };
 
 /// Priority for rules that tag split tunneling packets. Equals NF_IP_PRI_MANGLE.
@@ -639,6 +639,7 @@ impl<'a> PolicyBatch<'a> {
                 if let Some(tunnel) = tunnel {
                     match allowed_tunnel_traffic {
                         AllowedTunnelTraffic::All => {
+                            self.add_block_lan_in_tunnel_rules(&tunnel.interface)?;
                             self.add_allow_tunnel_rules(&tunnel.interface)?;
                         }
                         AllowedTunnelTraffic::None => (),
@@ -694,6 +695,7 @@ impl<'a> PolicyBatch<'a> {
                 // Important to block DNS *before* we allow the tunnel and allow LAN. So DNS
                 // can't leak to the wrong IPs in the tunnel or on the LAN.
                 self.add_drop_dns_rule();
+                self.add_block_lan_in_tunnel_rules(&tunnel.interface)?;
                 self.add_allow_tunnel_rules(&tunnel.interface)?;
                 if *allow_lan {
                     self.add_block_cve_2019_14899(tunnel);
@@ -901,6 +903,43 @@ impl<'a> PolicyBatch<'a> {
             add_verdict(&mut rule, &Verdict::Accept);
             self.batch.add(&rule, nftnl::MsgType::Add);
         }
+        Ok(())
+    }
+
+    /// Drop traffic between the tunnel interface and the LAN, before allowing LAN traffic
+    /// on other interfaces.
+    fn add_block_lan_in_tunnel_rules(&mut self, tunnel_interface: &str) -> Result<()> {
+        let ends = [
+            (&self.out_chain, Direction::Out, End::Dst),
+            (&self.forward_chain, Direction::Out, End::Dst),
+        ];
+
+        // Accept: Tunnel => LAN / Private IP ranges that *should* be reachable in the tunnel.
+        for (chain, direction, end) in ends {
+            for net in ALLOWED_IN_TUNNEL_LAN_NETS {
+                let mut rule = Rule::new(chain);
+                check_iface(&mut rule, direction, tunnel_interface)?;
+                check_net(&mut rule, end, net);
+                add_verdict(&mut rule, &Verdict::Accept);
+                self.batch.add(&rule, nftnl::MsgType::Add);
+            }
+        }
+
+        // Drop: LAN => Tunnel / Multicast ranges + LAN Sharing ranges.
+        for (chain, direction, end) in ends {
+            let nets = ALLOWED_LAN_NETS
+                .iter()
+                .chain(ALLOWED_LAN_MULTICAST_NETS.iter());
+
+            for net in nets {
+                let mut rule = Rule::new(chain);
+                check_iface(&mut rule, direction, tunnel_interface)?;
+                check_net(&mut rule, end, *net);
+                add_verdict(&mut rule, &Verdict::Drop);
+                self.batch.add(&rule, nftnl::MsgType::Add);
+            }
+        }
+
         Ok(())
     }
 

--- a/talpid-types/src/bin/generate-cpp-lannetworks.rs
+++ b/talpid-types/src/bin/generate-cpp-lannetworks.rs
@@ -1,7 +1,7 @@
 use std::io::{self, Write};
 
 use ipnetwork::IpNetwork;
-use talpid_types::net::{ALLOWED_LAN_MULTICAST_NETS, ALLOWED_LAN_NETS};
+use talpid_types::net::{ALLOWED_IN_TUNNEL_LAN_NETS, ALLOWED_LAN_MULTICAST_NETS, ALLOWED_LAN_NETS};
 
 pub fn main() {
     generate_allowed_nets_cpp_header(&mut std::io::stdout()).unwrap()
@@ -25,6 +25,13 @@ fn generate_allowed_nets_cpp_header(mut w: impl Write) -> io::Result<()> {
             .partition(|net| net.is_ipv4());
     generate_ip_network_cpp_definitions(&mut w, "g_ipv4MulticastNets", &ipv4_multicast_nets)?;
     generate_ip_network_cpp_definitions(&mut w, "g_ipv6MulticastNets", &ipv6_multicast_nets)?;
+
+    let (ipv4_in_tunnel_nets, ipv6_in_tunnel_nets): (Vec<IpNetwork>, _) =
+        ALLOWED_IN_TUNNEL_LAN_NETS
+            .iter()
+            .partition(|net| net.is_ipv4());
+    generate_ip_network_cpp_definitions(&mut w, "g_ipv4InTunnelLanNets", &ipv4_in_tunnel_nets)?;
+    generate_ip_network_cpp_definitions(&mut w, "g_ipv6InTunnelLanNets", &ipv6_in_tunnel_nets)?;
 
     Ok(())
 }

--- a/talpid-types/src/bin/snapshots/generate_cpp_lannetworks__tests__cpp_definition.snap
+++ b/talpid-types/src/bin/snapshots/generate_cpp_lannetworks__tests__cpp_definition.snap
@@ -32,3 +32,11 @@ static const wfp::IpNetwork g_ipv6MulticastNets[] = {
 	wfp::IpNetwork(wfp::IpAddress::Literal6({ 0xff04, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000 }), 16),
 	wfp::IpNetwork(wfp::IpAddress::Literal6({ 0xff05, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000 }), 16),
 };
+
+static const wfp::IpNetwork g_ipv4InTunnelLanNets[] = {
+	wfp::IpNetwork(wfp::IpAddress::Literal({ 10, 0, 0, 0 }), 8),
+};
+
+static const wfp::IpNetwork g_ipv6InTunnelLanNets[] = {
+	wfp::IpNetwork(wfp::IpAddress::Literal6({ 0xfc00, 0xbbbb, 0xbbbb, 0xbb01, 0x0000, 0x0000, 0x0000, 0x0000 }), 64),
+};

--- a/talpid-types/src/net/allowed_nets.rs
+++ b/talpid-types/src/net/allowed_nets.rs
@@ -59,6 +59,7 @@ const fn v6(address: Ipv6Addr, prefix: u8) -> IpNetwork {
 }
 
 /// Whether `ip` should be an allowed remote address in the VPN tunnel.
+#[inline]
 pub fn is_ip_allowed_in_tunnel(ip: IpAddr) -> bool {
     ALLOWED_IN_TUNNEL_LAN_NETS
         .iter()

--- a/talpid-types/src/net/allowed_nets.rs
+++ b/talpid-types/src/net/allowed_nets.rs
@@ -11,6 +11,23 @@ pub const ALLOWED_LAN_NETS: [IpNetwork; 6] = [
     v6(Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 0), 7),
 ];
 
+/// Private networks that are legitimately reachable *inside* a Mullvad tunnel.
+///
+/// [`ALLOWED_LAN_NETS`] covers the entire private address space, but a handful of those addresses
+/// are Mullvad's own and only exist on the other side of the tunnel. Traffic to them must keep
+/// working when LAN traffic is dropped on the tunnel interface.
+pub const ALLOWED_IN_TUNNEL_LAN_NETS: [IpNetwork; 2] = [
+    // The relay IPv4 gateway. Hosts the DNS resolver, the tunnel config service used for DAITA and
+    // PQ key exchange, and connectivity check pings. Generous to avoid restricting potential future
+    // ranges.
+    v4(Ipv4Addr::new(10, 0, 0, 0), 8),
+    // The relay IPv6 gateway.
+    v6(
+        Ipv6Addr::new(0xfc00, 0xbbbb, 0xbbbb, 0xbb01, 0, 0, 0, 0),
+        64,
+    ),
+];
+
 /// When "allow local network" is enabled the app will allow traffic to these networks.
 pub const ALLOWED_LAN_MULTICAST_NETS: [IpNetwork; 8] = [
     // Local network broadcast. Not routable

--- a/talpid-types/src/net/allowed_nets.rs
+++ b/talpid-types/src/net/allowed_nets.rs
@@ -1,5 +1,5 @@
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 /// When "allow local network" is enabled the app will allow traffic to and from these networks.
 pub const ALLOWED_LAN_NETS: [IpNetwork; 6] = [
@@ -56,4 +56,44 @@ const fn v4(address: Ipv4Addr, prefix: u8) -> IpNetwork {
 // Short-hand for `IpNetwork::V6(Ipv6Network::new_checked(address, prefix).unwrap())`.
 const fn v6(address: Ipv6Addr, prefix: u8) -> IpNetwork {
     IpNetwork::V6(Ipv6Network::new_checked(address, prefix).unwrap())
+}
+
+/// Whether `ip` should be an allowed remote address in the VPN tunnel.
+pub fn is_ip_allowed_in_tunnel(ip: IpAddr) -> bool {
+    ALLOWED_IN_TUNNEL_LAN_NETS
+        .iter()
+        .any(|net| net.contains(ip))
+        || !ALLOWED_LAN_NETS
+            .iter()
+            .chain(ALLOWED_LAN_MULTICAST_NETS.iter())
+            .any(|net| net.contains(ip))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_in_tunnel_nets() {
+        // - IPv4 gateway/DNS: 10.64.0.1
+        // - SOCKS proxies: 10.124.0.0/23
+        // - Possible future range: 10.128.0.1
+        let must_allow: Vec<IpAddr> = ["10.64.0.1", "10.128.0.1", "10.124.0.2", "100.64.0.1"]
+            .iter()
+            .map(|ip| ip.parse().unwrap())
+            .collect();
+
+        for ip in must_allow {
+            assert!(
+                is_ip_allowed_in_tunnel(ip),
+                "{ip} must be allowed in tunnel"
+            );
+        }
+
+        let must_disallow = "192.168.1.1".parse().unwrap();
+        assert!(
+            !is_ip_allowed_in_tunnel(must_disallow),
+            "{must_disallow} must not be allowed in tunnel"
+        );
+    }
 }

--- a/talpid-wireguard/src/gotatun/lan_filter.rs
+++ b/talpid-wireguard/src/gotatun/lan_filter.rs
@@ -1,0 +1,41 @@
+//! Drop packets read from the TUN device that are destined for the local network, unless allowed by
+//! [`is_ip_allowed_in_tunnel`].
+
+use gotatun::{
+    packet::{Ip, Packet, PacketBufPool},
+    tun::{IpRecv, MtuWatcher},
+};
+use std::io;
+use talpid_types::net::is_ip_allowed_in_tunnel;
+
+/// Wraps an [`IpRecv`] and drops any packet destined for the local network. Packets that we can't
+/// read a destination address from at all are dropped as well.
+pub struct LanFilter<R> {
+    inner: R,
+}
+
+impl<R: IpRecv> LanFilter<R> {
+    pub fn new(inner: R) -> Self {
+        Self { inner }
+    }
+}
+
+impl<R: IpRecv> IpRecv for LanFilter<R> {
+    async fn recv<'a>(
+        &'a mut self,
+        pool: &mut PacketBufPool,
+    ) -> io::Result<impl Iterator<Item = Packet<Ip>> + Send + 'a> {
+        let packets = self.inner.recv(pool).await?;
+
+        Ok(
+            packets.filter(|packet: &Packet<Ip>| match packet.destination() {
+                Some(destination) => is_ip_allowed_in_tunnel(destination),
+                None => false,
+            }),
+        )
+    }
+
+    fn mtu(&self) -> MtuWatcher {
+        self.inner.mtu()
+    }
+}

--- a/talpid-wireguard/src/gotatun/mod.rs
+++ b/talpid-wireguard/src/gotatun/mod.rs
@@ -40,20 +40,21 @@ use gotatun::tun::{
 };
 
 mod conversions;
+mod lan_filter;
 mod obfuscation;
 mod source_filter;
 
 use conversions::to_gotatun_peer;
+use lan_filter::LanFilter;
 use source_filter::SourceFilter;
 
 type TransportFactory = MaybeObfuscatingTransportFactory;
 
-type SinglehopDevice = Device<(TransportFactory, GotaTunDevice, SourceFilter<GotaTunDevice>)>;
-type ExitDevice = Device<(
-    UdpChannelFactory,
-    GotaTunDevice,
-    SourceFilter<GotaTunDevice>,
-)>;
+/// Everything read from the TUN device passes both filters before it enters the tunnel.
+type TunRx = LanFilter<SourceFilter<GotaTunDevice>>;
+
+type SinglehopDevice = Device<(TransportFactory, GotaTunDevice, TunRx)>;
+type ExitDevice = Device<(UdpChannelFactory, GotaTunDevice, TunRx)>;
 
 #[cfg(not(all(feature = "multihop-pcap", target_os = "linux")))]
 type EntryDevice = Device<(TransportFactory, TunChannelTx, TunChannelRx)>;
@@ -516,7 +517,7 @@ async fn create_devices(
                 entry_mtu,
             );
 
-            let tun_rx = SourceFilter::new(tun_dev.clone(), source_v4, source_v6);
+            let tun_rx = LanFilter::new(SourceFilter::new(tun_dev.clone(), source_v4, source_v6));
             let exit_device = DeviceBuilder::new()
                 .with_udp(udp_channels)
                 .with_ip_pair(tun_dev, tun_rx)
@@ -543,7 +544,7 @@ async fn create_devices(
         } else {
             // Singlehop setup
 
-            let tun_rx = SourceFilter::new(tun_dev.clone(), source_v4, source_v6);
+            let tun_rx = LanFilter::new(SourceFilter::new(tun_dev.clone(), source_v4, source_v6));
             let device = DeviceBuilder::new()
                 .with_udp(factory)
                 .with_ip_pair(tun_dev, tun_rx)

--- a/windows/winfw/src/winfw/fwcontext.cpp
+++ b/windows/winfw/src/winfw/fwcontext.cpp
@@ -5,6 +5,7 @@
 #include "rules/ifirewallrule.h"
 #include "rules/ports.h"
 #include "rules/baseline/blockall.h"
+#include "rules/baseline/blocklanintunnel.h"
 #include "rules/baseline/permitdhcp.h"
 #include "rules/baseline/permitndp.h"
 #include "rules/baseline/permitdhcpserver.h"
@@ -220,6 +221,9 @@ bool FwContext::applyPolicyConnecting
 		{
 			case WinFwAllowedTunnelTrafficType::All:
 			{
+				ruleset.emplace_back(std::make_unique<baseline::BlockLanInTunnel>(
+					*tunnelInterfaceAlias
+				));
 				ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnel>(
 					relayClients,
 					*tunnelInterfaceAlias,
@@ -333,6 +337,10 @@ bool FwContext::applyPolicyConnected
 			tunnelInterfaceAlias, nonTunnelDnsServers
 		));
 	}
+
+	ruleset.emplace_back(std::make_unique<baseline::BlockLanInTunnel>(
+		tunnelInterfaceAlias
+	));
 
 	ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnel>(
 		relayClients,

--- a/windows/winfw/src/winfw/mullvadguids.cpp
+++ b/windows/winfw/src/winfw/mullvadguids.cpp
@@ -423,6 +423,62 @@ const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_BlockExitIp()
 }
 
 //static
+const GUID &MullvadGuids::Filter_Baseline_BlockLanInTunnel_PermitMullvad_Outbound_Ipv4()
+{
+	static const GUID g =
+	{
+		0x79992285,
+		0x5773,
+		0x4020,
+		{ 0x92, 0xa2, 0xbd, 0x0b, 0x0a, 0x82, 0x0c, 0x34 }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_BlockLanInTunnel_Outbound_Ipv4()
+{
+	static const GUID g =
+	{
+		0x7726f8dd,
+		0xcc11,
+		0x419d,
+		{ 0xb2, 0xd9, 0x7b, 0xdd, 0xa5, 0xed, 0x90, 0xce }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_BlockLanInTunnel_PermitMullvad_Outbound_Ipv6()
+{
+	static const GUID g =
+	{
+		0x2a371ec4,
+		0x89e2,
+		0x49e5,
+		{ 0x8b, 0xde, 0xf4, 0x03, 0x35, 0x67, 0x23, 0x26 }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_BlockLanInTunnel_Outbound_Ipv6()
+{
+	static const GUID g =
+	{
+		0x935cde0d,
+		0xa8f2,
+		0x4067,
+		{ 0xb5, 0x38, 0xf3, 0x36, 0x12, 0x9b, 0x20, 0xa0 }
+	};
+
+	return g;
+}
+
+//static
 const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv4_1()
 {
 	static const GUID g =

--- a/windows/winfw/src/winfw/mullvadguids.h
+++ b/windows/winfw/src/winfw/mullvadguids.h
@@ -53,6 +53,12 @@ public:
 	static const GUID &Filter_Baseline_PermitVpnTunnel_ExitIp();
 	static const GUID &Filter_Baseline_PermitVpnTunnel_BlockExitIp();
 
+	static const GUID &Filter_Baseline_BlockLanInTunnel_PermitMullvad_Outbound_Ipv4();
+	static const GUID &Filter_Baseline_BlockLanInTunnel_Outbound_Ipv4();
+	static const GUID &Filter_Baseline_BlockLanInTunnel_PermitMullvad_Outbound_Ipv6();
+	static const GUID &Filter_Baseline_BlockLanInTunnel_Outbound_Ipv6();
+	static const GUID &Filter_Baseline_BlockLanInTunnel_Inbound_Ipv6();
+
 	static const GUID &Filter_Baseline_PermitVpnTunnelService_Ipv4_1();
 	static const GUID &Filter_Baseline_PermitVpnTunnelService_Ipv6_1();
 	static const GUID &Filter_Baseline_PermitVpnTunnelService_Ipv4_2();

--- a/windows/winfw/src/winfw/rules/baseline/blocklanintunnel.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/blocklanintunnel.cpp
@@ -1,0 +1,151 @@
+#include "stdafx.h"
+#include "blocklanintunnel.h"
+#include <winfw/mullvadguids.h>
+#include <winfw/lannetworks.h>
+#include <libwfp/filterbuilder.h>
+#include <libwfp/conditionbuilder.h>
+#include <libwfp/ipnetwork.h>
+#include <libwfp/conditions/conditioninterface.h>
+#include <libwfp/conditions/conditionip.h>
+
+using namespace wfp::conditions;
+
+namespace rules::baseline
+{
+
+namespace
+{
+
+//
+// The permit filters have to outrank the block filters, since both match the private ranges that
+// are reachable in the tunnel. Filters that share a weight class are ordered by BFE based on how
+// specific their conditions are, and the block filters have more conditions than the permit
+// filters, so relying on the same class for both makes the block filters win.
+//
+const auto PERMIT_WEIGHT = wfp::FilterBuilder::WeightClass::Max;
+const auto BLOCK_WEIGHT = wfp::FilterBuilder::WeightClass::Class14;
+
+} // anonymous namespace
+
+BlockLanInTunnel::BlockLanInTunnel(const std::wstring &tunnelInterfaceAlias)
+	: m_tunnelInterfaceAlias(tunnelInterfaceAlias)
+{
+}
+
+bool BlockLanInTunnel::apply(IObjectInstaller &objectInstaller)
+{
+	return applyIpv4(objectInstaller) && applyIpv6(objectInstaller);
+}
+
+bool BlockLanInTunnel::applyIpv4(IObjectInstaller &objectInstaller) const
+{
+	wfp::FilterBuilder filterBuilder;
+
+	//
+	// #1 Permit outbound connections to Mullvad's in-tunnel networks.
+	//
+
+	filterBuilder
+		.key(MullvadGuids::Filter_Baseline_BlockLanInTunnel_PermitMullvad_Outbound_Ipv4())
+		.name(L"Permit outbound connections to Mullvad in-tunnel networks (IPv4)")
+		.description(L"This filter is part of a rule that blocks LAN traffic on the tunnel interface")
+		.provider(MullvadGuids::Provider())
+		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V4)
+		.sublayer(MullvadGuids::SublayerBaseline())
+		.weight(PERMIT_WEIGHT)
+		.permit();
+
+	wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V4);
+
+	conditionBuilder.add_condition(ConditionInterface::Alias(m_tunnelInterfaceAlias));
+
+	for (const auto &network : g_ipv4InTunnelLanNets) {
+		conditionBuilder.add_condition(ConditionIp::Remote(network));
+	}
+
+	if (!objectInstaller.addFilter(filterBuilder, conditionBuilder))
+	{
+		return false;
+	}
+
+	//
+	// #2 Block outbound connections to the LAN.
+	//
+
+	filterBuilder
+		.key(MullvadGuids::Filter_Baseline_BlockLanInTunnel_Outbound_Ipv4())
+		.name(L"Block outbound connections to the LAN on tunnel interface (IPv4)")
+		.weight(BLOCK_WEIGHT)
+		.block();
+
+	conditionBuilder.reset();
+
+	conditionBuilder.add_condition(ConditionInterface::Alias(m_tunnelInterfaceAlias));
+
+	for (const auto &network : g_ipv4LanNets) {
+		conditionBuilder.add_condition(ConditionIp::Remote(network));
+	}
+	for (const auto &network : g_ipv4MulticastNets) {
+		conditionBuilder.add_condition(ConditionIp::Remote(network));
+	}
+
+	return objectInstaller.addFilter(filterBuilder, conditionBuilder);
+}
+
+bool BlockLanInTunnel::applyIpv6(IObjectInstaller &objectInstaller) const
+{
+	wfp::FilterBuilder filterBuilder;
+
+	//
+	// #1 Permit outbound connections to Mullvad's in-tunnel networks.
+	//
+
+	filterBuilder
+		.key(MullvadGuids::Filter_Baseline_BlockLanInTunnel_PermitMullvad_Outbound_Ipv6())
+		.name(L"Permit outbound connections to Mullvad in-tunnel networks (IPv6)")
+		.description(L"This filter is part of a rule that blocks LAN traffic on the tunnel interface")
+		.provider(MullvadGuids::Provider())
+		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V6)
+		.sublayer(MullvadGuids::SublayerBaseline())
+		.weight(PERMIT_WEIGHT)
+		.permit();
+
+	wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
+
+	conditionBuilder.add_condition(ConditionInterface::Alias(m_tunnelInterfaceAlias));
+
+	for (const auto &network : g_ipv6InTunnelLanNets) {
+		conditionBuilder.add_condition(ConditionIp::Remote(network));
+	}
+
+	if (!objectInstaller.addFilter(filterBuilder, conditionBuilder))
+	{
+		return false;
+	}
+
+	//
+	// #2 Block outbound connections to the LAN.
+	//
+
+	filterBuilder
+		.key(MullvadGuids::Filter_Baseline_BlockLanInTunnel_Outbound_Ipv6())
+		.name(L"Block outbound connections to the LAN on tunnel interface (IPv6)")
+		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V6)
+		.weight(BLOCK_WEIGHT)
+		.block();
+
+	conditionBuilder.reset();
+
+	conditionBuilder.add_condition(ConditionInterface::Alias(m_tunnelInterfaceAlias));
+
+	for (const auto &network : g_ipv6LanNets) {
+		conditionBuilder.add_condition(ConditionIp::Remote(network));
+	}
+	for (const auto &network : g_ipv6MulticastNets) {
+		conditionBuilder.add_condition(ConditionIp::Remote(network));
+	}
+
+	return objectInstaller.addFilter(filterBuilder, conditionBuilder);
+}
+
+}

--- a/windows/winfw/src/winfw/rules/baseline/blocklanintunnel.h
+++ b/windows/winfw/src/winfw/rules/baseline/blocklanintunnel.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <winfw/rules/ifirewallrule.h>
+#include <string>
+
+namespace rules::baseline
+{
+
+//
+// Block private IP ranges on the tunnel device.
+//
+// Some exceptions are made for Mullvad IPs.
+//
+class BlockLanInTunnel : public IFirewallRule
+{
+public:
+
+	BlockLanInTunnel(const std::wstring &tunnelInterfaceAlias);
+
+	bool apply(IObjectInstaller &objectInstaller) override;
+
+private:
+
+	bool applyIpv4(IObjectInstaller &objectInstaller) const;
+	bool applyIpv6(IObjectInstaller &objectInstaller) const;
+
+	const std::wstring m_tunnelInterfaceAlias;
+};
+
+}

--- a/windows/winfw/src/winfw/winfw.vcxproj
+++ b/windows/winfw/src/winfw/winfw.vcxproj
@@ -32,6 +32,7 @@
     <ClCompile Include="mullvadobjects.cpp" />
     <ClCompile Include="objectpurger.cpp" />
     <ClCompile Include="rules\baseline\blockall.cpp" />
+    <ClCompile Include="rules\baseline\blocklanintunnel.cpp" />
     <ClCompile Include="rules\baseline\permitdhcp.cpp" />
     <ClCompile Include="rules\baseline\permitdhcpserver.cpp" />
     <ClCompile Include="rules\baseline\permitdns.cpp" />
@@ -67,6 +68,7 @@
     <ClInclude Include="mullvadobjects.h" />
     <ClInclude Include="objectpurger.h" />
     <ClInclude Include="rules\baseline\blockall.h" />
+    <ClInclude Include="rules\baseline\blocklanintunnel.h" />
     <ClInclude Include="rules\baseline\permitdhcp.h" />
     <ClInclude Include="rules\baseline\permitdhcpserver.h" />
     <ClInclude Include="rules\baseline\permitdns.h" />

--- a/windows/winfw/src/winfw/winfw.vcxproj.filters
+++ b/windows/winfw/src/winfw/winfw.vcxproj.filters
@@ -13,6 +13,9 @@
     <ClCompile Include="rules\baseline\blockall.cpp">
       <Filter>rules\baseline</Filter>
     </ClCompile>
+    <ClCompile Include="rules\baseline\blocklanintunnel.cpp">
+      <Filter>rules\baseline</Filter>
+    </ClCompile>
     <ClCompile Include="rules\baseline\permitdhcp.cpp">
       <Filter>rules\baseline</Filter>
     </ClCompile>
@@ -82,6 +85,9 @@
       <Filter>rules\baseline</Filter>
     </ClInclude>
     <ClInclude Include="rules\baseline\permitdhcpserver.h">
+      <Filter>rules\baseline</Filter>
+    </ClInclude>
+    <ClInclude Include="rules\baseline\blocklanintunnel.h">
       <Filter>rules\baseline</Filter>
     </ClInclude>
     <ClInclude Include="rules\baseline\permitlan.h">


### PR DESCRIPTION
Changes:
* On Linux and Windows, block most private IP ranges in the firewall for the TUN device.
* For macOS and Android (and Gotatun generally), the same thing was accomplished by wrapping `IpRecv` and dropping packets for those ranges. Outbound only.

Fix DES-133

### Todo
- [ ] Decide on ranges

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11037)
<!-- Reviewable:end -->
