### PR TITLE
Cancel superseded workflow runs when a PR branch moves

### DIFF
--- a/.github/workflows/android-reproducible-builds.yml
+++ b/.github/workflows/android-reproducible-builds.yml
@@ -28,6 +28,10 @@ on:
     tags:
       - 'android/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -11,6 +11,10 @@ on:
       - '**/*.proto'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -36,6 +36,14 @@ on:
         type: string
         required: false
 
+# Cancel superseded runs when a pull request branch moves. Runs on main are
+# never cancelled. The same block is repeated in every workflow that
+# schedules macOS jobs, since macOS runner concurrency is the bottleneck in
+# this repo's CI.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/downloader.yml
+++ b/.github/workflows/downloader.yml
@@ -26,6 +26,10 @@ on:
       - '!prepare-release.sh'
       - '!**/osv-scanner.toml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -8,6 +8,10 @@ on:
       - mullvad-management-interface/proto/**
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/ios-rust-ffi.yml
+++ b/.github/workflows/ios-rust-ffi.yml
@@ -12,6 +12,10 @@ on:
       - 'mullvad-ios/**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/ios-screenshots-creation.yml
+++ b/.github/workflows/ios-screenshots-creation.yml
@@ -10,6 +10,10 @@ on:
       - ios/Gemfile.lock
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/ios-screenshots-tests.yml
+++ b/.github/workflows/ios-screenshots-tests.yml
@@ -13,6 +13,10 @@ on:
       - ios/**/*.xctestplan
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/ios-validate-build-schemas.yml
+++ b/.github/workflows/ios-validate-build-schemas.yml
@@ -15,6 +15,10 @@ on:
       - Cargo.toml
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -17,6 +17,10 @@ on:
       - 'mullvad-ios/**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -27,6 +27,7 @@ jobs:
   swift-format:
     name: Run swift format lint
     runs-on: macos-26
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -38,6 +39,7 @@ jobs:
   ui-test-build:
     name: Build for ui tests (staging)
     runs-on: macos-26
+    timeout-minutes: 30
     env:
       SOURCE_PACKAGES_PATH: .spm
     steps:
@@ -63,6 +65,7 @@ jobs:
   test:
     name: Unit tests
     runs-on: macos-26-xlarge
+    timeout-minutes: 30
     env:
       SOURCE_PACKAGES_PATH: .spm
     steps:

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -17,6 +17,10 @@ on:
         type: string
         required: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/testframework-clippy.yml
+++ b/.github/workflows/testframework-clippy.yml
@@ -11,6 +11,10 @@ on:
       - 'ci/cargo-ci.sh'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/testframework.yml
+++ b/.github/workflows/testframework.yml
@@ -30,6 +30,10 @@ on:
       - '!**/osv-scanner.toml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions: {}
 
 jobs:


### PR DESCRIPTION
GitHub does not cancel older runs by default, so every push to a pull request queued another full set of jobs while the previous ones kept their place in line. Earlier today half the pending macOS jobs were building commits that were no longer the branch head, and macOS runner concurrency is the scarcest resource in this repo.

Scoped to the workflows that schedule macOS jobs, since those are the bottleneck. We can add it to the rest as well if we feel like we want/need that.

Runs on main and on release tags are never cancelled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11060)
<!-- Reviewable:end -->
