### PR TITLE
Tweak ios.yml and ios-rust-ffi.yml workflows

### DIFF
--- a/.github/workflows/ios-rust-ffi.yml
+++ b/.github/workflows/ios-rust-ffi.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
     paths:
       - .github/workflows/ios-rust-ffi.yml
-      - clippy.toml
       - 'ci/cargo-ci.sh'
+      - clippy.toml
       - Cargo.lock
       - Cargo.toml
       - '**/*.rs'
@@ -26,10 +26,64 @@ defaults:
     shell: bash
 
 jobs:
+  plan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run: ${{ steps.result.outputs.run }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Get changed files
+        id: changed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          files=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files?per_page=100" \
+            --paginate \
+            --jq '.[].filename' | tr '\n' ' ')
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+
+      - name: Print changed files
+        run: |
+          echo 'Changed files:'
+          printf '%s\n' ${{ steps.changed.outputs.files }}
+
+      - name: Detect affected packages
+        id: affected
+        uses: robertrautenbach/rust-affected@a2b1ce76c640d9f9ef261a39221fd45a8fbf8227  # v4.0.3
+        with:
+          changed_files: ${{ steps.changed.outputs.files }}
+          force_triggers: |
+            .github/workflows/ios-rust-ffi.yml
+            ci/cargo-ci.sh
+            clippy.toml
+            Cargo.lock
+            Cargo.toml
+
+      - name: Decide whether to run
+        id: result
+        run: |
+          if [[ ${{ steps.affected.outputs.force_all }} == true ]] || \
+             grep -q "mullvad-ios" <<< '${{ steps.affected.outputs.changed_crates }}' || \
+             grep -q "mullvad-ios" <<< '${{ steps.affected.outputs.affected_binary_members }}' || \
+             grep -q "mullvad-api" <<< '${{ steps.affected.outputs.affected_binary_members }}'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # Linting shares this job with the build so that clippy runs against the target
   # directory the build just populated. The tests are a separate job: they run
   # against the host, so they cannot reuse anything built for the iOS target.
   build-ios:
+    needs: plan
+    if: needs.plan.outputs.run == 'true'
     runs-on: macos-latest
     env:
       TARGET: aarch64-apple-ios
@@ -64,6 +118,8 @@ jobs:
   # NOTE: Tests actually target macOS here. This is because we do not have an iOS runner
   #       handy, so this takes no --target.
   test-ios-crates:
+    needs: plan
+    if: needs.plan.outputs.run == 'true'
     runs-on: macos-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -48,17 +48,21 @@ jobs:
 
       - name: Setup project
         uses: ./.github/actions/ios/setup-project-toolchain
+        with:
+          ios_rust_target: aarch64-apple-ios
 
       - name: Build for ui tests
         run: |
-          set -o pipefail && env NSUnbufferedIO=YES xcodebuild \
+          set -o pipefail && \
+          env NSUnbufferedIO=YES \
+          xcodebuild CODE_SIGNING_ALLOWED=NO \
           -project MullvadVPN.xcodeproj \
           -scheme MullvadVPNUITests \
           -testPlan MullvadVPNUITestsAll \
           -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
           -disableAutomaticPackageResolution \
           -allowProvisioningUpdates \
-          -destination "platform=iOS Simulator,name=iPhone 17" \
+          -destination "generic/platform=iOS" \
           clean build-for-testing 2>&1 | xcbeautify
         working-directory: ios/
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -64,7 +64,7 @@ jobs:
 
   test:
     name: Unit tests
-    runs-on: macos-26-xlarge
+    runs-on: macos-26
     timeout-minutes: 30
     env:
       SOURCE_PACKAGES_PATH: .spm


### PR DESCRIPTION
Some small improvements:

- Execute build unit tests on same runner as UI test build
  Aligning them moves one job away from macos 26 xlarge, which frees it
  up for other jobs to use.

- Build for the `generic/platform=iOS` destination
  This makes sure it can be build for the physical device used in the
  end to end tests.

- Build ios-rust-ffi job when dependencies change
  Instead of running on every Rust-related change in the repository.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11067)
<!-- Reviewable:end -->
