### PR TITLE
Handle path updates in GotaTun actor

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		01335D602F89D000008AB806 /* GotaTunProviderProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D5F2F89D000008AB806 /* GotaTunProviderProxy.swift */; };
 		01335D612F89D400008AB806 /* ObservedStateBroadcaster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D622F89D400008AB806 /* ObservedStateBroadcaster.swift */; };
 		01335D662F89E200008AB806 /* ObservedState+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D652F89E200008AB806 /* ObservedState+Testing.swift */; };
+		01335D682F89E400008AB806 /* GotaTunPathObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D672F89E400008AB806 /* GotaTunPathObserver.swift */; };
 		014E8C2A2F28B09700837D0A /* MullvadLogging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58D223F3294C8FF00029F5F8 /* MullvadLogging.framework */; };
 		014E8C302F294FB000837D0A /* relays-test-data.json in Resources */ = {isa = PBXBuildFile; fileRef = 014E8C2F2F294FB000837D0A /* relays-test-data.json */; };
 		014E8C312F294FB000837D0A /* relays-test-data.json in Resources */ = {isa = PBXBuildFile; fileRef = 014E8C2F2F294FB000837D0A /* relays-test-data.json */; };
@@ -1796,6 +1797,7 @@
 		01335D5F2F89D000008AB806 /* GotaTunProviderProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunProviderProxy.swift; sourceTree = "<group>"; };
 		01335D622F89D400008AB806 /* ObservedStateBroadcaster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservedStateBroadcaster.swift; sourceTree = "<group>"; };
 		01335D652F89E200008AB806 /* ObservedState+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ObservedState+Testing.swift"; sourceTree = "<group>"; };
+		01335D672F89E400008AB806 /* GotaTunPathObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunPathObserver.swift; sourceTree = "<group>"; };
 		014E8C2F2F294FB000837D0A /* relays-test-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "relays-test-data.json"; sourceTree = "<group>"; };
 		014E8C352F2BC60300837D0A /* LogRedactorBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogRedactorBenchmarkTests.swift; sourceTree = "<group>"; };
 		014E8C392F2D594400837D0A /* RustLogRedactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustLogRedactor.swift; sourceTree = "<group>"; };
@@ -3043,6 +3045,7 @@
 			children = (
 				01335D3E2F89B711008AB806 /* GotaTunActor.swift */,
 				01335D3F2F89B711008AB806 /* GotaTunAdapterProtocol.swift */,
+				01335D672F89E400008AB806 /* GotaTunPathObserver.swift */,
 			);
 			path = GotaTun;
 			sourceTree = "<group>";
@@ -6644,6 +6647,7 @@
 				583832252AC318A100EA2071 /* PacketTunnelActor+ConnectionMonitoring.swift in Sources */,
 				F05919752C45194B00C301F3 /* EphemeralPeerKey.swift in Sources */,
 				01335D432F89B711008AB806 /* GotaTunAdapterProtocol.swift in Sources */,
+				01335D682F89E400008AB806 /* GotaTunPathObserver.swift in Sources */,
 				01335D442F89B711008AB806 /* GotaTunActor.swift in Sources */,
 				58C7A4552A863FB90060C66F /* TunnelMonitor.swift in Sources */,
 				58C7A4512A863FB50060C66F /* PingerProtocol.swift in Sources */,

--- a/ios/PacketTunnelCore/Actor/ObservedState+Extensions.swift
+++ b/ios/PacketTunnelCore/Actor/ObservedState+Extensions.swift
@@ -57,6 +57,30 @@ extension ObservedState {
         }
     }
 
+    /// Applies `body` to the associated connection state, preserving the current case.
+    /// No-op in states that carry no connection state.
+    public mutating func mutateConnectionState(_ body: (inout ObservedConnectionState) -> Void) {
+        switch self {
+        case var .connecting(connectionState):
+            body(&connectionState)
+            self = .connecting(connectionState)
+        case var .reconnecting(connectionState):
+            body(&connectionState)
+            self = .reconnecting(connectionState)
+        case var .connected(connectionState):
+            body(&connectionState)
+            self = .connected(connectionState)
+        case .negotiatingEphemeralPeer(var connectionState, let privateKey):
+            body(&connectionState)
+            self = .negotiatingEphemeralPeer(connectionState, privateKey)
+        case var .disconnecting(connectionState):
+            body(&connectionState)
+            self = .disconnecting(connectionState)
+        case .initial, .disconnected, .error:
+            break
+        }
+    }
+
     public var blockedState: ObservedBlockedState? {
         switch self {
         case let .error(blockedState):

--- a/ios/PacketTunnelCore/Actor/State.swift
+++ b/ios/PacketTunnelCore/Actor/State.swift
@@ -293,5 +293,6 @@ public enum ActorReconnectReason: Equatable, Sendable {
     case connectionLoss
 
     /// Restored  connectivity
+    // TODO: remove when WireGuardGo is removed
     case restoredConnectivity
 }

--- a/ios/PacketTunnelCore/GotaTun/GotaTunActor.swift
+++ b/ios/PacketTunnelCore/GotaTun/GotaTunActor.swift
@@ -21,6 +21,7 @@ private enum GotaTunEvent: Sendable {
     case adapterTimeout(generation: UInt64)
     case adapterError(GotaTunError, generation: UInt64)
     case reconnect(NextRelays, ActorReconnectReason)
+    case networkReachability(NWPath.Status)
     case setErrorState(BlockedStateReason)
     case sleep
     case wake
@@ -48,6 +49,7 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
     private let providerDelegate: TunnelProviderDelegate
     private let settingsReader: SettingsReaderProtocol
     private let relaySelector: RelaySelectorProtocol
+    private let defaultPathObserver: GotaTunPathObserverProtocol
     private let blockedStateErrorMapper: BlockedStateErrorMapperProtocol
     private let adapterFactory: GotaTunAdapterFactory
     private var lastAppliedSettings: TunnelInterfaceSettings?
@@ -67,7 +69,6 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
     private var stateBroadcaster = ObservedStateBroadcaster()
     /// Unknown until the path monitor delivers its first update, which is what releases `start`.
     private var currentReachability: NetworkReachability = .undetermined
-    private var initialReachability: CheckedContinuation<Void, Never>?
     private var currentAdapter: GotaTunAdapterProtocol?
     /// Incremented whenever the current adapter is replaced or stopped. Events tagged with an
     /// older generation come from an adapter no longer in use and are dropped.
@@ -110,12 +111,14 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
         providerDelegate: sending TunnelProviderDelegate,
         settingsReader: SettingsReaderProtocol,
         relaySelector: RelaySelectorProtocol,
+        defaultPathObserver: GotaTunPathObserverProtocol = GotaTunPathObserver(),
         blockedStateErrorMapper: BlockedStateErrorMapperProtocol,
         adapterFactory: GotaTunAdapterFactory
     ) {
         self.providerDelegate = providerDelegate
         self.settingsReader = settingsReader
         self.relaySelector = relaySelector
+        self.defaultPathObserver = defaultPathObserver
         self.blockedStateErrorMapper = blockedStateErrorMapper
         self.adapterFactory = adapterFactory
 
@@ -125,18 +128,28 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
     }
 
     deinit {
+        Task { [defaultPathObserver] in await defaultPathObserver.stop() }
         eventContinuation.finish()
     }
 
-    /// Consume events in a detached task until the event stream is finished. This function **must** be called excatly once per the lifetime of an actor. Without this, the actor will never act on events, so no work will actually be done.
+    /// Starts path observation and consumes actor events.
+    /// The events are consumed in a detached task until the event stream is finished. This function **must** be called excatly once per the lifetime of an actor. Without this, the actor will never act on events, so no work will actually be done.
     /// `self` is resolved weakly per iteration so the loop does not keep the actor alive.
     private nonisolated consuming func consumeEvents() {
         Task.detached { [weak self, eventStream] in
+            await self?.startPathObservation()
             for await event in eventStream {
                 guard let self else { return }
                 await self.handleEvent(event)
             }
         }
+    }
+
+    private func startPathObservation() async {
+        let eventContinuation = self.eventContinuation
+        currentReachability = await defaultPathObserver.start { status in
+            eventContinuation.yield(.networkReachability(status))
+        }.networkReachability
     }
 
     // MARK: - PacketTunnelActorProtocol
@@ -145,7 +158,7 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
         stateBroadcaster.makeStream(replaying: observedState)
     }
 
-    public func start(options: StartOptions) async {
+    nonisolated public func start(options: StartOptions) async {
         eventContinuation.yield(.start(options))
     }
 
@@ -208,7 +221,7 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
         case let .start(options):
             await handleStart(options)
         case .stop:
-            handleStop()
+            await handleStop()
         case let .adapterConnected(generation):
             guard isCurrentAdapter(generation) else { return }
             await handleAdapterConnected()
@@ -220,6 +233,8 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
             handleAdapterError(error)
         case let .reconnect(nextRelays, reason):
             await handleReconnect(nextRelays: nextRelays, reason: reason)
+        case let .networkReachability(pathStatus):
+            await handleNetworkReachability(pathStatus)
         case let .setErrorState(reason):
             handleSetErrorState(reason)
         case .sleep:
@@ -241,17 +256,24 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
             return
         }
 
+        guard !isDeviceOffline else {
+            logger.debug("Starting while offline, entering blocked state")
+            enterErrorState(reason: .offline)
+            return
+        }
+
         await startConnection(nextRelays: options.selectedRelays.map { .preSelected($0) } ?? .random)
     }
 
     // MARK: - Stop
 
-    private func handleStop() {
+    private func handleStop() async {
         switch observedState {
         case .disconnected:
             return
         default:
             stopCurrentAdapter()
+            await defaultPathObserver.stop()
             observedState = .disconnected
             logger.debug("Stopped, entering disconnected state")
         }
@@ -296,7 +318,11 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
 
     private func handleReconnect(nextRelays: NextRelays, reason: ActorReconnectReason) async {
         switch observedState {
-        case .error:
+        case let .error(blocked):
+            if blocked.reason == .offline, isDeviceOffline {
+                logger.debug("Ignoring reconnect while offline")
+                return
+            }
             logger.debug("Reconnecting from error state")
             stopCurrentAdapter()
             await startConnection(nextRelays: nextRelays)
@@ -305,6 +331,44 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
             await restartConnection(nextRelays: nextRelays)
         default:
             logger.debug("Ignoring reconnect, not connected or connecting")
+        }
+    }
+
+    // MARK: - Network reachability
+
+    private func handleNetworkReachability(_ pathStatus: NWPath.Status) async {
+        let newReachability = pathStatus.networkReachability
+
+        guard newReachability != .undetermined else {
+            logger.debug("Ignoring unknown network path status: \(pathStatus)")
+            return
+        }
+
+        let previousReachability = currentReachability
+        currentReachability = newReachability
+
+        switch observedState {
+        case .connecting, .connected, .reconnecting:
+            guard newReachability != .unreachable else {
+                logger.debug("Network unreachable, entering blocked state")
+                enterErrorState(reason: .offline)
+                return
+            }
+
+            observedState.mutateConnectionState { $0.networkReachability = newReachability }
+            currentAdapter?.recycleUdpSockets()
+
+        case let .error(blocked):
+            // Restoration requires connectivity to have been lost first, otherwise the first
+            // update after starting would masquerade as a recovery and pre-empt the retry timer.
+            guard newReachability == .reachable, previousReachability == .unreachable,
+                blocked.reason.recoverableError()
+            else { return }
+            logger.debug("Network reachable, restoring connectivity from \(blocked.reason)")
+            await startConnection(nextRelays: .random)
+
+        default:
+            return
         }
     }
 
@@ -414,7 +478,7 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
             config: config,
             selectedRelays: selectedRelays,
             relayConstraints: settings.tunnelSettings.relayConstraints,
-            networkReachability: .undetermined,
+            networkReachability: currentReachability,
             connectionAttemptCount: attemptCount,
             lastKeyRotation: nil
         )
@@ -552,6 +616,10 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
     }
 
     // MARK: - Helpers
+
+    private var isDeviceOffline: Bool {
+        currentReachability == .unreachable
+    }
 
     /// Whether the tunnel was already up, so a fresh attempt is reported as `.reconnecting`.
     private var isTunnelEstablished: Bool {

--- a/ios/PacketTunnelCore/GotaTun/GotaTunPathObserver.swift
+++ b/ios/PacketTunnelCore/GotaTun/GotaTunPathObserver.swift
@@ -1,0 +1,80 @@
+// This Source Code Form is subject to the terms of the GPLv3 License.
+// You can obtain a copy of the license at https://www.gnu.org/licenses/gpl-3.0.en.html.
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright (c) Mullvad VPN AB. All rights reserved.
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+import Foundation
+import Network
+
+/// A type providing default path observation for the GotaTun actor.
+public protocol GotaTunPathObserverProtocol: Sendable {
+    /// Start observing the default path and return its current status. Later changes are delivered
+    /// to `body` in the order they occurred. Must be called once; further calls return the same
+    /// status without restarting observation.
+    ///
+    /// A path update will be delivered even if reachability does not change - going from WiFi to modem or otherwise should still result in notifiying the user.
+    @discardableResult
+    func start(_ body: @escaping @Sendable (Network.NWPath.Status) -> Void) async -> Network.NWPath.Status
+
+    /// Stop observing the default path. The observer cannot be started again.
+    func stop() async
+}
+
+public actor GotaTunPathObserver: GotaTunPathObserverProtocol {
+    private let pathMonitor = NWPathMonitor()
+    private var observation: Task<Void, Never>?
+    private var startedStatus: Network.NWPath.Status?
+
+    /// How long a reported loss of connectivity must persist before it is believed. Applying
+    /// tunnel settings, and interface handoffs, momentarily leave the path unsatisfied.
+    private static let pathUpdateDebounceDelay: Duration = .milliseconds(250)
+
+    public init() {}
+
+    @discardableResult
+    public func start(
+        _ body: @escaping @Sendable (Network.NWPath.Status) -> Void
+    ) async -> Network.NWPath.Status {
+        if let startedStatus { return startedStatus }
+
+        var iterator = pathMonitor.makeAsyncIterator()
+        let currentStatus = await iterator.next()?.status ?? .unsatisfied
+        startedStatus = currentStatus
+
+        observation = Task { [iterator] in
+            var iterator = iterator
+            var pendingLoss: Task<Void, Never>?
+            defer { pendingLoss?.cancel() }
+
+            while let status = await iterator.next()?.status {
+                pendingLoss?.cancel()
+                pendingLoss = nil
+
+                // Losing a path should be debounced - .satisfied updates need not be debounced. This swallows spurious losses in connectivity.
+                guard status == .unsatisfied else {
+                    body(status)
+                    continue
+                }
+
+                pendingLoss = Task {
+                    try? await Task.sleep(for: Self.pathUpdateDebounceDelay)
+                    guard !Task.isCancelled else { return }
+                    body(status)
+                }
+            }
+        }
+
+        return currentStatus
+    }
+
+    public func stop() {
+        // Cancelling ends the sequence, which ends `observation`.
+        pathMonitor.cancel()
+        observation = nil
+    }
+}

--- a/ios/PacketTunnelCoreTests/GotaTunActorTests.swift
+++ b/ios/PacketTunnelCoreTests/GotaTunActorTests.swift
@@ -25,12 +25,14 @@ final class GotaTunActorTests: XCTestCase {
         providerDelegate: TunnelProviderDelegate = TunnelProviderDelegateStub(),
         settingsReader: SettingsReaderProtocol = SettingsReaderStub.staticConfiguration(),
         relaySelector: RelaySelectorProtocol = RelaySelectorStub.nonFallible(),
+        defaultPathObserver: GotaTunPathObserverFake = GotaTunPathObserverFake(),
         blockedStateErrorMapper: BlockedStateErrorMapperProtocol = BlockedStateErrorMapperStub()
     ) -> GotaTunActor {
         GotaTunActor(
             providerDelegate: providerDelegate,
             settingsReader: settingsReader,
             relaySelector: relaySelector,
+            defaultPathObserver: defaultPathObserver,
             blockedStateErrorMapper: blockedStateErrorMapper,
             adapterFactory: adapterFactory
         )
@@ -166,6 +168,28 @@ final class GotaTunActorTests: XCTestCase {
                 await actor.start(options: launchOptions)
                 await actor.start(options: launchOptions)
             })
+    }
+
+    // MARK: - Stop
+
+    func testStopGoesToDisconnected() async throws {
+        let actor = makeActor()
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+
+        await waitFor(actor, until: { $0.isDisconnected }, while: { actor.stop() })
+    }
+
+    func testStopIsNoopBeforeStart() async throws {
+        let pathObserver = GotaTunPathObserverFake()
+        let actor = makeActor(defaultPathObserver: pathObserver)
+        actor.stop()
+        await actor.drainEvents()
+
+        let state = await actor.observedState
+        XCTAssertEqual(state, .disconnected)
+        let stopCount = await pathObserver.stopCount
+        XCTAssertEqual(stopCount, 1, "Stopping must tear observation down")
     }
 
     // MARK: - Timeout handling
@@ -432,7 +456,188 @@ final class GotaTunActorTests: XCTestCase {
         XCTAssertEqual(factory.adaptersCreated.count, 0, "Stopping before start must not connect anything")
     }
 
-    func testStopFromConnecting() async throws {
+    // MARK: - Network reachability
+
+    func testOfflineEntersErrorState() async throws {
+        let pathObserver = GotaTunPathObserverFake()
+        let actor = makeActor(defaultPathObserver: pathObserver)
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+
+        await waitFor(
+            actor, until: { $0.blockedReason == .offline },
+            while: {
+                await pathObserver.updatePath(.unsatisfied)
+            })
+    }
+
+    func testOfflinePathUpdateWhileConnectedBlocksAndStopsAdapter() async throws {
+        let factory = GotaTunAdapterFactoryStub(outcome: .connected())
+        let pathObserver = GotaTunPathObserverFake()
+        let actor = makeActor(adapterFactory: factory, defaultPathObserver: pathObserver)
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+        XCTAssertEqual(factory.adaptersCreated.count, 1)
+        XCTAssertFalse(factory.adaptersCreated[0].isStopped)
+
+        await waitFor(
+            actor, until: { $0.blockedReason == .offline },
+            while: {
+                await pathObserver.updatePath(.unsatisfied)
+            })
+        await actor.drainEvents()
+
+        XCTAssertTrue(
+            factory.adaptersCreated[0].isStopped,
+            "The tunnel must be torn down when the path is lost")
+        XCTAssertEqual(
+            factory.adaptersCreated.count, 1,
+            "Going offline must block rather than start another attempt")
+    }
+
+    func testPathObserverStartsWithTheActor() async throws {
+        let pathObserver = GotaTunPathObserverFake()
+        let actor = makeActor(defaultPathObserver: pathObserver)
+
+        await actor.drainEvents()
+        var startCount = await pathObserver.startCount
+        XCTAssertEqual(startCount, 1)
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+
+        startCount = await pathObserver.startCount
+        XCTAssertEqual(startCount, 1, "Starting the tunnel must not restart observation")
+    }
+
+    func testStartedWhileOfflineBlocksImmediately() async throws {
+        let factory = GotaTunAdapterFactoryStub(outcome: .connected())
+        let pathObserver = GotaTunPathObserverFake(status: .unsatisfied)
+        let actor = makeActor(adapterFactory: factory, defaultPathObserver: pathObserver)
+
+        await waitFor(
+            actor, until: { $0.blockedReason == .offline }, while: { await actor.start(options: launchOptions) })
+
+        XCTAssertEqual(factory.adaptersCreated.count, 0, "Must not attempt to connect while offline")
+    }
+
+    func testStartedWhileOfflineThenOnlineConnects() async throws {
+        let factory = GotaTunAdapterFactoryStub(outcome: .connected())
+        let pathObserver = GotaTunPathObserverFake(status: .unsatisfied)
+        let actor = makeActor(adapterFactory: factory, defaultPathObserver: pathObserver)
+
+        await waitFor(
+            actor, until: { $0.blockedReason == .offline }, while: { await actor.start(options: launchOptions) })
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await pathObserver.updatePath(.satisfied) })
+
+        XCTAssertEqual(factory.adaptersCreated.count, 1)
+    }
+
+    func testPathObserverStoppedOnTeardown() async throws {
+        let pathObserver = GotaTunPathObserverFake()
+        let actor = makeActor(defaultPathObserver: pathObserver)
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+
+        await waitFor(actor, until: { $0.isDisconnected }, while: { actor.stop() })
+
+        let stopCount = await pathObserver.stopCount
+        XCTAssertEqual(stopCount, 1)
+        let isStarted = await pathObserver.isStarted
+        XCTAssertFalse(isStarted)
+    }
+
+    func testSatisfiedPathRecyclesSockets() async throws {
+        let factory = GotaTunAdapterFactoryStub(outcome: .connected())
+        let pathObserver = GotaTunPathObserverFake()
+        let actor = makeActor(adapterFactory: factory, defaultPathObserver: pathObserver)
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+
+        let recycled = expectation(description: "Sockets recycled")
+        factory.adaptersCreated[0].onRecycleUdpSockets = { recycled.fulfill() }
+
+        await pathObserver.updatePath(.satisfied)
+        await fulfillment(of: [recycled], timeout: 2.0)
+
+        XCTAssertEqual(factory.adaptersCreated[0].recycleUdpSocketsCount, 1)
+        XCTAssertEqual(factory.adaptersCreated.count, 1)
+
+        let state = await actor.observedState
+        XCTAssertTrue(state.isConnected, "Expected to remain connected, got \(state.name)")
+    }
+
+    func testRequiresConnectionDoesNotGoOffline() async throws {
+        let factory = GotaTunAdapterFactoryStub(outcome: .connected())
+        let pathObserver = GotaTunPathObserverFake()
+        let actor = makeActor(adapterFactory: factory, defaultPathObserver: pathObserver)
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+
+        await pathObserver.updatePath(.requiresConnection)
+        await actor.drainEvents()
+
+        let state = await actor.observedState
+        XCTAssertTrue(state.isConnected, "Expected to remain connected, got \(state.name)")
+        XCTAssertEqual(state.connectionState?.networkReachability, .reachable)
+    }
+
+    func testRepeatedUnsatisfiedDoesNotChurn() async throws {
+        let factory = GotaTunAdapterFactoryStub(outcome: .connected())
+        let pathObserver = GotaTunPathObserverFake()
+        let actor = makeActor(adapterFactory: factory, defaultPathObserver: pathObserver)
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+
+        let offlineExpectation = expectation(description: "Offline error emitted exactly once")
+        offlineExpectation.assertForOverFulfill = true
+
+        let states = await actor.observedStates
+        let task = Task {
+            for await state in states where state.blockedReason == .offline {
+                offlineExpectation.fulfill()
+            }
+        }
+
+        await pathObserver.updatePath(.unsatisfied)
+        await pathObserver.updatePath(.unsatisfied)
+        await pathObserver.updatePath(.unsatisfied)
+        await fulfillment(of: [offlineExpectation], timeout: 2.0)
+        await actor.drainEvents()
+        task.cancel()
+
+        XCTAssertEqual(factory.adaptersCreated.count, 1)
+    }
+
+    func testObservedReachabilityTracksPath() async throws {
+        let pathObserver = GotaTunPathObserverFake()
+        let actor = makeActor(defaultPathObserver: pathObserver)
+
+        await waitFor(
+            actor,
+            until: { $0.isConnecting && $0.connectionState?.networkReachability == .reachable },
+            while: { await actor.start(options: launchOptions) }
+        )
+    }
+
+    func testOnlineAfterOfflineReconnects() async throws {
+        let factory = GotaTunAdapterFactoryStub(outcome: .connected())
+        let pathObserver = GotaTunPathObserverFake()
+        let actor = makeActor(adapterFactory: factory, defaultPathObserver: pathObserver)
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+
+        await waitFor(
+            actor, until: { $0.blockedReason == .offline }, while: { await pathObserver.updatePath(.unsatisfied) })
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await pathObserver.updatePath(.satisfied) })
+
+        XCTAssertEqual(factory.adaptersCreated.count, 2)
+    }
+
+    // MARK: - Stop during connection
+
+    func testStopDuringConnecting() async throws {
         // The adapter never reports, so the actor stays in `.connecting` until stopped.
         let factory = GotaTunAdapterFactoryStub(outcome: .never)
         let actor = makeActor(adapterFactory: factory)

--- a/ios/PacketTunnelCoreTests/Mocks/DefaultPathObserverFake.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/DefaultPathObserverFake.swift
@@ -34,3 +34,40 @@ class DefaultPathObserverFake: DefaultPathObserverProtocol, @unchecked Sendable 
     /// Simulate network path update.
     func updatePath(_ newPath: Network.NWPath.Status) {}
 }
+
+/// GotaTun path observer fake that keeps current path in actor state and provides a method to
+/// simulate path change from tests.
+actor GotaTunPathObserverFake: GotaTunPathObserverProtocol {
+    private var pathStatus: Network.NWPath.Status
+    private var defaultPathHandler: (@Sendable (Network.NWPath.Status) -> Void)?
+
+    private(set) var startCount = 0
+    private(set) var stopCount = 0
+
+    init(status: Network.NWPath.Status = .satisfied) {
+        self.pathStatus = status
+    }
+
+    var isStarted: Bool {
+        defaultPathHandler != nil
+    }
+
+    @discardableResult
+    func start(_ body: @escaping @Sendable (Network.NWPath.Status) -> Void) -> Network.NWPath.Status {
+        startCount += 1
+        guard defaultPathHandler == nil else { return pathStatus }
+        defaultPathHandler = body
+        return pathStatus
+    }
+
+    func stop() {
+        defaultPathHandler = nil
+        stopCount += 1
+    }
+
+    /// Simulate network path update.
+    func updatePath(_ newPath: Network.NWPath.Status) {
+        pathStatus = newPath
+        defaultPathHandler?(newPath)
+    }
+}


### PR DESCRIPTION
These changes allow GotaTun actor to handle path updates. Turns out that `NWPathMonitor` has a nice async interface after all.

Bear in mind, these changes do not introduce the required changes on the Rust side to rebind sockets when paths are updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11046)
<!-- Reviewable:end -->
