### PR TITLE
Add support for including and excluding multiple apps in one command

### DIFF
--- a/mullvad-cli/src/cmds/split_tunnel/linux.rs
+++ b/mullvad-cli/src/cmds/split_tunnel/linux.rs
@@ -1,29 +1,16 @@
 use anyhow::Result;
-use clap::Subcommand;
 use mullvad_management_interface::MullvadProxyClient;
+
+use crate::cmds::split_tunnel::shared::SplitTunnel;
 
 /// Manage split tunneling. To launch applications outside the tunnel, use the program
 /// 'mullvad-exclude' instead of this command
-#[derive(Subcommand, Debug)]
-pub enum SplitTunnel {
-    /// List all processes that are excluded from the tunnel
-    List,
-    /// Add a PID to exclude from the tunnel
-    Add { pid: i32 },
-    /// Stop excluding a PID from the tunnel
-    Delete { pid: i32 },
-    /// Stop excluding all processes from the tunnel
-    Clear,
-}
-
 impl SplitTunnel {
     pub async fn handle(self) -> Result<()> {
+        let mut proxy = MullvadProxyClient::new().await?;
         match self {
             SplitTunnel::List => {
-                let pids = MullvadProxyClient::new()
-                    .await?
-                    .get_split_tunnel_processes()
-                    .await?;
+                let pids = proxy.get_split_tunnel_processes().await?;
 
                 println!("Excluded PIDs:");
                 for pid in &pids {
@@ -32,27 +19,22 @@ impl SplitTunnel {
 
                 Ok(())
             }
-            SplitTunnel::Add { pid } => {
-                MullvadProxyClient::new()
-                    .await?
-                    .add_split_tunnel_process(pid)
-                    .await?;
-                println!("Excluding process");
+            SplitTunnel::Add { pids } => {
+                for pid in pids {
+                    proxy.add_split_tunnel_process(pid).await?;
+                    println!("Excluding process {pid:?} ");
+                }
                 Ok(())
             }
-            SplitTunnel::Delete { pid } => {
-                MullvadProxyClient::new()
-                    .await?
-                    .remove_split_tunnel_process(pid)
-                    .await?;
-                println!("Stopped excluding process");
+            SplitTunnel::Delete { pids } => {
+                for pid in pids {
+                    proxy.remove_split_tunnel_process(pid).await?;
+                    println!("Stopped excluding process {pid:?}");
+                }
                 Ok(())
             }
             SplitTunnel::Clear => {
-                MullvadProxyClient::new()
-                    .await?
-                    .clear_split_tunnel_processes()
-                    .await?;
+                proxy.clear_split_tunnel_processes().await?;
                 println!("Stopped excluding all processes");
                 Ok(())
             }

--- a/mullvad-cli/src/cmds/split_tunnel/macos.rs
+++ b/mullvad-cli/src/cmds/split_tunnel/macos.rs
@@ -1,31 +1,10 @@
 use anyhow::Result;
-use std::path::PathBuf;
 
-use clap::Subcommand;
 use mullvad_management_interface::MullvadProxyClient;
 
+use crate::cmds::split_tunnel::shared::SplitTunnel;
+
 use super::super::BooleanOption;
-
-/// Set options for applications to exclude from the tunnel.
-#[derive(Subcommand, Debug)]
-pub enum SplitTunnel {
-    /// Display the split tunnel status and apps
-    Get,
-
-    /// Enable or disable split tunnel
-    Set { policy: BooleanOption },
-
-    /// Manage applications to exclude from the tunnel
-    #[clap(subcommand)]
-    App(App),
-}
-
-#[derive(Subcommand, Debug)]
-pub enum App {
-    Add { path: PathBuf },
-    Remove { path: PathBuf },
-    Clear,
-}
 
 impl SplitTunnel {
     pub async fn handle(self) -> Result<()> {
@@ -52,35 +31,6 @@ impl SplitTunnel {
                 Ok(())
             }
             SplitTunnel::App(subcmd) => Self::app(subcmd).await,
-        }
-    }
-
-    async fn app(subcmd: App) -> Result<()> {
-        match subcmd {
-            App::Add { path } => {
-                MullvadProxyClient::new()
-                    .await?
-                    .add_split_tunnel_app(path)
-                    .await?;
-                println!("Added path to excluded apps list");
-                Ok(())
-            }
-            App::Remove { path } => {
-                MullvadProxyClient::new()
-                    .await?
-                    .remove_split_tunnel_app(path)
-                    .await?;
-                println!("Stopped excluding app from tunnel");
-                Ok(())
-            }
-            App::Clear => {
-                MullvadProxyClient::new()
-                    .await?
-                    .clear_split_tunnel_apps()
-                    .await?;
-                println!("Stopped excluding all apps");
-                Ok(())
-            }
         }
     }
 }

--- a/mullvad-cli/src/cmds/split_tunnel/mod.rs
+++ b/mullvad-cli/src/cmds/split_tunnel/mod.rs
@@ -10,4 +10,4 @@ mod imp;
 #[path = "macos.rs"]
 mod imp;
 
-pub use imp::*;
+pub mod shared;

--- a/mullvad-cli/src/cmds/split_tunnel/shared.rs
+++ b/mullvad-cli/src/cmds/split_tunnel/shared.rs
@@ -1,0 +1,95 @@
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+use anyhow::Result;
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+use std::path::PathBuf;
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+use mullvad_management_interface::MullvadProxyClient;
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+use super::super::BooleanOption;
+use clap::Subcommand;
+
+#[derive(Subcommand, Debug)]
+pub enum SplitTunnel {
+    /// Display the split tunnel status and apps
+    #[cfg(target_os = "macos")]
+    Get,
+    #[cfg(target_os = "windows")]
+    Get {
+        /// List processes that are currently being excluded, as well as whether they are
+        /// excluded because of their executable paths or because they're subprocesses of
+        /// such processes
+        #[arg(long)]
+        list_processes: bool,
+    },
+    /// list all processes that are excluded from the tunnel
+    #[cfg(target_os = "linux")]
+    List,
+    /// Add a PID to exclude from the tunnel
+    #[cfg(target_os = "linux")]
+    Add {
+        #[arg(required(true), num_args = 1..)]
+        pids: Vec<i32>,
+    },
+    /// Stop excluding a PID from the tunnel
+    #[cfg(target_os = "linux")]
+    Delete {
+        #[arg(required(true), num_args = 1..)]
+        pids: Vec<i32>,
+    },
+    /// Stop excluding all processes from the tunnel
+    #[cfg(target_os = "linux")]
+    Clear,
+
+    /// Enable or disable split tunnel
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    Set { policy: BooleanOption },
+
+    /// Manage applications to exclude from the tunnel
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    #[clap(subcommand)]
+    App(App),
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[derive(Subcommand, Debug)]
+pub enum App {
+    Add {
+        #[arg(required(true), num_args = 1..)]
+        paths: Vec<PathBuf>,
+    },
+    Remove {
+        #[arg(required(true), num_args = 1..)]
+        paths: Vec<PathBuf>,
+    },
+    Clear,
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+impl SplitTunnel {
+    pub(crate) async fn app(subcmd: App) -> Result<()> {
+        let mut proxy = MullvadProxyClient::new().await?;
+        match subcmd {
+            App::Add { paths } => {
+                for path in paths {
+                    proxy.add_split_tunnel_app(&path).await?;
+                    println!("Added {path:?} to excluded apps list");
+                }
+                Ok(())
+            }
+            App::Remove { paths } => {
+                for path in paths {
+                    proxy.remove_split_tunnel_app(&path).await?;
+                    println!("Stopped excluding {path:?} from tunnel");
+                }
+                Ok(())
+            }
+            App::Clear => {
+                proxy.clear_split_tunnel_apps().await?;
+                println!("Stopped excluding all apps");
+                Ok(())
+            }
+        }
+    }
+}

--- a/mullvad-cli/src/cmds/split_tunnel/windows.rs
+++ b/mullvad-cli/src/cmds/split_tunnel/windows.rs
@@ -1,40 +1,11 @@
 use anyhow::Result;
-use std::{
-    ffi::OsStr,
-    path::{Path, PathBuf},
-};
+use std::{ffi::OsStr, path::Path};
 
-use clap::Subcommand;
 use mullvad_management_interface::MullvadProxyClient;
 
+use crate::cmds::split_tunnel::shared::SplitTunnel;
+
 use super::super::BooleanOption;
-
-/// Set options for applications to exclude from the tunnel.
-#[derive(Subcommand, Debug)]
-pub enum SplitTunnel {
-    /// Display the split tunnel status and apps
-    Get {
-        /// List processes that are currently being excluded, as well as whether they are
-        /// excluded because of their executable paths or because they're subprocesses of
-        /// such processes
-        #[arg(long)]
-        list_processes: bool,
-    },
-
-    /// Enable or disable split tunnel
-    Set { policy: BooleanOption },
-
-    /// Manage applications to exclude from the tunnel
-    #[clap(subcommand)]
-    App(App),
-}
-
-#[derive(Subcommand, Debug)]
-pub enum App {
-    Add { path: PathBuf },
-    Remove { path: PathBuf },
-    Clear,
-}
 
 impl SplitTunnel {
     pub async fn handle(self) -> Result<()> {
@@ -76,35 +47,6 @@ impl SplitTunnel {
                 Ok(())
             }
             SplitTunnel::App(subcmd) => Self::app(subcmd).await,
-        }
-    }
-
-    async fn app(subcmd: App) -> Result<()> {
-        match subcmd {
-            App::Add { path } => {
-                MullvadProxyClient::new()
-                    .await?
-                    .add_split_tunnel_app(path)
-                    .await?;
-                println!("Added path to excluded apps list");
-                Ok(())
-            }
-            App::Remove { path } => {
-                MullvadProxyClient::new()
-                    .await?
-                    .remove_split_tunnel_app(path)
-                    .await?;
-                println!("Stopped excluding app from tunnel");
-                Ok(())
-            }
-            App::Clear => {
-                MullvadProxyClient::new()
-                    .await?
-                    .clear_split_tunnel_apps()
-                    .await?;
-                println!("Stopped excluding all apps");
-                Ok(())
-            }
         }
     }
 }

--- a/mullvad-cli/src/main.rs
+++ b/mullvad-cli/src/main.rs
@@ -7,7 +7,7 @@ mod cmds;
 mod format;
 use cmds::*;
 
-use crate::cmds::reset::SettingsKey;
+use crate::cmds::{reset::SettingsKey, split_tunnel::shared::SplitTunnel};
 
 pub const BIN_NAME: &str = env!("CARGO_BIN_NAME");
 
@@ -141,7 +141,7 @@ enum Cli {
     AntiCensorship(anti_censorship::AntiCensorship),
 
     #[clap(subcommand)]
-    SplitTunnel(split_tunnel::SplitTunnel),
+    SplitTunnel(SplitTunnel),
 
     /// Return the state of the VPN tunnel
     Status {


### PR DESCRIPTION
This PR adds support for using multiple arguments on the CLI when using `split-tunnel app` `add` and `remove` commands.

Parts of the implementation is now shared between macOS and Windows, as Linux uses `pid`s instead of path to executables.
The functionality and arguments name haven't been changed, so it should work the same way it did otherwise.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11038)
<!-- Reviewable:end -->
