### PR TITLE
Devices logs are duplicated when being sent

### DIFF
--- a/ios/MullvadVPN/Classes/ConsolidatedApplicationLog.swift
+++ b/ios/MullvadVPN/Classes/ConsolidatedApplicationLog.swift
@@ -11,10 +11,10 @@
 import Foundation
 import MullvadLogging
 
-private let kLogDelimiter = "===================="
-private let kRedactedPlaceholder = "[REDACTED]"
-
 class ConsolidatedApplicationLog: TextOutputStreamable, @unchecked Sendable {
+    let kLogDelimiter = "===================="
+    let kRedactedPlaceholder = "[REDACTED]"
+
     typealias Metadata = KeyValuePairs<MetadataKey, String>
     private let bufferSize: UInt64
 
@@ -48,16 +48,6 @@ class ConsolidatedApplicationLog: TextOutputStreamable, @unchecked Sendable {
             for fileURL in fileURLs {
                 self.addSingleLogFile(fileURL)
             }
-            DispatchQueue.main.async {
-                completion?()
-            }
-        }
-    }
-
-    func addError(message: String, error: String, completion: (@Sendable () -> Void)? = nil) {
-        let redactedError = redact(string: error)
-        logQueue.async(flags: .barrier) {
-            self.logs.append(LogAttachment(label: message, content: redactedError))
             DispatchQueue.main.async {
                 completion?()
             }
@@ -103,10 +93,11 @@ class ConsolidatedApplicationLog: TextOutputStreamable, @unchecked Sendable {
 
     private func addSingleLogFile(_ fileURL: URL) {
         guard fileURL.isFileURL else {
-            addError(
-                message: fileURL.absoluteString,
-                error: "Invalid log file URL: \(fileURL.absoluteString)."
-            )
+            logs.append(
+                LogAttachment(
+                    label: fileURL.absoluteString,
+                    content: redact(string: "Invalid log file URL: \(fileURL.absoluteString).")
+                ))
             return
         }
 
@@ -114,12 +105,13 @@ class ConsolidatedApplicationLog: TextOutputStreamable, @unchecked Sendable {
         let redactedPath = redact(string: path)
 
         if let lossyString = readFileLossy(path: path, maxBytes: bufferSize) {
-            let redactedString = redact(string: lossyString)
-            logQueue.async(flags: .barrier) {
-                self.logs.append(LogAttachment(label: redactedPath, content: redactedString))
-            }
+            logs.append(LogAttachment(label: redactedPath, content: redact(string: lossyString)))
         } else {
-            addError(message: redactedPath, error: "Log file does not exist: \(path).")
+            logs.append(
+                LogAttachment(
+                    label: redactedPath,
+                    content: redact(string: "Log file does not exist: \(path).")
+                ))
         }
     }
 

--- a/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportInteractor.swift
+++ b/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportInteractor.swift
@@ -31,6 +31,12 @@ final class ProblemReportInteractor: @unchecked Sendable {
     }
 
     func fetchReportString(completion: @escaping @Sendable (String) -> Void) {
+        let existing = consolidatedLog.string
+        guard existing.isEmpty else {
+            completion(existing)
+            return
+        }
+
         consolidatedLog.addLogFiles(
             fileURLs: ApplicationTarget.allCases.flatMap {
                 ApplicationConfiguration.logFileURLs(for: $0, in: ApplicationConfiguration.containerURL)
@@ -47,7 +53,6 @@ final class ProblemReportInteractor: @unchecked Sendable {
         includeAccountTokenInLogs: Bool,
         completion: @escaping @Sendable (Result<Void, Error>) -> Void
     ) {
-        let logString = self.consolidatedLog.string
         let accountToken =
             if isUserLoggedIn() && includeAccountTokenInLogs,
                 let token = tunnelManager.deviceState.accountData?.identifier
@@ -55,17 +60,8 @@ final class ProblemReportInteractor: @unchecked Sendable {
                 "\naccount-token: \(token)"
             } else { "" }
 
-        if logString.isEmpty {
-            fetchReportString { [weak self, accountToken] updatedLogString in
-                self?.sendProblemReport(
-                    email: email,
-                    message: message + accountToken,
-                    logString: updatedLogString,
-                    completion: completion
-                )
-            }
-        } else {
-            sendProblemReport(
+        fetchReportString { [weak self] logString in
+            self?.sendProblemReport(
                 email: email,
                 message: message + accountToken,
                 logString: logString,

--- a/ios/MullvadVPNTests/MullvadVPN/Log/ConsolidatedApplicationLogTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/Log/ConsolidatedApplicationLogTests.swift
@@ -8,9 +8,10 @@
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
-import MullvadLogging
 import MullvadRustRuntime
 import XCTest
+
+@testable import MullvadLogging
 
 final class ConsolidatedApplicationLogTests: XCTestCase, @unchecked Sendable {
     nonisolated(unsafe) var consolidatedLog: ConsolidatedApplicationLog!
@@ -53,22 +54,6 @@ final class ConsolidatedApplicationLogTests: XCTestCase, @unchecked Sendable {
         )
     }
 
-    func testAddError() async {
-        let expectation = self.expectation(description: "Error added to log")
-        let errorMessage = "Test error"
-        let errorDetails = "A sensitive error occurred"
-
-        consolidatedLog.addError(message: errorMessage, error: errorDetails) {
-            expectation.fulfill()
-        }
-
-        await fulfillment(of: [expectation], timeout: 1)
-        XCTAssertTrue(
-            consolidatedLog.string.contains(errorMessage),
-            "Log should include the error message."
-        )
-    }
-
     func testStringOutput() async {
         let expectation = self.expectation(description: "Log files added")
         let mockFile = createMockFile(content: content, fileName: "\(generateRandomName()).txt")
@@ -84,7 +69,7 @@ final class ConsolidatedApplicationLogTests: XCTestCase, @unchecked Sendable {
     /// have their sensitive content fully redacted at collection time.
     func testOldLogFileContentIsRedactedAtCollectionTime() async {
         let expectation = self.expectation(description: "Old log file processed")
-        let mockFile = createMockFile(content: oldReleaseLogContent, fileName: "\(generateRandomName()).log")
+        let mockFile = createMockFile(content: oldReleaseLogContent, fileName: "\(generateRandomName()).txt")
 
         consolidatedLog.addLogFiles(fileURLs: [mockFile]) {
             expectation.fulfill()
@@ -106,6 +91,46 @@ final class ConsolidatedApplicationLogTests: XCTestCase, @unchecked Sendable {
         // Non-sensitive content should survive
         XCTAssertTrue(output.contains("MullvadVPN version 2024.5"), "Version header should be preserved")
         XCTAssertTrue(output.contains("Refresh device state"), "Normal log text should be preserved")
+    }
+
+    func testAddLogFilesAccumulatesEntriesWhenCalledTwice() async {
+        let expectation1 = expectation(description: "First file added")
+        let expectation2 = expectation(description: "Second file added")
+        let mockFile = createMockFile(content: content, fileName: "\(generateRandomName()).txt")
+
+        consolidatedLog.addLogFiles(fileURLs: [mockFile]) { expectation1.fulfill() }
+        await fulfillment(of: [expectation1], timeout: 1)
+        let sectionsAfterFirst = consolidatedLog.string.components(
+            separatedBy: consolidatedLog.kLogDelimiter
+        ).count
+
+        consolidatedLog.addLogFiles(fileURLs: [mockFile]) { expectation2.fulfill() }
+        await fulfillment(of: [expectation2], timeout: 1)
+        let sectionsAfterSecond = consolidatedLog.string.components(
+            separatedBy: consolidatedLog.kLogDelimiter
+        ).count
+
+        XCTAssertEqual(
+            sectionsAfterSecond,
+            2 * sectionsAfterFirst - 1,  // Doubled, minus system info header.
+            "Calling addLogFiles twice doubles log sections."
+        )
+    }
+
+    func testStringIsNotEmptyAfterAddingLogFiles() async {
+        let expectation = expectation(description: "File added")
+        let mockFile = createMockFile(content: content, fileName: "\(generateRandomName()).txt")
+
+        XCTAssertTrue(consolidatedLog.string.isEmpty, "String should be empty before adding files.")
+
+        consolidatedLog.addLogFiles(fileURLs: [mockFile]) { expectation.fulfill() }
+        await fulfillment(of: [expectation], timeout: 1)
+
+        XCTAssertFalse(
+            consolidatedLog.string.isEmpty,
+            "String should not be empty after calling addLogFiles, "
+                + "meaning guard in fetchReportString prevents duplicate loads."
+        )
     }
 
     // MARK: - Private functions


### PR DESCRIPTION
**What is being observed?**

When one shares logs from the device, every log content (except for the header) is sent twice

**Reproduction steps**

- Go to the log view
- Send logs to yourself

Notice that every block of logs appear twice

**What needs to be done to fix this?**

- Make sure logs are not sent twice
- Add Unit Tests that guarantee log contents are not duplicated

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11061)
<!-- Reviewable:end -->
