### PR TITLE
Wrap AppResetManager's actual functionality in NEVER_IN_PRODUCTION

### DIFF
--- a/ios/Shared/AppResetManager.swift
+++ b/ios/Shared/AppResetManager.swift
@@ -14,152 +14,162 @@ import MullvadSettings
 import NetworkExtension
 import UIKit
 
+#if NEVER_IN_PRODUCTION
+    typealias AppResetManager = AppResetManagerReal
+#else
+    typealias AppResetManager = AppResetManagerNoOp
+#endif
+
+
 @MainActor
-final class AppResetManager {
-    #if NEVER_IN_PRODUCTION
-        private let launchArguments: LaunchArguments
-        private let tunnelManager: TunnelManager
-        private let settingsManager: SettingsManager
-        private var tunnelObserver: TunnelObserver!
+final class AppResetManagerReal {
+    private let launchArguments: LaunchArguments
+    private let tunnelManager: TunnelManager
+    private let settingsManager: SettingsManager
+    private var tunnelObserver: TunnelObserver!
 
-        let logger = Logger(label: "AppResetManager")
+    let logger = Logger(label: "AppResetManager")
 
-        var onAppReady: (@Sendable @MainActor () -> Void)?
+    var onAppReady: (@Sendable @MainActor () -> Void)?
 
-        private let isConfigurationLoaded = CurrentValueSubject<Bool, Never>(false)
-        private let isAppReady = CurrentValueSubject<Bool, Never>(false)
+    private let isConfigurationLoaded = CurrentValueSubject<Bool, Never>(false)
+    private let isAppReady = CurrentValueSubject<Bool, Never>(false)
 
-        private var cancellables = Set<AnyCancellable>()
-    #endif
+    private var cancellables = Set<AnyCancellable>()
 
     init(
         launchArguments: LaunchArguments,
         tunnelManager: TunnelManager,
         settingsManager: SettingsManager
     ) {
-        #if NEVER_IN_PRODUCTION
-            self.launchArguments = launchArguments
-            self.tunnelManager = tunnelManager
-            self.settingsManager = settingsManager
-            guard launchArguments.target.isUITest else { return }
-            observeReadiness()
-            addObserver()
-        #endif
+        self.launchArguments = launchArguments
+        self.tunnelManager = tunnelManager
+        self.settingsManager = settingsManager
+        guard launchArguments.target.isUITest else { return }
+        observeReadiness()
+        addObserver()
     }
 
     func start() {
-        #if NEVER_IN_PRODUCTION
-            guard launchArguments.target.isUITest else { return }
-            Task {
-                async let cleanup: () = StorePaymentManager.cleanupUnfinishedTransactions()
-                async let setupTask: () = setup()
-                _ = await (cleanup, setupTask)
+        guard launchArguments.target.isUITest else { return }
+        Task {
+            async let cleanup: () = StorePaymentManager.cleanupUnfinishedTransactions()
+            async let setupTask: () = setup()
+            _ = await (cleanup, setupTask)
+        }
+    }
+
+    private func observeReadiness() {
+        Publishers.CombineLatest(isConfigurationLoaded, isAppReady)
+            .filter { configurationLoaded, appReady in
+                configurationLoaded && appReady
+            }
+            .sink { [weak self] _, _ in
+                guard let self else { return }
+                tunnelManager.removeObserver(tunnelObserver)
+                onAppReady?()
+            }
+            .store(in: &cancellables)
+    }
+
+    private func addObserver() {
+        let tunnelObserver = TunnelBlockObserver(
+            didLoadConfiguration: { [weak self] tunnelManager in
+                self?.isConfigurationLoaded.send(true)
+            },
+            didUpdateTunnelStatus: { [weak self] tunnelManager, tunnelStatus in
+                guard let self else { return }
+                if tunnelStatus.observedState != .disconnected {
+                    tunnelManager.stopTunnel()
+                } else if case .disconnected = tunnelStatus.observedState {
+                    Task {
+                        await reset()
+                    }
+                }
+            }
+        )
+        tunnelManager.addObserver(tunnelObserver)
+        self.tunnelObserver = tunnelObserver
+    }
+
+    private func setup() async {
+        do {
+            guard try await isTunnelActive() == false else { return }
+            await reset()
+        } catch {
+            logger.error("Unexpected tunnel error: \(error.localizedDescription)")
+            isAppReady.send(true)
+        }
+    }
+
+    private func reset() async {
+        switch tunnelManager.deviceState {
+        case .loggedIn:
+            await logoutIfNeeded()
+            fallthrough
+        default:
+            resetUserDefaults()
+            resetKeychain()
+            isAppReady.send(true)
+        }
+    }
+
+    private func logoutIfNeeded() async {
+        guard launchArguments.authenticationState == .forceLoggedOut else {
+            return
+        }
+        await tunnelManager.unsetAccount(isRemovingProfile: false)
+    }
+
+    private func resetKeychain() {
+        let policy = launchArguments.settingsResetPolicy
+        settingsManager.resetStore(policy: policy.toSettingsResetPolicy)
+        if policy.shouldReset(.settings) {
+            tunnelManager.updateSettings([.reset])
+        }
+    }
+
+    private func resetUserDefaults() {
+        let policy = launchArguments.appPreferencesResetPolicy
+        let defaults = UserDefaults.standard
+        let keysToRemove: Set<UITestAppPreferencesKey> = policy.resolvedKeys()
+        for key in keysToRemove {
+            defaults.removeObject(forKey: key.rawValue)
+        }
+        defaults.synchronize()
+    }
+
+    private func isTunnelActive() async throws -> Bool {
+        #if targetEnvironment(simulator)
+            return false
+        #else
+            try await withCheckedThrowingContinuation { continuation in
+                NETunnelProviderManager.loadAllFromPreferences { managers, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                        return
+                    }
+
+                    let active = (managers ?? []).contains {
+                        [.connected, .connecting, .reasserting].contains($0.connection.status)
+                    }
+
+                    continuation.resume(returning: active)
+                }
             }
         #endif
     }
+}
 
-    #if NEVER_IN_PRODUCTION
-        private func observeReadiness() {
-            Publishers.CombineLatest(isConfigurationLoaded, isAppReady)
-                .filter { configurationLoaded, appReady in
-                    configurationLoaded && appReady
-                }
-                .sink { [weak self] _, _ in
-                    guard let self else { return }
-                    tunnelManager.removeObserver(tunnelObserver)
-                    onAppReady?()
-                }
-                .store(in: &cancellables)
-        }
+@MainActor
+final class AppResetManagerNoOp {
+    init(
+        launchArguments: LaunchArguments,
+        tunnelManager: TunnelManager,
+        settingsManager: SettingsManager
+    ) {}
 
-        private func addObserver() {
-            let tunnelObserver = TunnelBlockObserver(
-                didLoadConfiguration: { [weak self] tunnelManager in
-                    self?.isConfigurationLoaded.send(true)
-                },
-                didUpdateTunnelStatus: { [weak self] tunnelManager, tunnelStatus in
-                    guard let self else { return }
-                    if tunnelStatus.observedState != .disconnected {
-                        tunnelManager.stopTunnel()
-                    } else if case .disconnected = tunnelStatus.observedState {
-                        Task {
-                            await reset()
-                        }
-                    }
-                }
-            )
-            tunnelManager.addObserver(tunnelObserver)
-            self.tunnelObserver = tunnelObserver
-        }
-
-        private func setup() async {
-            do {
-                guard try await isTunnelActive() == false else { return }
-                await reset()
-            } catch {
-                logger.error("Unexpected tunnel error: \(error.localizedDescription)")
-                isAppReady.send(true)
-            }
-        }
-
-        private func reset() async {
-            switch tunnelManager.deviceState {
-            case .loggedIn:
-                await logoutIfNeeded()
-                fallthrough
-            default:
-                resetUserDefaults()
-                resetKeychain()
-                isAppReady.send(true)
-            }
-        }
-
-        private func logoutIfNeeded() async {
-            guard launchArguments.authenticationState == .forceLoggedOut else {
-                return
-            }
-            await tunnelManager.unsetAccount(isRemovingProfile: false)
-        }
-
-        private func resetKeychain() {
-            let policy = launchArguments.settingsResetPolicy
-            settingsManager.resetStore(policy: policy.toSettingsResetPolicy)
-            if policy.shouldReset(.settings) {
-                tunnelManager.updateSettings([.reset])
-            }
-        }
-
-        private func resetUserDefaults() {
-            let policy = launchArguments.appPreferencesResetPolicy
-            let defaults = UserDefaults.standard
-            let keysToRemove: Set<UITestAppPreferencesKey> = policy.resolvedKeys()
-            for key in keysToRemove {
-                defaults.removeObject(forKey: key.rawValue)
-            }
-            defaults.synchronize()
-        }
-
-        private func isTunnelActive() async throws -> Bool {
-            #if targetEnvironment(simulator)
-                return false
-            #else
-                try await withCheckedThrowingContinuation { continuation in
-                    NETunnelProviderManager.loadAllFromPreferences { managers, error in
-                        if let error {
-                            continuation.resume(throwing: error)
-                            return
-                        }
-
-                        let active = (managers ?? []).contains {
-                            [.connected, .connecting, .reasserting].contains($0.connection.status)
-                        }
-
-                        continuation.resume(returning: active)
-                    }
-                }
-            #endif
-        }
-    #endif
+    func start() {}
 }
 
 extension UITestSettingsKey {

--- a/ios/Shared/AppResetManager.swift
+++ b/ios/Shared/AppResetManager.swift
@@ -16,142 +16,150 @@ import UIKit
 
 @MainActor
 final class AppResetManager {
-    private let launchArguments: LaunchArguments
-    private let tunnelManager: TunnelManager
-    private let settingsManager: SettingsManager
-    private var tunnelObserver: TunnelObserver!
+    #if NEVER_IN_PRODUCTION
+        private let launchArguments: LaunchArguments
+        private let tunnelManager: TunnelManager
+        private let settingsManager: SettingsManager
+        private var tunnelObserver: TunnelObserver!
 
-    let logger = Logger(label: "AppResetManager")
+        let logger = Logger(label: "AppResetManager")
 
-    var onAppReady: (@Sendable @MainActor () -> Void)?
+        var onAppReady: (@Sendable @MainActor () -> Void)?
 
-    private let isConfigurationLoaded = CurrentValueSubject<Bool, Never>(false)
-    private let isAppReady = CurrentValueSubject<Bool, Never>(false)
+        private let isConfigurationLoaded = CurrentValueSubject<Bool, Never>(false)
+        private let isAppReady = CurrentValueSubject<Bool, Never>(false)
 
-    private var cancellables = Set<AnyCancellable>()
+        private var cancellables = Set<AnyCancellable>()
+    #endif
 
     init(
         launchArguments: LaunchArguments,
         tunnelManager: TunnelManager,
         settingsManager: SettingsManager
     ) {
-        self.launchArguments = launchArguments
-        self.tunnelManager = tunnelManager
-        self.settingsManager = settingsManager
-        guard launchArguments.target.isUITest else { return }
-        observeReadiness()
-        addObserver()
+        #if NEVER_IN_PRODUCTION
+            self.launchArguments = launchArguments
+            self.tunnelManager = tunnelManager
+            self.settingsManager = settingsManager
+            guard launchArguments.target.isUITest else { return }
+            observeReadiness()
+            addObserver()
+        #endif
     }
 
     func start() {
-        guard launchArguments.target.isUITest else { return }
-        Task {
-            async let cleanup: () = StorePaymentManager.cleanupUnfinishedTransactions()
-            async let setupTask: () = setup()
-            _ = await (cleanup, setupTask)
-        }
-    }
-
-    private func observeReadiness() {
-        Publishers.CombineLatest(isConfigurationLoaded, isAppReady)
-            .filter { configurationLoaded, appReady in
-                configurationLoaded && appReady
-            }
-            .sink { [weak self] _, _ in
-                guard let self else { return }
-                tunnelManager.removeObserver(tunnelObserver)
-                onAppReady?()
-            }
-            .store(in: &cancellables)
-    }
-
-    private func addObserver() {
-        let tunnelObserver = TunnelBlockObserver(
-            didLoadConfiguration: { [weak self] tunnelManager in
-                self?.isConfigurationLoaded.send(true)
-            },
-            didUpdateTunnelStatus: { [weak self] tunnelManager, tunnelStatus in
-                guard let self else { return }
-                if tunnelStatus.observedState != .disconnected {
-                    tunnelManager.stopTunnel()
-                } else if case .disconnected = tunnelStatus.observedState {
-                    Task {
-                        await reset()
-                    }
-                }
-            }
-        )
-        tunnelManager.addObserver(tunnelObserver)
-        self.tunnelObserver = tunnelObserver
-    }
-
-    private func setup() async {
-        do {
-            guard try await isTunnelActive() == false else { return }
-            await reset()
-        } catch {
-            logger.error("Unexpected tunnel error: \(error.localizedDescription)")
-            isAppReady.send(true)
-        }
-    }
-
-    private func reset() async {
-        switch tunnelManager.deviceState {
-        case .loggedIn:
-            await logoutIfNeeded()
-            fallthrough
-        default:
-            resetUserDefaults()
-            resetKeychain()
-            isAppReady.send(true)
-        }
-    }
-
-    private func logoutIfNeeded() async {
-        guard launchArguments.authenticationState == .forceLoggedOut else {
-            return
-        }
-        await tunnelManager.unsetAccount(isRemovingProfile: false)
-    }
-
-    private func resetKeychain() {
-        let policy = launchArguments.settingsResetPolicy
-        settingsManager.resetStore(policy: policy.toSettingsResetPolicy)
-        if policy.shouldReset(.settings) {
-            tunnelManager.updateSettings([.reset])
-        }
-    }
-
-    private func resetUserDefaults() {
-        let policy = launchArguments.appPreferencesResetPolicy
-        let defaults = UserDefaults.standard
-        let keysToRemove: Set<UITestAppPreferencesKey> = policy.resolvedKeys()
-        for key in keysToRemove {
-            defaults.removeObject(forKey: key.rawValue)
-        }
-        defaults.synchronize()
-    }
-
-    private func isTunnelActive() async throws -> Bool {
-        #if targetEnvironment(simulator)
-            return false
-        #else
-            try await withCheckedThrowingContinuation { continuation in
-                NETunnelProviderManager.loadAllFromPreferences { managers, error in
-                    if let error {
-                        continuation.resume(throwing: error)
-                        return
-                    }
-
-                    let active = (managers ?? []).contains {
-                        [.connected, .connecting, .reasserting].contains($0.connection.status)
-                    }
-
-                    continuation.resume(returning: active)
-                }
+        #if NEVER_IN_PRODUCTION
+            guard launchArguments.target.isUITest else { return }
+            Task {
+                async let cleanup: () = StorePaymentManager.cleanupUnfinishedTransactions()
+                async let setupTask: () = setup()
+                _ = await (cleanup, setupTask)
             }
         #endif
     }
+
+    #if NEVER_IN_PRODUCTION
+        private func observeReadiness() {
+            Publishers.CombineLatest(isConfigurationLoaded, isAppReady)
+                .filter { configurationLoaded, appReady in
+                    configurationLoaded && appReady
+                }
+                .sink { [weak self] _, _ in
+                    guard let self else { return }
+                    tunnelManager.removeObserver(tunnelObserver)
+                    onAppReady?()
+                }
+                .store(in: &cancellables)
+        }
+
+        private func addObserver() {
+            let tunnelObserver = TunnelBlockObserver(
+                didLoadConfiguration: { [weak self] tunnelManager in
+                    self?.isConfigurationLoaded.send(true)
+                },
+                didUpdateTunnelStatus: { [weak self] tunnelManager, tunnelStatus in
+                    guard let self else { return }
+                    if tunnelStatus.observedState != .disconnected {
+                        tunnelManager.stopTunnel()
+                    } else if case .disconnected = tunnelStatus.observedState {
+                        Task {
+                            await reset()
+                        }
+                    }
+                }
+            )
+            tunnelManager.addObserver(tunnelObserver)
+            self.tunnelObserver = tunnelObserver
+        }
+
+        private func setup() async {
+            do {
+                guard try await isTunnelActive() == false else { return }
+                await reset()
+            } catch {
+                logger.error("Unexpected tunnel error: \(error.localizedDescription)")
+                isAppReady.send(true)
+            }
+        }
+
+        private func reset() async {
+            switch tunnelManager.deviceState {
+            case .loggedIn:
+                await logoutIfNeeded()
+                fallthrough
+            default:
+                resetUserDefaults()
+                resetKeychain()
+                isAppReady.send(true)
+            }
+        }
+
+        private func logoutIfNeeded() async {
+            guard launchArguments.authenticationState == .forceLoggedOut else {
+                return
+            }
+            await tunnelManager.unsetAccount(isRemovingProfile: false)
+        }
+
+        private func resetKeychain() {
+            let policy = launchArguments.settingsResetPolicy
+            settingsManager.resetStore(policy: policy.toSettingsResetPolicy)
+            if policy.shouldReset(.settings) {
+                tunnelManager.updateSettings([.reset])
+            }
+        }
+
+        private func resetUserDefaults() {
+            let policy = launchArguments.appPreferencesResetPolicy
+            let defaults = UserDefaults.standard
+            let keysToRemove: Set<UITestAppPreferencesKey> = policy.resolvedKeys()
+            for key in keysToRemove {
+                defaults.removeObject(forKey: key.rawValue)
+            }
+            defaults.synchronize()
+        }
+
+        private func isTunnelActive() async throws -> Bool {
+            #if targetEnvironment(simulator)
+                return false
+            #else
+                try await withCheckedThrowingContinuation { continuation in
+                    NETunnelProviderManager.loadAllFromPreferences { managers, error in
+                        if let error {
+                            continuation.resume(throwing: error)
+                            return
+                        }
+
+                        let active = (managers ?? []).contains {
+                            [.connected, .connecting, .reasserting].contains($0.connection.status)
+                        }
+
+                        continuation.resume(returning: active)
+                    }
+                }
+            #endif
+        }
+    #endif
 }
 
 extension UITestSettingsKey {

--- a/ios/Shared/AppResetManager.swift
+++ b/ios/Shared/AppResetManager.swift
@@ -20,7 +20,6 @@ import UIKit
     typealias AppResetManager = AppResetManagerNoOp
 #endif
 
-
 @MainActor
 final class AppResetManagerReal {
     private let launchArguments: LaunchArguments

--- a/ios/Shared/AppResetManager.swift
+++ b/ios/Shared/AppResetManager.swift
@@ -163,6 +163,8 @@ final class AppResetManagerReal {
 
 @MainActor
 final class AppResetManagerNoOp {
+    var onAppReady: (@Sendable @MainActor () -> Void)?
+
     init(
         launchArguments: LaunchArguments,
         tunnelManager: TunnelManager,


### PR DESCRIPTION
All details of this class other than its public interface are now wrapped in conditional compilation pragmas, ensuring that the class itelf is a no-op if the app is configured for production at build time.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11051)
<!-- Reviewable:end -->
