### PR TITLE
Remove unnecessary device cleanup during install/update and add timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,14 @@ Line wrap the file at 100 chars.                                              Th
   Required for reproducible builds.
 - Stop embedding absolute build machine PDB paths in the Rust Windows binaries + winfw.dll.
   Required for reproducible builds.
+- Add timeout to device cleanup tasks during installs.
 
 ### Removed
 #### Windows
 - Remove `netsh`-based DNS configuration. All Windows build older than 22H2 support configuring DNS
   via the `iphlpapi` IP helper API.
+- Stop removing leftover Wintun adapters during installation. Wintun dropped support for adapter
+  pools, so this has not been necessary since 2022.5-beta1.
 
 ### Fixed
 #### Linux

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -721,8 +721,8 @@ ManifestDPIAware true
 # which kills the app and may thus cause the daemon to disconnect.
 #
 !macro customCheckAppRunning
-	push $R0
-	push $R1
+	Push $R0
+	Push $R1
 
 	# This must be done here for compatibility with <= 2021.2,
 	# since those versions do not kill the GUI in the uninstaller.
@@ -739,12 +739,13 @@ ManifestDPIAware true
 	${EndIf}
 
 	# Killing without /f will likely cause the daemon to disconnect.
-	nsExec::Exec `"$SYSDIR\taskkill.exe" /f /t /im "${APP_EXECUTABLE_FILENAME}"` $R0
+	nsExec::Exec `"$SYSDIR\taskkill.exe" /f /t /im "${APP_EXECUTABLE_FILENAME}"`
+	Pop $R0
 	Sleep 500
 
 	customCheckAppRunning_skip_kill:
-	pop $R1
-	pop $R0
+	Pop $R1
+	Pop $R0
 
 !macroend
 
@@ -1075,9 +1076,11 @@ ManifestDPIAware true
 
 	Pop $FullUninstall
 
-	nsExec::Exec `"$SYSDIR\taskkill.exe" /t /im "${APP_EXECUTABLE_FILENAME}"` $0
+	nsExec::Exec `"$SYSDIR\taskkill.exe" /t /im "${APP_EXECUTABLE_FILENAME}"`
+	Pop $0
 	Sleep 500
-	nsExec::Exec `"$SYSDIR\taskkill.exe" /f /t /im "${APP_EXECUTABLE_FILENAME}"` $0
+	nsExec::Exec `"$SYSDIR\taskkill.exe" /f /t /im "${APP_EXECUTABLE_FILENAME}"`
+	Pop $0
 
 	${If} $FullUninstall == 0
 		# Save the target tunnel state if we're upgrading

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -243,45 +243,6 @@ ManifestDPIAware true
 !define RemoveAbandonedWireGuardNt '!insertmacro "RemoveAbandonedWireGuardNt"'
 
 #
-# RemoveAbandonedWintunAdapter
-#
-# Removes old Wintun interface, even if it belongs to a different pool.
-#
-!macro RemoveAbandonedWintunAdapter
-	Push $0
-	Push $1
-
-	mullvad_nsis::Log "RemoveAbandonedWintunAdapter()"
-
-	nsExec::ExecToStack /TIMEOUT=${ABANDONED_DRIVER_TIMEOUT} '"$PLUGINSDIR\mullvad-setup.exe" driver remove wintun-abandoned-device'
-	Pop $0
-	Pop $1
-
-	${If} $0 == ${NSEXEC_TIMEOUT}
-		mullvad_nsis::Log "RemoveAbandonedWintunAdapter() timed out!"
-		Goto RemoveAbandonedWintunAdapter_return_only
-	${ElseIf} $0 != ${MVSETUP_OK}
-		IntFmt $0 "0x%X" $0
-		StrCpy $R0 "Failed to remove network adapter: error $0"
-		mullvad_nsis::LogWithDetails $R0 $1
-		Goto RemoveAbandonedWintunAdapter_return_only
-	${EndIf}
-
-	mullvad_nsis::Log "RemoveAbandonedWintunAdapter() completed successfully"
-
-	Push 0
-	Pop $R0
-
-	RemoveAbandonedWintunAdapter_return_only:
-
-	Pop $1
-	Pop $0
-
-!macroend
-
-!define RemoveAbandonedWintunAdapter '!insertmacro "RemoveAbandonedWintunAdapter"'
-
-#
 # InstallService
 #
 # Register the service with Windows and start it
@@ -812,7 +773,6 @@ ManifestDPIAware true
 	${RemoveApiAddressCache}
 
 	${ExtractMullvadSetup}
-	${RemoveAbandonedWintunAdapter}
 	${RemoveAbandonedWireGuardNt}
 
 	${RemoveSplitTunnelDriver}

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -219,7 +219,11 @@ ManifestDPIAware true
 	Pop $1
 
 	${If} $0 == ${NSEXEC_TIMEOUT}
-		mullvad_nsis::Log "RemoveAbandonedWireGuardNt() timed out!"
+		StrCpy $R0 "RemoveAbandonedWireGuardNt() timed out!"
+		mullvad_nsis::LogWithDetails $R0 $1
+		# nsExec abandons the process on timeout rather than terminating it.
+		nsExec::Exec `"$SYSDIR\taskkill.exe" /f /t /im "mullvad-setup.exe"`
+		Pop $0
 		Goto RemoveAbandonedWireGuardNt_return_only
 	${ElseIf} $0 != ${MVSETUP_OK}
 		IntFmt $0 "0x%X" $0
@@ -773,7 +777,9 @@ ManifestDPIAware true
 	${RemoveApiAddressCache}
 
 	${ExtractMullvadSetup}
+
 	${RemoveAbandonedWireGuardNt}
+	# Ignoring errors ($R0 != 0) here
 
 	${RemoveSplitTunnelDriver}
 

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -52,6 +52,14 @@ ManifestDPIAware true
 !define MVSETUP_VERSION_NOT_OLDER 2
 !define MVSETUP_DAEMON_NOT_RUNNING 3
 
+# nsExec pushes this instead of an exit code when /TIMEOUT expires
+# after an idle period (of no stdout/stderr output).
+!define NSEXEC_TIMEOUT "timeout"
+
+# How long to wait for the removal of an abandoned driver or network adapter,
+# in milliseconds.
+!define ABANDONED_DRIVER_TIMEOUT 60000
+
 # Override electron-builder generated application settings key.
 # electron-builder uses a GUID here rather than the application name.
 !define INSTALL_REGISTRY_KEY "Software\${PRODUCT_NAME}"
@@ -206,11 +214,14 @@ ManifestDPIAware true
 
 	mullvad_nsis::Log "RemoveAbandonedWireGuardNt()"
 
-	nsExec::ExecToStack '"$PLUGINSDIR\mullvad-setup.exe" driver remove wg-nt-abandoned'
+	nsExec::ExecToStack /TIMEOUT=${ABANDONED_DRIVER_TIMEOUT} '"$PLUGINSDIR\mullvad-setup.exe" driver remove wg-nt-abandoned'
 	Pop $0
 	Pop $1
 
-	${If} $0 != ${MVSETUP_OK}
+	${If} $0 == ${NSEXEC_TIMEOUT}
+		mullvad_nsis::Log "RemoveAbandonedWireGuardNt() timed out!"
+		Goto RemoveAbandonedWireGuardNt_return_only
+	${ElseIf} $0 != ${MVSETUP_OK}
 		IntFmt $0 "0x%X" $0
 		StrCpy $R0 "Failed to remove legacy MullvadWireGuard driver: error $0"
 		mullvad_nsis::LogWithDetails $R0 $1
@@ -242,11 +253,14 @@ ManifestDPIAware true
 
 	mullvad_nsis::Log "RemoveAbandonedWintunAdapter()"
 
-	nsExec::ExecToStack '"$PLUGINSDIR\mullvad-setup.exe" driver remove wintun-abandoned-device'
+	nsExec::ExecToStack /TIMEOUT=${ABANDONED_DRIVER_TIMEOUT} '"$PLUGINSDIR\mullvad-setup.exe" driver remove wintun-abandoned-device'
 	Pop $0
 	Pop $1
 
-	${If} $0 != ${MVSETUP_OK}
+	${If} $0 == ${NSEXEC_TIMEOUT}
+		mullvad_nsis::Log "RemoveAbandonedWintunAdapter() timed out!"
+		Goto RemoveAbandonedWintunAdapter_return_only
+	${ElseIf} $0 != ${MVSETUP_OK}
 		IntFmt $0 "0x%X" $0
 		StrCpy $R0 "Failed to remove network adapter: error $0"
 		mullvad_nsis::LogWithDetails $R0 $1

--- a/mullvad-setup/src/driver_setup/device.rs
+++ b/mullvad-setup/src/driver_setup/device.rs
@@ -204,8 +204,10 @@ pub struct DeviceInfo<'a> {
 impl DeviceInfo<'_> {
     /// Uninstalls the device represented by this `DeviceInfo`. This calls [`DiUninstallDevice`].
     ///
+    /// Returns whether a reboot is needed to complete the removal.
+    ///
     /// [`DiUninstallDevice`]: https://learn.microsoft.com/en-us/windows/win32/api/newdev/nf-newdev-diuninstalldevice.
-    pub fn uninstall_device(self) -> io::Result<()> {
+    pub fn uninstall_device(self) -> io::Result<bool> {
         let mut needs_reboot: windows_sys::core::BOOL = 0;
         // SAFETY: `self.set.0` and `self.data` are valid and belong to the same enumeration.
         // `needs_reboot` is a writable BOOL.
@@ -223,7 +225,7 @@ impl DeviceInfo<'_> {
             return Err(io::Error::last_os_error());
         }
 
-        Ok(())
+        Ok(needs_reboot != FALSE)
     }
 
     /// Read the `NetCfgInstanceId` registry value from a device's driver key.

--- a/mullvad-setup/src/driver_setup/mod.rs
+++ b/mullvad-setup/src/driver_setup/mod.rs
@@ -51,9 +51,12 @@ pub fn remove_wintun_abandoned_device() -> Result<(), Error> {
         if let Ok(id) = device_info.get_device_net_cfg_instance_id()
             && id.eq_ignore_ascii_case(WINTUN_ABANDONED_GUID)
         {
-            device_info
+            let needs_reboot = device_info
                 .uninstall_device()
                 .map_err(Error::DeviceEnumeration)?;
+            if needs_reboot {
+                tracing::warn!("A reboot is needed to finish removing the Wintun adapter");
+            }
             return Ok(());
         }
     }
@@ -102,10 +105,18 @@ fn uninstall_devices_by_hardware_id(hardware_id: &str) -> Result<usize, Error> {
             if let Ok(ids) = device_info.get_hardware_ids()
                 && ids.iter().any(|id| id.eq_ignore_ascii_case(hardware_id))
             {
-                device_info
+                let needs_reboot = device_info
                     .uninstall_device()
                     .map_err(Error::DeviceEnumeration)?;
+
                 removed += 1;
+
+                // Avoid looping forever if we couldn't remove it right away.
+                if needs_reboot {
+                    tracing::warn!("A reboot is needed to finish uninstalling {hardware_id}");
+                    return Ok(removed);
+                }
+
                 continue 'outer;
             }
         }


### PR DESCRIPTION
I've removed `RemoveAbandonedWintunAdapter` since it's no longer necessary. It seemed to hang for some users:

    [13:04:x] RemoveAbandonedWintunAdapter()
    [13:37:x] RemoveAbandonedWintunAdapter() completed successfully

I've also added a (generous) timeout to the device cleanup. That will hopefully prevent extreme cases like this.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11063)
<!-- Reviewable:end -->
