### PR TITLE
Sort the relay list by name even though no translation was applied

### DIFF
--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -29,6 +29,9 @@ Line wrap the file at 100 chars.                                              Th
 - Remove the initial privacy consent screen. The app now shows the Login Screen on first start.
   The privacy policy can still be reached from Settings.
 
+### Fixed
+- Fix the sorting of the location list in English being incorrect.
+
 
 ## [android/2026.9-beta1] - 2026-08-20
 ### Added

--- a/android/lib/feature/location/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/location/impl/list/SelectLocationListViewModel.kt
+++ b/android/lib/feature/location/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/location/impl/list/SelectLocationListViewModel.kt
@@ -93,7 +93,7 @@ class SelectLocationListViewModel(
             selectedLocationUseCase(),
             _expandedItems,
         ) { filteredCountries, customLists, recents, selectedItem, expandedItems ->
-            // If we have no locations we have an empty relay list and we should show an error
+            // If we have no locations we have an empty relay list, and we should show an error
             if (filteredCountries.countries.isEmpty()) {
                 emptyLocationsRelayListItems(
                     relayListType = relayListType,

--- a/android/lib/repository/src/main/kotlin/net/mullvad/mullvadvpn/lib/repository/RelayListRepository.kt
+++ b/android/lib/repository/src/main/kotlin/net/mullvad/mullvadvpn/lib/repository/RelayListRepository.kt
@@ -38,7 +38,7 @@ class RelayListRepository(
         combine(managementService.relayCountries, translationRepository.translations) {
                 countries,
                 translations ->
-                countries.translateRelays(translations)
+                countries.translateRelays(translations).sortLocations()
             }
             .stateIn(CoroutineScope(dispatcher), SharingStarted.WhileSubscribed(), emptyList())
 
@@ -49,25 +49,27 @@ class RelayListRepository(
             return this
         }
 
-        return Every.list<RelayItem.Location.Country>()
-            .modify(this) { country ->
-                country.copy {
-                    RelayItem.Location.Country.name set translations.lookup(country.name)
+        return Every.list<RelayItem.Location.Country>().modify(this) { country ->
+            country.copy {
+                RelayItem.Location.Country.name set translations.lookup(country.name)
 
-                    val cityTraversal = RelayItem.Location.Country.cities.every(Every.list())
+                val cityTraversal = RelayItem.Location.Country.cities.every(Every.list())
 
-                    cityTraversal.name transform { translations.lookup(it) }
-                    cityTraversal.countryName transform { translations.lookup(it) }
+                cityTraversal.name transform { translations.lookup(it) }
+                cityTraversal.countryName transform { translations.lookup(it) }
 
-                    val relayTraversal = cityTraversal.relays.every(Every.list())
+                val relayTraversal = cityTraversal.relays.every(Every.list())
 
-                    relayTraversal.cityName transform { translations.lookup(it) }
-                    relayTraversal.countryName transform { translations.lookup(it) }
-
-                    RelayItem.Location.Country.cities transform { cities -> cities.sortedByName() }
-                }
+                relayTraversal.cityName transform { translations.lookup(it) }
+                relayTraversal.countryName transform { translations.lookup(it) }
             }
-            .sortedByName()
+        }
+    }
+
+    private fun List<RelayItem.Location.Country>.sortLocations(): List<RelayItem.Location.Country> {
+        return this.sortedByName().map { country ->
+            country.copy { RelayItem.Location.Country.cities set country.cities.sortedByName() }
+        }
     }
 
     val wireguardEndpointData: StateFlow<WireguardEndpointData> =


### PR DESCRIPTION
This is so that we do not rely on the daemon to sort the countries and cities correctly.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11042)
<!-- Reviewable:end -->
