### PR TITLE
Build, test and lint the iOS FFI crates in the same job

### DIFF
--- a/.github/workflows/ios-rust-ffi.yml
+++ b/.github/workflows/ios-rust-ffi.yml
@@ -26,11 +26,13 @@ defaults:
     shell: bash
 
 jobs:
+  # Only the device target is built. It differs from aarch64-apple-ios-sim just in
+  # target_abi and target_env, plus the simulator's wider target_feature baseline,
+  # and no crate in this repo branches on any of those.
   build-ios:
     runs-on: macos-latest
-    strategy:
-      matrix:
-        target: [aarch64-apple-ios, aarch64-apple-ios-sim]
+    env:
+      TARGET: aarch64-apple-ios
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -46,20 +48,19 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust
-        run: rustup target add ${{ matrix.target }}
+        run: rustup target add "$TARGET"
 
       - name: Build and test crates
         # NOTE: Tests actually target macOS here. This is because we do not have an iOS runner
         #       handy.
         run: |
-          time ci/cargo-ci.sh build --verbose --lib $PACKAGES --target ${{ matrix.target }}
+          time ci/cargo-ci.sh build --verbose --lib $PACKAGES --target "$TARGET"
           time ci/cargo-ci.sh test --verbose --lib $PACKAGES
 
   clippy-check-ios:
     runs-on: macos-latest
-    strategy:
-      matrix:
-        target: [aarch64-apple-ios, aarch64-apple-ios-sim]
+    env:
+      TARGET: aarch64-apple-ios
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -71,10 +72,10 @@ jobs:
 
       - name: Install Rust
         run: |
-          rustup target add ${{ matrix.target }}
+          rustup target add "$TARGET"
           rustup component add clippy
 
       - name: Clippy check
         run: |
-          time ci/cargo-ci.sh clippy --all-targets --no-default-features $PACKAGES --target ${{ matrix.target }}
-          time ci/cargo-ci.sh clippy --all-targets --all-features $PACKAGES --target ${{ matrix.target }}
+          time ci/cargo-ci.sh clippy --all-targets --no-default-features $PACKAGES --target "$TARGET"
+          time ci/cargo-ci.sh clippy --all-targets --all-features $PACKAGES --target "$TARGET"

--- a/.github/workflows/ios-rust-ffi.yml
+++ b/.github/workflows/ios-rust-ffi.yml
@@ -26,9 +26,9 @@ defaults:
     shell: bash
 
 jobs:
-  # Only the device target is built. It differs from aarch64-apple-ios-sim just in
-  # target_abi and target_env, plus the simulator's wider target_feature baseline,
-  # and no crate in this repo branches on any of those.
+  # Linting shares this job with the build so that clippy runs against the target
+  # directory the build just populated. The tests are a separate job: they run
+  # against the host, so they cannot reuse anything built for the iOS target.
   build-ios:
     runs-on: macos-latest
     env:
@@ -48,34 +48,36 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust
-        run: rustup target add "$TARGET"
-
-      - name: Build and test crates
-        # NOTE: Tests actually target macOS here. This is because we do not have an iOS runner
-        #       handy.
         run: |
-          time ci/cargo-ci.sh build --verbose --lib $PACKAGES --target "$TARGET"
-          time ci/cargo-ci.sh test --verbose --lib $PACKAGES
+          rustup target add "$TARGET"
+          rustup component add clippy
 
-  clippy-check-ios:
+      - name: Build crates
+        run: time ci/cargo-ci.sh build --verbose --lib $PACKAGES --target "$TARGET"
+
+      - name: Clippy check (no features)
+        run: time ci/cargo-ci.sh clippy --all-targets --no-default-features $PACKAGES --target "$TARGET"
+
+      - name: Clippy check (all features)
+        run: time ci/cargo-ci.sh clippy --all-targets --all-features $PACKAGES --target "$TARGET"
+
+  # NOTE: Tests actually target macOS here. This is because we do not have an iOS runner
+  #       handy, so this takes no --target.
+  test-ios-crates:
     runs-on: macos-latest
-    env:
-      TARGET: aarch64-apple-ios
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Checkout submodules
+        run: |
+          git config --global --add safe.directory '*'
+          git submodule update --init --depth=1 --recursive ios/wireguard-apple
 
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b  # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Rust
-        run: |
-          rustup target add "$TARGET"
-          rustup component add clippy
-
-      - name: Clippy check
-        run: |
-          time ci/cargo-ci.sh clippy --all-targets --no-default-features $PACKAGES --target "$TARGET"
-          time ci/cargo-ci.sh clippy --all-targets --all-features $PACKAGES --target "$TARGET"
+      - name: Test crates
+        run: time ci/cargo-ci.sh test --verbose --lib $PACKAGES

--- a/.github/workflows/ios-rust-ffi.yml
+++ b/.github/workflows/ios-rust-ffi.yml
@@ -18,6 +18,13 @@ concurrency:
 
 permissions: {}
 
+env:
+  PACKAGES: -p mullvad-ios -p mullvad-api
+
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build-ios:
     runs-on: macos-latest
@@ -42,12 +49,11 @@ jobs:
         run: rustup target add ${{ matrix.target }}
 
       - name: Build and test crates
-        shell: bash
         # NOTE: Tests actually target macOS here. This is because we do not have an iOS runner
         #       handy.
         run: |
-          time ci/cargo-ci.sh build --verbose --lib -p mullvad-ios -p mullvad-api --target ${{ matrix.target }}
-          time ci/cargo-ci.sh test --verbose --lib -p mullvad-ios -p mullvad-api
+          time ci/cargo-ci.sh build --verbose --lib $PACKAGES --target ${{ matrix.target }}
+          time ci/cargo-ci.sh test --verbose --lib $PACKAGES
 
   clippy-check-ios:
     runs-on: macos-latest
@@ -69,9 +75,6 @@ jobs:
           rustup component add clippy
 
       - name: Clippy check
-        shell: bash
         run: |
-          time ci/cargo-ci.sh clippy --all-targets --no-default-features -p mullvad-ios -p mullvad-api \
-            --target ${{ matrix.target }}
-          time ci/cargo-ci.sh clippy --all-targets --all-features -p mullvad-ios -p mullvad-api \
-            --target ${{ matrix.target }}
+          time ci/cargo-ci.sh clippy --all-targets --no-default-features $PACKAGES --target ${{ matrix.target }}
+          time ci/cargo-ci.sh clippy --all-targets --all-features $PACKAGES --target ${{ matrix.target }}


### PR DESCRIPTION
The `ios-rust-ffi.yml` job fires on *all* changes to any Rust file. And it launches four jobs into the most contested runner queue (macOS). This PR is an attempt at cutting down CI minutes for this workflow. Hopefully without losing any quality or test.

Folding the clippy job into the build job the number of jobs from four to two, and lets clippy run against the target directory the build just populated instead of starting from an empty one on a second runner. A failing build now also skips the lint rather than burning a slot to report it separately.

The test step never took a target, so the matrix ran it twice with identical arguments. It is now pinned to one leg. This is a cleanup we should do even if we decide to not merge the clippy job into the build job.

Concrete changes:
* Stop running `cargo test` twice with the exact same parameters.
* Run `cargo test` in a separate job, to get that failure reported separately
* Remove the `-sim` target completely. Only build and lint against the real iOS target
* Run the clippy lint run in the same job as the cargo build job, in order to make it go faster
* Extract some repeated constants to variables and global config to simplify

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11068)
<!-- Reviewable:end -->
