### PR TITLE
Refactor account operations for actor isolation

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -1061,6 +1061,8 @@
 		F07B53572C53B5270024F547 /* LocalNetworkIPs.swift in Sources */ = {isa = PBXBuildFile; fileRef = F07B53562C53B5270024F547 /* LocalNetworkIPs.swift */; };
 		F07CFF2029F2720E008C0343 /* NewDeviceNotificationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F07CFF1F29F2720E008C0343 /* NewDeviceNotificationProvider.swift */; };
 		F07F63CE2C63E5790027A351 /* AccessMethodRepository+Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0164EB92B4456D30020268D /* AccessMethodRepository+Stub.swift */; };
+		F080AED7303F202F00D4DE50 /* AccountManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F080AED6303F202F00D4DE50 /* AccountManager.swift */; };
+		F080AED8303F202F00D4DE50 /* AccountManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F080AED6303F202F00D4DE50 /* AccountManager.swift */; };
 		F08827892B3192110020A383 /* AccessMethodRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58EF875A2B16385400C098B2 /* AccessMethodRepositoryProtocol.swift */; };
 		F08B6B772C52878400D0A121 /* EphemeralPeerExchangeActorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98F1B502C19C48D003C869E /* EphemeralPeerExchangeActorTests.swift */; };
 		F08B6B782C528B8A00D0A121 /* EphemeralPeerExchangingProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F059197E2C454CE000C301F3 /* EphemeralPeerExchangingProtocol.swift */; };
@@ -2689,6 +2691,7 @@
 		F07CFF1F29F2720E008C0343 /* NewDeviceNotificationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewDeviceNotificationProvider.swift; sourceTree = "<group>"; };
 		F07F1BD42E4A361E003FB336 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		F08096FA2E4A325600D8B0CF /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		F080AED6303F202F00D4DE50 /* AccountManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountManager.swift; sourceTree = "<group>"; };
 		F09035B22FAB708D004635A3 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		F09035B42FAB724C004635A3 /* LogRedactorComparisonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogRedactorComparisonTests.swift; sourceTree = "<group>"; };
 		F09084672C6E88ED001CD36E /* DaitaPromptAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaitaPromptAlert.swift; sourceTree = "<group>"; };
@@ -3404,6 +3407,8 @@
 		5823FA5726CE4A4100283BF8 /* TunnelManager */ = {
 			isa = PBXGroup;
 			children = (
+				F080AED6303F202F00D4DE50 /* AccountManager.swift */,
+				A9E031762ACB08950095D843 /* BackgroundTaskProvider.swift */,
 				588527B1276B3F0700BAA373 /* LoadTunnelConfigurationOperation.swift */,
 				58F2E14B276A61C000A79513 /* RotateKeyOperation.swift */,
 				586E54FA27A2DF6D0029B88B /* SendTunnelProviderMessageOperation.swift */,
@@ -3421,7 +3426,6 @@
 				58B93A1226C3F13600A55733 /* TunnelState.swift */,
 				A9E0317D2ACC32920095D843 /* TunnelStatusBlockObserver.swift */,
 				5803B4B12940A48700C23744 /* TunnelStore.swift */,
-				A9E031762ACB08950095D843 /* BackgroundTaskProvider.swift */,
 				58421031282E42B000F24E46 /* UpdateDeviceDataOperation.swift */,
 				A9F360332AAB626300F53531 /* VPNConnectionProtocol.swift */,
 				581DA2742A1E283E0046ED47 /* WgKeyRotation.swift */,
@@ -6554,6 +6558,7 @@
 				A9A5FA352ACB05160083449F /* WgKeyRotationTests.swift in Sources */,
 				F0A7EBB62CF092CC005BB671 /* ApplicationConfiguration.swift in Sources */,
 				E10A0002000000000000AB01 /* PacketTunnelDebugSettings.swift in Sources */,
+				F080AED7303F202F00D4DE50 /* AccountManager.swift in Sources */,
 				7AB4CCB92B69097E006037F5 /* IPOverrideTests.swift in Sources */,
 				A9A5FA362ACB05160083449F /* TunnelManagerTests.swift in Sources */,
 			);
@@ -6794,6 +6799,7 @@
 				5878A27529093A310096FC88 /* StorePaymentEvent.swift in Sources */,
 				F062000C2CB7EB5D002E6DB9 /* UIImage+Helpers.swift in Sources */,
 				F910A4012D3FF23A002FF3BB /* View+Modifier.swift in Sources */,
+				F080AED8303F202F00D4DE50 /* AccountManager.swift in Sources */,
 				7A6389EB2B7FAD7A008E77E1 /* SettingsFieldValidationErrorContentView.swift in Sources */,
 				440870822D7A00B70038972F /* UIImage+Assets.swift in Sources */,
 				F09444132ECCA4B30059606A /* RecentListDataSource.swift in Sources */,

--- a/ios/MullvadVPN/Classes/DeviceDataThrottling.swift
+++ b/ios/MullvadVPN/Classes/DeviceDataThrottling.swift
@@ -53,6 +53,6 @@ struct DeviceDataThrottling {
 
     private mutating func startUpdate(now: Date) {
         lastUpdate = now
-        tunnelManager.updateDeviceData()
+        tunnelManager.updateAccountData()
     }
 }

--- a/ios/MullvadVPN/TunnelManager/AccountManager.swift
+++ b/ios/MullvadVPN/TunnelManager/AccountManager.swift
@@ -1,0 +1,135 @@
+// This Source Code Form is subject to the terms of the GPLv3 License.
+// You can obtain a copy of the license at https://www.gnu.org/licenses/gpl-3.0.en.html.
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright (c) Mullvad VPN AB. All rights reserved.
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+import Foundation
+import MullvadREST
+import MullvadSettings
+import MullvadTypes
+import Operations
+
+protocol AccountManagerTunnelInteractor: Sendable {
+    var deviceState: DeviceState { get }
+    func setDeviceState(_ deviceState: DeviceState, persist: Bool)
+    func setLastUsedAccount(_ accountNumber: String)
+    func unsetTunnelConfiguration()
+    func removeLastUsedAccount()
+}
+
+struct AccountManager: Sendable {
+    let operationQueue: AsyncOperationQueue
+    let internalQueue: DispatchQueue
+    let interactor: AccountManagerTunnelInteractor
+    let backgroundTaskProvider: BackgroundTaskProviding
+    let accountsProxy: RESTAccountHandling
+    let devicesProxy: DeviceHandling
+    let category: String
+
+    func setAccount(
+        action: SetAccountAction,
+        completionHandler: @escaping @Sendable (Result<StoredAccountData?, Error>) -> Void
+    ) {
+        let operation = SetAccountOperation(
+            dispatchQueue: internalQueue,
+            accountsProxy: accountsProxy,
+            devicesProxy: devicesProxy,
+            action: action,
+            deviceState: {
+                interactor.deviceState
+            },
+            onUpdateAccount: { deviceState in
+                interactor.setDeviceState(deviceState, persist: true)
+            }
+        )
+
+        operation.completionQueue = .main
+        operation.completionHandler = { result in
+            completionHandler(result)
+        }
+
+        operation.addObserver(
+            BackgroundObserver(
+                backgroundTaskProvider: backgroundTaskProvider,
+                name: action.taskName,
+                cancelUponExpiration: true
+            ))
+
+        operation.addCondition(MutuallyExclusive(category: category))
+
+        // Unsetting (ie. logging out) or deleting the account should cancel all other
+        // currently ongoing activity.
+        switch action {
+        case .unset, .delete:
+            operationQueue.cancelAllOperations()
+        default:
+            break
+        }
+
+        operationQueue.addOperation(operation)
+    }
+
+    func rotatePrivateKey(completionHandler: @escaping @Sendable (Result<Void, Error>) -> Void) -> Cancellable {
+        let operation = RotateKeyOperation(dispatchQueue: internalQueue, devicesProxy: devicesProxy) {
+            interactor.deviceState
+        } onUpdateAccount: { deviceState in
+            interactor.setDeviceState(deviceState, persist: true)
+        }
+
+        operation.completionQueue = .main
+        operation.completionHandler = { result in
+            completionHandler(result)
+        }
+
+        operation.addObserver(
+            BackgroundObserver(
+                backgroundTaskProvider: backgroundTaskProvider,
+                name: "Rotate private key",
+                cancelUponExpiration: true
+            )
+        )
+
+        operation.addCondition(
+            MutuallyExclusive(category: category)
+        )
+
+        operationQueue.addOperation(operation)
+
+        return operation
+    }
+
+    func updateDeviceData(_ completionHandler: (@Sendable (Error?) -> Void)? = nil) -> Cancellable {
+        let operation = UpdateDeviceDataOperation(
+            dispatchQueue: internalQueue,
+            devicesProxy: devicesProxy,
+            deviceState: {
+                interactor.deviceState
+            },
+            onUpdateAccount: { deviceState in
+                interactor.setDeviceState(deviceState, persist: true)
+            }
+        )
+
+        operation.completionQueue = .main
+        operation.completionHandler = { completion in
+            completionHandler?(completion.error)
+        }
+
+        operation.addObserver(
+            BackgroundObserver(
+                backgroundTaskProvider: backgroundTaskProvider,
+                name: "Update device data",
+                cancelUponExpiration: true
+            )
+        )
+
+        operation.addCondition(MutuallyExclusive(category: category))
+        operationQueue.addOperation(operation)
+        return operation
+    }
+}

--- a/ios/MullvadVPN/TunnelManager/AccountManager.swift
+++ b/ios/MullvadVPN/TunnelManager/AccountManager.swift
@@ -44,6 +44,9 @@ struct AccountManager: Sendable {
                 interactor.deviceState
             },
             onUpdateAccount: { deviceState in
+                if let accountNumber = deviceState.accountData?.number {
+                    interactor.setLastUsedAccount(accountNumber)
+                }
                 interactor.setDeviceState(deviceState, persist: true)
             }
         )

--- a/ios/MullvadVPN/TunnelManager/RotateKeyOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/RotateKeyOperation.swift
@@ -17,20 +17,26 @@ import Operations
 
 class RotateKeyOperation: ResultOperation<Void>, @unchecked Sendable {
     private let logger = Logger(label: "RotateKeyOperation")
-    private let interactor: TunnelInteractor
     private let devicesProxy: DeviceHandling
+    private let deviceState: @Sendable () -> DeviceState
+    private let onUpdateAccount: @Sendable (DeviceState) -> Void
     private var task: Cancellable?
 
-    init(dispatchQueue: DispatchQueue, interactor: TunnelInteractor, devicesProxy: DeviceHandling) {
-        self.interactor = interactor
+    init(
+        dispatchQueue: DispatchQueue,
+        devicesProxy: DeviceHandling,
+        deviceState: @escaping @Sendable () -> DeviceState,
+        onUpdateAccount: @escaping @Sendable (DeviceState) -> Void
+    ) {
         self.devicesProxy = devicesProxy
-
+        self.deviceState = deviceState
+        self.onUpdateAccount = onUpdateAccount
         super.init(dispatchQueue: dispatchQueue, completionQueue: nil, completionHandler: nil)
     }
 
     override func main() {
         // Extract login metadata.
-        guard case let .loggedIn(accountData, deviceData) = interactor.deviceState else {
+        guard case let .loggedIn(accountData, deviceData) = deviceState() else {
             finish(result: .failure(InvalidDeviceStateError()))
             return
         }
@@ -51,7 +57,7 @@ class RotateKeyOperation: ResultOperation<Void>, @unchecked Sendable {
         let publicKey = keyRotation.beginAttempt()
 
         // Persist mutated device data.
-        interactor.setDeviceState(.loggedIn(accountData, keyRotation.data), persist: true)
+        onUpdateAccount(.loggedIn(accountData, keyRotation.data))
 
         // Send REST request to rotate the device key.
         logger.debug("Replacing old key with new key on server...")
@@ -87,24 +93,15 @@ class RotateKeyOperation: ResultOperation<Void>, @unchecked Sendable {
         _ = keyRotation.setCompleted(with: fetchedDevice)
 
         // Persist changes.
-        interactor.setDeviceState(.loggedIn(accountData, keyRotation.data), persist: true)
+        onUpdateAccount(.loggedIn(accountData, keyRotation.data))
 
-        // Notify the tunnel that key rotation took place and that it should reload VPN configuration.
-        if let tunnel = interactor.tunnel {
-            _ = tunnel.notifyKeyRotation { [weak self] _ in
-                self?.finish(result: .success(()))
-            }
-        } else {
-            finish(result: .success(()))
-        }
+        finish(result: .success(()))
     }
 
     private func handleError(_ error: Error) {
         if !error.isOperationCancellationError {
             logger.error(error: error, message: "Failed to rotate device key.")
         }
-
-        interactor.handleRestError(error)
         finish(result: .failure(error))
     }
 }

--- a/ios/MullvadVPN/TunnelManager/SetAccountOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/SetAccountOperation.swift
@@ -23,7 +23,7 @@ enum SetAccountAction {
     case existing(String)
 
     /// Unset account.
-    case unset(isRemovingProfile: Bool)
+    case unset
 
     /// Delete account.
     case delete(String)
@@ -39,28 +39,28 @@ enum SetAccountAction {
 }
 
 class SetAccountOperation: ResultOperation<StoredAccountData?>, @unchecked Sendable {
-    private let interactor: TunnelInteractor
     private let accountsProxy: RESTAccountHandling
     private let devicesProxy: DeviceHandling
     private let action: SetAccountAction
-    private let setLastUsedAccount: @Sendable (String) throws -> Void
+    private let deviceState: @Sendable () -> DeviceState
+    private let onUpdateAccount: @Sendable (DeviceState) -> Void
 
     private let logger = Logger(label: "SetAccountOperation")
     private var tasks: [Cancellable] = []
 
     init(
         dispatchQueue: DispatchQueue,
-        interactor: TunnelInteractor,
         accountsProxy: RESTAccountHandling,
         devicesProxy: DeviceHandling,
         action: SetAccountAction,
-        setLastUsedAccount: @escaping @Sendable (String) throws -> Void
+        deviceState: @escaping @Sendable () -> DeviceState,
+        onUpdateAccount: @escaping @Sendable (DeviceState) -> Void
     ) {
-        self.interactor = interactor
         self.accountsProxy = accountsProxy
         self.devicesProxy = devicesProxy
         self.action = action
-        self.setLastUsedAccount = setLastUsedAccount
+        self.onUpdateAccount = onUpdateAccount
+        self.deviceState = deviceState
 
         super.init(dispatchQueue: dispatchQueue)
     }
@@ -83,8 +83,8 @@ class SetAccountOperation: ResultOperation<StoredAccountData?>, @unchecked Senda
                 }
             }
 
-        case .unset(let isRemovingProfile):
-            startLogoutFlow(isRemovingProfile: isRemovingProfile) { [self] in
+        case .unset:
+            startLogoutFlow { [self] in
                 finish(result: .success(nil))
             }
 
@@ -113,14 +113,16 @@ class SetAccountOperation: ResultOperation<StoredAccountData?>, @unchecked Senda
      Does nothing if device is already logged out.
      */
     private func startLogoutFlow(isRemovingProfile: Bool = true, completion: @escaping @Sendable () -> Void) {
-        switch interactor.deviceState {
+        switch deviceState() {
         case let .loggedIn(accountData, deviceData):
             deleteDevice(accountNumber: accountData.number, deviceIdentifier: deviceData.identifier) { [self] _ in
-                unsetDeviceState(isRemovingProfile: isRemovingProfile, completion: completion)
+                onUpdateAccount(.loggedOut)
+                completion()
             }
 
         case .revoked:
-            unsetDeviceState(completion: completion)
+            onUpdateAccount(.loggedOut)
+            completion()
 
         case .loggedOut:
             completion()
@@ -167,10 +169,8 @@ class SetAccountOperation: ResultOperation<StoredAccountData?>, @unchecked Senda
     ) {
         deleteAccount(accountNumber: accountNumber) { [self] result in
             if result.isSuccess {
-                interactor.removeLastUsedAccount()
-                unsetDeviceState {
-                    completion(result)
-                }
+                onUpdateAccount(.loggedOut)
+                completion(result)
             } else {
                 completion(result)
             }
@@ -191,9 +191,6 @@ class SetAccountOperation: ResultOperation<StoredAccountData?>, @unchecked Senda
     ) {
         do {
             let accountData = try result.get()
-
-            storeLastUsedAccount(accountNumber: accountData.number)
-
             createDevice(accountNumber: accountData.number) { [self] result in
                 completion(
                     result.map { newDevice in
@@ -204,18 +201,6 @@ class SetAccountOperation: ResultOperation<StoredAccountData?>, @unchecked Senda
             }
         } catch {
             completion(.failure(error))
-        }
-    }
-
-    /// Store last used account number in settings.
-    /// Errors are ignored but logged.
-    private func storeLastUsedAccount(accountNumber: String) {
-        logger.debug("Store last used account.")
-
-        do {
-            try setLastUsedAccount(accountNumber)
-        } catch {
-            logger.error(error: error, message: "Failed to store last used account number.")
         }
     }
 
@@ -239,7 +224,7 @@ class SetAccountOperation: ResultOperation<StoredAccountData?>, @unchecked Senda
         )
 
         // Transition device state to logged in.
-        interactor.setDeviceState(.loggedIn(accountData, storedDeviceData), persist: true)
+        onUpdateAccount(.loggedIn(accountData, storedDeviceData))
     }
 
     /// Create new account and produce `StoredAccountData` upon success.
@@ -355,46 +340,6 @@ class SetAccountOperation: ResultOperation<StoredAccountData?>, @unchecked Senda
         }
 
         tasks.append(task)
-    }
-
-    /**
-     Transitions device state into logged out state by performing the following tasks:
-
-     1. Prepare tunnel manager for removal of VPN configuration. In response tunnel manager stops processing VPN status
-        notifications coming from VPN configuration.
-     2. Reset device staate to logged out and persist it.
-     3. Remove VPN configuration and release an instance of `Tunnel` object.
-     */
-    private func unsetDeviceState(isRemovingProfile: Bool = true, completion: @escaping @Sendable () -> Void) {
-        // Reset tunnel and device state.
-        interactor.updateTunnelStatus { tunnelStatus in
-            tunnelStatus = TunnelStatus()
-            tunnelStatus.state = .disconnected
-        }
-        interactor.setDeviceState(.loggedOut, persist: true)
-
-        // Finish immediately if tunnel provider is not set.
-        guard let tunnel = interactor.tunnel, isRemovingProfile else {
-            completion()
-            return
-        }
-
-        // Tell the caller to unsubscribe from VPN status notifications.
-        interactor.prepareForVPNConfigurationDeletion()
-
-        // Remove VPN configuration.
-        tunnel.removeFromPreferences { [self] error in
-            dispatchQueue.async { [self] in
-                // Ignore error but log it.
-                if let error {
-                    logger.error(error: error, message: "Failed to remove VPN configuration.")
-                }
-
-                interactor.setTunnel(nil, shouldRefreshTunnelState: false)
-
-                completion()
-            }
-        }
     }
 
     /// Create new private key and create new device via API.

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -80,6 +80,8 @@ final class TunnelManager: @unchecked Sendable {
 
     private let settingsManager: SettingsManager
 
+    private var accountManager: AccountManager!
+
     // MARK: - Initialization
 
     init(
@@ -103,6 +105,16 @@ final class TunnelManager: @unchecked Sendable {
         self.relaySelector = relaySelector
         self.settingsManager = settingsManager
 
+        self.accountManager = AccountManager(
+            operationQueue: operationQueue,
+            internalQueue: internalQueue,
+            interactor: AccountManagerInteractor(manager: self),
+            backgroundTaskProvider: backgroundTaskProvider,
+            accountsProxy: accountsProxy,
+            devicesProxy: devicesProxy,
+            category: OperationCategory.deviceStateUpdate.category
+        )
+
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(applicationDidBecomeActive),
@@ -115,6 +127,82 @@ final class TunnelManager: @unchecked Sendable {
         #if NOT_PRODUCTION_PERMANENT
             relayCacheTracker.addObserver(self)
         #endif
+    }
+
+    // MARK: - Account
+
+    func setNewAccount() async throws -> StoredAccountData {
+        try await setAccount(action: .new)!
+    }
+
+    func setExistingAccount(accountNumber: String) async throws -> StoredAccountData {
+        try await setAccount(action: .existing(accountNumber))!
+    }
+
+    func unsetAccount(isRemovingProfile: Bool = true) async {
+        do {
+            _ = try await setAccount(action: .unset)
+            unsetTunnelConfiguration(isRemovingProfile: isRemovingProfile)
+        } catch {
+            logger.debug("Failed to unset account: \(error.description)")
+        }
+    }
+
+    func updateAccountData(_ completionHandler: (@Sendable (Result<Void, Error>) -> Void)? = nil) {
+        _ = accountManager.updateDeviceData { [weak self] error in
+            guard let self else { return }
+            if let error {
+                self.handleRestError(error)
+                completionHandler?(.failure(error))
+            } else {
+                completionHandler?(.success(()))
+            }
+        }
+    }
+
+    func deleteAccount(accountNumber: String) async throws {
+        _ = try await setAccount(action: .delete(accountNumber))
+        removeLastUsedAccount()
+        unsetTunnelConfiguration()
+    }
+
+    private func setAccount(
+        action: SetAccountAction,
+        completionHandler: @escaping @Sendable (Result<StoredAccountData?, Error>) -> Void
+    ) {
+        accountManager.setAccount(action: action) { [weak self] result in
+            guard let self else { return }
+            self.startOrStopPeriodicPrivateKeyRotation()
+            completionHandler(result)
+        }
+    }
+
+    private func setAccount(action: SetAccountAction) async throws -> StoredAccountData? {
+        try await withCheckedThrowingContinuation { continuation in
+            setAccount(action: action) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+
+    func rotatePrivateKey(completionHandler: @MainActor @escaping @Sendable (Error?) -> Void) -> Cancellable {
+        accountManager.rotatePrivateKey { [weak self] result in
+            guard let self else { return }
+
+            updatePrivateKeyRotationTimer()
+
+            switch result {
+            case .success:
+                guard let tunnel else { return }
+                _ = tunnel.notifyKeyRotation { result in
+                    Task { @MainActor in
+                        completionHandler(result.error)
+                    }
+                }
+            case .failure(let error):
+                handleRestError(error)
+            }
+        }
     }
 
     // MARK: - Periodic private key rotation
@@ -169,7 +257,7 @@ final class TunnelManager: @unchecked Sendable {
             let timer = DispatchSource.makeTimerSource(queue: .main)
 
             timer.setEventHandler { [weak self] in
-                _ = self?.rotatePrivateKey { _ in
+                _ = self?.accountManager.rotatePrivateKey { _ in
                     // no-op
                 }
             }
@@ -372,163 +460,6 @@ final class TunnelManager: @unchecked Sendable {
                 self.stopTunnel(isOnDemandEnabled: true)
             }
         }
-    }
-
-    func setNewAccount() async throws -> StoredAccountData {
-        try await setAccount(action: .new)!
-    }
-
-    func setExistingAccount(accountNumber: String) async throws -> StoredAccountData {
-        try await setAccount(action: .existing(accountNumber))!
-    }
-
-    private func setAccount(
-        action: SetAccountAction,
-        completionHandler: @escaping @Sendable (Result<StoredAccountData?, Error>) -> Void
-    ) {
-        let operation = SetAccountOperation(
-            dispatchQueue: internalQueue,
-            interactor: TunnelInteractorProxy(self),
-            accountsProxy: accountsProxy,
-            devicesProxy: devicesProxy,
-            action: action,
-            setLastUsedAccount: settingsManager.setLastUsedAccount
-        )
-
-        operation.completionQueue = .main
-        operation.completionHandler = { [weak self] result in
-            guard let self else { return }
-            startOrStopPeriodicPrivateKeyRotation()
-
-            completionHandler(result)
-        }
-
-        operation.addObserver(
-            BackgroundObserver(
-                backgroundTaskProvider: backgroundTaskProvider,
-                name: action.taskName,
-                cancelUponExpiration: true
-            ))
-
-        operation.addCondition(
-            MutuallyExclusive(category: OperationCategory.manageTunnel.category)
-        )
-        operation.addCondition(
-            MutuallyExclusive(category: OperationCategory.deviceStateUpdate.category)
-        )
-        operation.addCondition(
-            MutuallyExclusive(category: OperationCategory.settingsUpdate.category)
-        )
-
-        // Unsetting (ie. logging out) or deleting the account should cancel all other
-        // currently ongoing activity.
-        switch action {
-        case .unset, .delete:
-            operationQueue.cancelAllOperations()
-        default:
-            break
-        }
-
-        operationQueue.addOperation(operation)
-    }
-
-    private func setAccount(action: SetAccountAction) async throws -> StoredAccountData? {
-        try await withCheckedThrowingContinuation { continuation in
-            setAccount(action: action) { result in
-                continuation.resume(with: result)
-            }
-        }
-    }
-
-    func unsetAccount(isRemovingProfile: Bool = true) async {
-        do {
-            _ = try await setAccount(action: .unset(isRemovingProfile: isRemovingProfile))
-        } catch {
-            logger.debug("Failed to unset account: \(error.description)")
-        }
-    }
-
-    func updateAccountData(_ completionHandler: (@Sendable (Result<Void, Error>) -> Void)? = nil) {
-        let interactor = AccountInteractor(
-            tunnelManager: self,
-            accountsProxy: accountsProxy,
-            apiProxy: apiProxy,
-            deviceProxy: devicesProxy
-        )
-
-        Task {
-            completionHandler?(await interactor.updateAccountData())
-        }
-    }
-
-    func deleteAccount(accountNumber: String) async throws {
-        _ = try await setAccount(action: .delete(accountNumber))
-    }
-
-    func updateDeviceData(_ completionHandler: (@Sendable (Error?) -> Void)? = nil) {
-        let operation = UpdateDeviceDataOperation(
-            dispatchQueue: internalQueue,
-            interactor: TunnelInteractorProxy(self),
-            devicesProxy: devicesProxy
-        )
-
-        operation.completionQueue = .main
-        operation.completionHandler = { completion in
-            completionHandler?(completion.error)
-        }
-
-        operation.addObserver(
-            BackgroundObserver(
-                backgroundTaskProvider: backgroundTaskProvider,
-                name: "Update device data",
-                cancelUponExpiration: true
-            )
-        )
-
-        operation.addCondition(
-            MutuallyExclusive(category: OperationCategory.deviceStateUpdate.category)
-        )
-
-        operationQueue.addOperation(operation)
-    }
-
-    func rotatePrivateKey(completionHandler: @MainActor @escaping @Sendable (Error?) -> Void) -> Cancellable {
-        let operation = RotateKeyOperation(
-            dispatchQueue: internalQueue,
-            interactor: TunnelInteractorProxy(self),
-            devicesProxy: devicesProxy
-        )
-
-        operation.completionQueue = .main
-        operation.completionHandler = { [weak self] result in
-            guard let self else { return }
-            MainActor.assumeIsolated {
-                self.updatePrivateKeyRotationTimer()
-
-                let error = result.error
-                if let error {
-                    self.handleRestError(error)
-                }
-
-                completionHandler(error)
-            }
-        }
-
-        operation.addObserver(
-            BackgroundObserver(
-                backgroundTaskProvider: backgroundTaskProvider,
-                name: "Rotate private key",
-                cancelUponExpiration: true
-            )
-        )
-
-        operation.addCondition(
-            MutuallyExclusive(category: OperationCategory.deviceStateUpdate.category)
-        )
-
-        operationQueue.addOperation(operation)
-
-        return operation
     }
 
     func updateSettings(_ updates: [TunnelSettingsUpdate], completionHandler: (@Sendable () -> Void)? = nil) {
@@ -1214,7 +1145,7 @@ final class TunnelManager: @unchecked Sendable {
         }
     }
 
-    private func unsetTunnelConfiguration(completion: @escaping @Sendable () -> Void) {
+    private func unsetTunnelConfiguration(isRemovingProfile: Bool = true, completion: (@Sendable () -> Void)? = nil) {
         // Tell the caller to unsubscribe from VPN status notifications.
         prepareForVPNConfigurationDeletion()
 
@@ -1225,8 +1156,8 @@ final class TunnelManager: @unchecked Sendable {
         }
 
         // Finish immediately if tunnel provider is not set.
-        guard let tunnel else {
-            completion()
+        guard let tunnel, isRemovingProfile else {
+            completion?()
             return
         }
 
@@ -1243,7 +1174,7 @@ final class TunnelManager: @unchecked Sendable {
 
                 setTunnel(nil, shouldRefreshTunnelState: false)
 
-                completion()
+                completion?()
             }
         }
     }
@@ -1435,3 +1366,46 @@ private struct TunnelInteractorProxy: TunnelInteractor {
         }
     }
 #endif
+
+extension TunnelManager {
+    /// Adapter exposing the narrow slice of `TunnelManager`
+    /// that `AccountManager` needs.
+    fileprivate struct AccountManagerInteractor: AccountManagerTunnelInteractor {
+        private weak var manager: TunnelManager?
+
+        init(manager: TunnelManager) {
+            self.manager = manager
+        }
+
+        var deviceState: DeviceState {
+            manager?.deviceState ?? .loggedOut
+        }
+
+        func setDeviceState(_ deviceState: DeviceState, persist: Bool) {
+            manager?.setDeviceState(deviceState, persist: persist)
+        }
+
+        func setLastUsedAccount(_ accountNumber: String) {
+            guard let manager else { return }
+
+            manager.logger.debug("Store last used account.")
+
+            do {
+                try manager.settingsManager.setLastUsedAccount(accountNumber)
+            } catch {
+                manager.logger.error(
+                    error: error,
+                    message: "Failed to store last used account number."
+                )
+            }
+        }
+
+        func unsetTunnelConfiguration() {
+            manager?.unsetTunnelConfiguration()
+        }
+
+        func removeLastUsedAccount() {
+            manager?.removeLastUsedAccount()
+        }
+    }
+}

--- a/ios/MullvadVPN/TunnelManager/UpdateDeviceDataOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/UpdateDeviceDataOperation.swift
@@ -16,24 +16,26 @@ import MullvadTypes
 import Operations
 
 class UpdateDeviceDataOperation: ResultOperation<StoredDeviceData>, @unchecked Sendable {
-    private let interactor: TunnelInteractor
     private let devicesProxy: DeviceHandling
+    private let deviceState: @Sendable () -> DeviceState
+    private let onUpdateAccount: @Sendable (DeviceState) -> Void
 
     private var task: Cancellable?
 
     init(
         dispatchQueue: DispatchQueue,
-        interactor: TunnelInteractor,
-        devicesProxy: DeviceHandling
+        devicesProxy: DeviceHandling,
+        deviceState: @escaping @Sendable () -> DeviceState,
+        onUpdateAccount: @escaping @Sendable (DeviceState) -> Void
     ) {
-        self.interactor = interactor
         self.devicesProxy = devicesProxy
-
-        super.init(dispatchQueue: dispatchQueue)
+        self.deviceState = deviceState
+        self.onUpdateAccount = onUpdateAccount
+        super.init(dispatchQueue: dispatchQueue, completionQueue: nil, completionHandler: nil)
     }
 
     override func main() {
-        guard case let .loggedIn(accountData, deviceData) = interactor.deviceState else {
+        guard case let .loggedIn(accountData, deviceData) = deviceState() else {
             finish(result: .failure(InvalidDeviceStateError()))
             return
         }
@@ -57,11 +59,11 @@ class UpdateDeviceDataOperation: ResultOperation<StoredDeviceData>, @unchecked S
 
     private func didReceiveDeviceResponse(result: Result<Device, Error>) {
         let result = result.tryMap { device -> StoredDeviceData in
-            switch interactor.deviceState {
+            switch deviceState() {
             case .loggedIn(let storedAccount, var storedDevice):
                 storedDevice.update(from: device)
                 let newDeviceState = DeviceState.loggedIn(storedAccount, storedDevice)
-                interactor.setDeviceState(newDeviceState, persist: true)
+                onUpdateAccount(newDeviceState)
 
                 return storedDevice
 
@@ -69,11 +71,6 @@ class UpdateDeviceDataOperation: ResultOperation<StoredDeviceData>, @unchecked S
                 throw InvalidDeviceStateError()
             }
         }
-
-        if let error = result.error {
-            interactor.handleRestError(error)
-        }
-
         finish(result: result)
     }
 }


### PR DESCRIPTION
This PR refactored all account-related operations to remove their direct dependency on TunnelInteractor and instead receive the required state access and update behavior through @Sendable closures.

This prepares the account-related operation flow for making TunnelManager an actor and reduces coupling between the operations and TunnelManager's state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11044)
<!-- Reviewable:end -->
