### PR TITLE
Flush build artifacts in 4-update-and-publish-metadata instead of 5-make-release

### DIFF
--- a/desktop/scripts/release/4-update-and-publish-metadata
+++ b/desktop/scripts/release/4-update-and-publish-metadata
@@ -40,6 +40,8 @@ ROLLOUT=0
 source "$SCRIPT_DIR/release-config.sh"
 source $REPO_ROOT/scripts/utils/log
 
+rm -rf "$ARTIFACT_DIR" && mkdir -p "$ARTIFACT_DIR" || exit 1
+
 function publish_metadata {
     local platforms
     platforms=(windows macos linux)

--- a/desktop/scripts/release/5-make-release
+++ b/desktop/scripts/release/5-make-release
@@ -38,8 +38,6 @@ $REPO_ROOT/scripts/utils/commit-verification
 source "$SCRIPT_DIR/release-config.sh"
 source $REPO_ROOT/scripts/utils/log
 
-rm -rf "$ARTIFACT_DIR" && mkdir -p "$ARTIFACT_DIR" || exit 1
-
 function publish_release {
     log_header "Downloading changelog"
 
@@ -104,11 +102,6 @@ function publish_release {
     fi
 }
 
-function remove_release_artifacts {
-    log_header "Cleaning up $ARTIFACT_DIR"
-    rm -r "$ARTIFACT_DIR"
-}
-
 ./download-release-artifacts "$PRODUCT_VERSION" "$ARTIFACT_DIR"
 publish_release
-remove_release_artifacts
+rm -rf "$ARTIFACT_DIR"


### PR DESCRIPTION
Prevents them from being downloaded twice during releases. I think I missed this when changing their order.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11048)
<!-- Reviewable:end -->
