### PR TITLE
Extend DNS cache flush timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Line wrap the file at 100 chars.                                              Th
 - Stop embedding absolute build machine PDB paths in the Rust Windows binaries + winfw.dll.
   Required for reproducible builds.
 - Add timeout to device cleanup tasks during installs.
+- Increase timeout on flushing DNS cache.
 
 ### Removed
 #### Windows

--- a/talpid-dns/src/windows/dnsapi.rs
+++ b/talpid-dns/src/windows/dnsapi.rs
@@ -7,7 +7,8 @@ use std::{
     time::{Duration, Instant},
 };
 
-static FLUSH_TIMEOUT: Duration = Duration::from_secs(5);
+const FLUSH_TIMEOUT: Duration = Duration::from_secs(10);
+const FLUSH_WARN_THRESHOLD: Duration = Duration::from_secs(4);
 static DNSAPI_HANDLE: OnceLock<DnsApi> = OnceLock::new();
 
 const MAX_CONCURRENT_FLUSHES: usize = 5;
@@ -65,7 +66,7 @@ impl DnsApi {
             // SAFETY: this function is trivially safe to call
             let result = if unsafe { (DnsFlushResolverCache)() } {
                 let elapsed = begin.elapsed();
-                if elapsed >= FLUSH_TIMEOUT {
+                if elapsed >= FLUSH_WARN_THRESHOLD {
                     log::warn!(
                         "Flushing system DNS cache took {} seconds",
                         elapsed.as_secs()

--- a/talpid-dns/src/windows/iphlpapi.rs
+++ b/talpid-dns/src/windows/iphlpapi.rs
@@ -84,9 +84,7 @@ impl DnsMonitorT for DnsMonitor {
         let Some(guid) = self.current_guid.take() else {
             return Ok(());
         };
-        set_interface_dns_servers_v4(&guid, &[])
-            .and(set_interface_dns_servers_v6(&guid, &[]))
-            .and(flush_dns_cache())
+        set_interface_dns_servers_v4(&guid, &[]).and(set_interface_dns_servers_v6(&guid, &[]))
     }
 
     fn reset_before_interface_removal(&mut self) -> Result<(), Self::Error> {

--- a/talpid-dns/src/windows/tcpip.rs
+++ b/talpid-dns/src/windows/tcpip.rs
@@ -55,11 +55,7 @@ impl DnsMonitorT for DnsMonitor {
 
     fn reset(&mut self) -> Result<(), Error> {
         if let Some(guid) = self.current_guid.take() {
-            let mut result = set_dns(&guid, &[]);
-            if self.should_flush {
-                result = result.and(flush_dns_cache());
-            }
-            return result;
+            return set_dns(&guid, &[]);
         }
         Ok(())
     }


### PR DESCRIPTION
Timeouts are currently hard failures. The PR mitigates this:

    [2026-07-28 00:03:06.574]  WARN talpid_dns::imp::dnsapi: Flushing system DNS cache took 6 seconds

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11065)
<!-- Reviewable:end -->
