### PR TITLE
Handle key rotation and a locked device in GotaTun

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		01335D552F89C645008AB806 /* MullvadRustRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A992DA1D2C24709F00DE7CE5 /* MullvadRustRuntime.framework */; };
 		01335D602F89D000008AB806 /* GotaTunProviderProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D5F2F89D000008AB806 /* GotaTunProviderProxy.swift */; };
 		01335D612F89D400008AB806 /* ObservedStateBroadcaster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D622F89D400008AB806 /* ObservedStateBroadcaster.swift */; };
+		01335D642F89E100008AB806 /* TestClock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D632F89E100008AB806 /* TestClock.swift */; };
 		01335D662F89E200008AB806 /* ObservedState+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D652F89E200008AB806 /* ObservedState+Testing.swift */; };
 		01335D682F89E400008AB806 /* GotaTunPathObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D672F89E400008AB806 /* GotaTunPathObserver.swift */; };
 		014E8C2A2F28B09700837D0A /* MullvadLogging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58D223F3294C8FF00029F5F8 /* MullvadLogging.framework */; };
@@ -1826,6 +1827,7 @@
 		01335D4E2F89C396008AB806 /* RustGotaTunAdapterFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustGotaTunAdapterFactory.swift; sourceTree = "<group>"; };
 		01335D5F2F89D000008AB806 /* GotaTunProviderProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunProviderProxy.swift; sourceTree = "<group>"; };
 		01335D622F89D400008AB806 /* ObservedStateBroadcaster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservedStateBroadcaster.swift; sourceTree = "<group>"; };
+		01335D632F89E100008AB806 /* TestClock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestClock.swift; sourceTree = "<group>"; };
 		01335D652F89E200008AB806 /* ObservedState+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ObservedState+Testing.swift"; sourceTree = "<group>"; };
 		01335D672F89E400008AB806 /* GotaTunPathObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunPathObserver.swift; sourceTree = "<group>"; };
 		014E8C2F2F294FB000837D0A /* relays-test-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "relays-test-data.json"; sourceTree = "<group>"; };
@@ -4478,6 +4480,7 @@
 				7AD0AA202AD6CB0000119E10 /* APIRequestProxyStub.swift */,
 				58F7753C2AB8473200425B47 /* BlockedStateErrorMapperStub.swift */,
 				581F23AC2A8CF92100788AB6 /* DefaultPathObserverFake.swift */,
+				01335D632F89E100008AB806 /* TestClock.swift */,
 				01335D652F89E200008AB806 /* ObservedState+Testing.swift */,
 				F0C4C9BF2C495E7500A79006 /* EphemeralPeerExchangeActorStub.swift */,
 				F0FBD98E2C4A60CC00EE5323 /* KeyExchangingResultStub.swift */,
@@ -6775,6 +6778,7 @@
 				58FE25EC2AA77639003D1918 /* TunnelMonitorStub.swift in Sources */,
 				58FE25EE2AA7764E003D1918 /* TunnelAdapterDummy.swift in Sources */,
 				581F23AD2A8CF92100788AB6 /* DefaultPathObserverFake.swift in Sources */,
+				01335D642F89E100008AB806 /* TestClock.swift in Sources */,
 				01335D662F89E200008AB806 /* ObservedState+Testing.swift in Sources */,
 				F07751582C50F149006E6A12 /* MultiHopEphemeralPeerExchangerTests.swift in Sources */,
 				5838321B2AC1B18400EA2071 /* PacketTunnelActor+Mocks.swift in Sources */,

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		0107F42D2F5F62950012451B /* MullvadSettings.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58B2FDD32AA71D2A003EB5C6 /* MullvadSettings.framework */; };
 		0107F4322F5F62C80012451B /* MullvadSettings.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58B2FDD32AA71D2A003EB5C6 /* MullvadSettings.framework */; };
 		0107F4362F5F62CE0012451B /* MullvadRustRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A992DA1D2C24709F00DE7CE5 /* MullvadRustRuntime.framework */; };
+		01335D422F89B711008AB806 /* GotaTunActorTimings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D402F89B711008AB806 /* GotaTunActorTimings.swift */; };
 		01335D432F89B711008AB806 /* GotaTunAdapterProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D3F2F89B711008AB806 /* GotaTunAdapterProtocol.swift */; };
 		01335D442F89B711008AB806 /* GotaTunActor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D3E2F89B711008AB806 /* GotaTunActor.swift */; };
 		01335D4A2F89B88E008AB806 /* GotaTunAdapterStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01335D482F89B88E008AB806 /* GotaTunAdapterStub.swift */; };
@@ -52,6 +53,7 @@
 		01C981E92F43C3410002D284 /* TunnelStateAccessibilityAnnouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C981E62F43C3410002D284 /* TunnelStateAccessibilityAnnouncer.swift */; };
 		01C981EA2F43C3410002D284 /* BlockedStateReason+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C981E52F43C3410002D284 /* BlockedStateReason+Localization.swift */; };
 		01C981EB2F45D5C20002D284 /* TunnelControlPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C981EA2F45D5C20002D284 /* TunnelControlPageTests.swift */; };
+		01CBA33C302C9E4600D41B65 /* GotaTunKeyPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CBA33B302C9E4600D41B65 /* GotaTunKeyPolicy.swift */; };
 		01CBA340302CA3C800D41B65 /* TunnelProviderDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CBA33F302CA3C800D41B65 /* TunnelProviderDelegate.swift */; };
 		01D13C212F11130500EC63DE /* RustLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D13C202F11130500EC63DE /* RustLogging.swift */; };
 		01FFF9582F0469FC00BDAF45 /* IPVersionSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FFF9562F0469FC00BDAF45 /* IPVersionSettings.swift */; };
@@ -1821,6 +1823,7 @@
 		0107F4212F5B97F30012451B /* RelayListCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayListCacheTests.swift; sourceTree = "<group>"; };
 		01335D3E2F89B711008AB806 /* GotaTunActor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunActor.swift; sourceTree = "<group>"; };
 		01335D3F2F89B711008AB806 /* GotaTunAdapterProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunAdapterProtocol.swift; sourceTree = "<group>"; };
+		01335D402F89B711008AB806 /* GotaTunActorTimings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunActorTimings.swift; sourceTree = "<group>"; };
 		01335D482F89B88E008AB806 /* GotaTunAdapterStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunAdapterStub.swift; sourceTree = "<group>"; };
 		01335D4B2F89B8F8008AB806 /* GotaTunActorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunActorTests.swift; sourceTree = "<group>"; };
 		01335D4D2F89C396008AB806 /* RustGotaTunAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustGotaTunAdapter.swift; sourceTree = "<group>"; };
@@ -1841,6 +1844,7 @@
 		01C981E52F43C3410002D284 /* BlockedStateReason+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlockedStateReason+Localization.swift"; sourceTree = "<group>"; };
 		01C981E62F43C3410002D284 /* TunnelStateAccessibilityAnnouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelStateAccessibilityAnnouncer.swift; sourceTree = "<group>"; };
 		01C981EA2F45D5C20002D284 /* TunnelControlPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelControlPageTests.swift; sourceTree = "<group>"; };
+		01CBA33B302C9E4600D41B65 /* GotaTunKeyPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunKeyPolicy.swift; sourceTree = "<group>"; };
 		01CBA33F302CA3C800D41B65 /* TunnelProviderDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelProviderDelegate.swift; sourceTree = "<group>"; };
 		01D13C202F11130500EC63DE /* RustLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustLogging.swift; sourceTree = "<group>"; };
 		01FFF9562F0469FC00BDAF45 /* IPVersionSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPVersionSettings.swift; sourceTree = "<group>"; };
@@ -3083,9 +3087,11 @@
 		01335D412F89B711008AB806 /* GotaTun */ = {
 			isa = PBXGroup;
 			children = (
+				01CBA33B302C9E4600D41B65 /* GotaTunKeyPolicy.swift */,
 				01335D3E2F89B711008AB806 /* GotaTunActor.swift */,
 				01335D3F2F89B711008AB806 /* GotaTunAdapterProtocol.swift */,
 				01335D672F89E400008AB806 /* GotaTunPathObserver.swift */,
+				01335D402F89B711008AB806 /* GotaTunActorTimings.swift */,
 			);
 			path = GotaTun;
 			sourceTree = "<group>";
@@ -6726,11 +6732,13 @@
 				44DF8AC42BF20BD200869CA4 /* PacketTunnelActor+PostQuantum.swift in Sources */,
 				583832252AC318A100EA2071 /* PacketTunnelActor+ConnectionMonitoring.swift in Sources */,
 				F05919752C45194B00C301F3 /* EphemeralPeerKey.swift in Sources */,
+				01335D422F89B711008AB806 /* GotaTunActorTimings.swift in Sources */,
 				01335D432F89B711008AB806 /* GotaTunAdapterProtocol.swift in Sources */,
 				01335D682F89E400008AB806 /* GotaTunPathObserver.swift in Sources */,
 				01335D442F89B711008AB806 /* GotaTunActor.swift in Sources */,
 				58C7A4552A863FB90060C66F /* TunnelMonitor.swift in Sources */,
 				58C7A4512A863FB50060C66F /* PingerProtocol.swift in Sources */,
+				01CBA33C302C9E4600D41B65 /* GotaTunKeyPolicy.swift in Sources */,
 				583832292AC3DF1300EA2071 /* PacketTunnelActorCommand.swift in Sources */,
 				58CF95A22AD6F35800B59F5D /* ObservedState.swift in Sources */,
 				449275422C3570CA000526DE /* ICMP.swift in Sources */,

--- a/ios/MullvadVPNTests/MullvadVPN/PacketTunnelCore/PacketTunnelActorReducerTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/PacketTunnelCore/PacketTunnelActorReducerTests.swift
@@ -27,7 +27,7 @@ final class PacketTunnelActorReducerTests: XCTestCase {
         )
     }
 
-    func makeConnectionData(keyPolicy: State.KeyPolicy = .useCurrent) -> State.ConnectionData {
+    func makeConnectionData(keyPolicy: State.KeyRotationPolicy = .useCurrent) -> State.ConnectionData {
         State.ConnectionData(
             selectedRelays: selectedRelays,
             relayConstraints: RelayConstraints(),
@@ -269,7 +269,8 @@ final class PacketTunnelActorReducerTests: XCTestCase {
 
     func testHandleNotifyKeyRotatedWhileUsingPriorKey() {
         // Given
-        let keyPolicy = State.KeyPolicy.usePrior(WireGuard.PrivateKey(), AutoCancellingTask(Task(operation: {})))
+        let keyPolicy = State.KeyRotationPolicy.usePrior(
+            WireGuard.PrivateKey(), AutoCancellingTask(Task(operation: {})))
         var state = State.connected(makeConnectionData(keyPolicy: keyPolicy))
         let date = Date()
 
@@ -295,14 +296,15 @@ final class PacketTunnelActorReducerTests: XCTestCase {
 
     func testHandleSwitchKeyFromUsePrior() {
         // Given
-        let keyPolicy = State.KeyPolicy.usePrior(WireGuard.PrivateKey(), AutoCancellingTask(Task(operation: {})))
+        let keyPolicy = State.KeyRotationPolicy.usePrior(
+            WireGuard.PrivateKey(), AutoCancellingTask(Task(operation: {})))
         var state = State.connected(makeConnectionData(keyPolicy: keyPolicy))
 
         // When
         let effects = PacketTunnelActor.Reducer.reduce(&state, .switchKey)
 
         // then
-        XCTAssertEqual(state.keyPolicy, State.KeyPolicy.useCurrent)
+        XCTAssertEqual(state.keyPolicy, State.KeyRotationPolicy.useCurrent)
         XCTAssertEqual(
             effects,
             [

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor.swift
@@ -328,7 +328,7 @@ extension PacketTunnelActor {
         settings: Settings,
         reason: ActorReconnectReason
     ) throws -> State.ConnectionData? {
-        var keyPolicy: State.KeyPolicy = .useCurrent
+        var keyPolicy: State.KeyRotationPolicy = .useCurrent
         var networkReachability = defaultPathObserver.currentPathStatus.networkReachability
         var lastKeyRotation: Date?
 

--- a/ios/PacketTunnelCore/Actor/State+Extensions.swift
+++ b/ios/PacketTunnelCore/Actor/State+Extensions.swift
@@ -117,7 +117,7 @@ extension State {
         self.connectionData ?? self.blockedData
     }
 
-    var keyPolicy: KeyPolicy? {
+    var keyPolicy: KeyRotationPolicy? {
         associatedData?.keyPolicy
     }
 
@@ -163,12 +163,12 @@ extension State {
 
     /// Apply a mutating function to the state's key policy
     /// - parameter modifier: A function that takes an `inout KeyPolicy` and modifies it
-    mutating func mutateKeyPolicy(_ modifier: (inout KeyPolicy) -> Void) {
+    mutating func mutateKeyPolicy(_ modifier: (inout KeyRotationPolicy) -> Void) {
         self.mutateAssociatedData { modifier(&$0.keyPolicy) }
     }
 }
 
-extension State.KeyPolicy {
+extension State.KeyRotationPolicy {
     func logFormat() -> String {
         switch self {
         case .useCurrent:
@@ -179,8 +179,8 @@ extension State.KeyPolicy {
     }
 }
 
-extension State.KeyPolicy: Equatable {
-    static func == (lhs: State.KeyPolicy, rhs: State.KeyPolicy) -> Bool {
+extension State.KeyRotationPolicy: Equatable {
+    static func == (lhs: State.KeyRotationPolicy, rhs: State.KeyRotationPolicy) -> Bool {
         switch (lhs, rhs) {
         case (.useCurrent, .useCurrent): true
         case let (.usePrior(priorA, _), .usePrior(priorB, _)): priorA == priorB

--- a/ios/PacketTunnelCore/Actor/State.swift
+++ b/ios/PacketTunnelCore/Actor/State.swift
@@ -95,14 +95,14 @@ public enum NetworkReachability: Equatable, Codable, Sendable {
 
 protocol StateAssociatedData {
     var currentKey: WireGuard.PrivateKey? { get set }
-    var keyPolicy: State.KeyPolicy { get set }
+    var keyPolicy: State.KeyRotationPolicy { get set }
     var networkReachability: NetworkReachability { get set }
     var lastKeyRotation: Date? { get set }
 }
 
 extension State {
     /// Policy describing what WG key to use for tunnel communication.
-    enum KeyPolicy: Sendable {
+    enum KeyRotationPolicy: Sendable {
         /// Use current key stored in device data.
         case useCurrent
 
@@ -124,7 +124,7 @@ extension State {
         public var currentKey: WireGuard.PrivateKey?
 
         /// Policy describing the current key that should be used by the tunnel.
-        public var keyPolicy: KeyPolicy
+        public var keyPolicy: KeyRotationPolicy
 
         /// Whether network connectivity outside of tunnel is available.
         public var networkReachability: NetworkReachability
@@ -173,7 +173,7 @@ extension State {
         public var currentKey: WireGuard.PrivateKey?
 
         /// Policy describing the current key that should be used by the tunnel.
-        public var keyPolicy: KeyPolicy
+        public var keyPolicy: KeyRotationPolicy
 
         /// Whether network connectivity outside of tunnel is available.
         public var networkReachability: NetworkReachability

--- a/ios/PacketTunnelCore/GotaTun/GotaTunActor.swift
+++ b/ios/PacketTunnelCore/GotaTun/GotaTunActor.swift
@@ -1,10 +1,12 @@
+// This Source Code Form is subject to the terms of the GPLv3 License.
+// You can obtain a copy of the license at https://www.gnu.org/licenses/gpl-3.0.en.html.
 //
-//  GotaTunActor.swift
-//  PacketTunnelCore
+// This file incorporates work covered by the following copyright and
+// permission notice:
 //
-//  Created by Emīls on 2026-08-13.
-//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//   Copyright (c) Mullvad VPN AB. All rights reserved.
 //
+// SPDX-License-Identifier: GPL-3.0-only
 
 import Foundation
 import MullvadLogging

--- a/ios/PacketTunnelCore/GotaTun/GotaTunActor.swift
+++ b/ios/PacketTunnelCore/GotaTun/GotaTunActor.swift
@@ -77,7 +77,8 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
     /// Incremented whenever the current adapter is replaced or stopped. Events tagged with an
     /// older generation come from an adapter no longer in use and are dropped.
     private var adapterGeneration: UInt64 = 0
-    private var keySwitchTask: AutoCancellingTask?
+    private var recoveryTask: Task<Void, Never>?
+    private var keySwitchTask: Task<Void, Never>?
     private var keyPolicy = GotaTunKeyPolicy()
 
     // MARK: - Event channel
@@ -290,7 +291,8 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
             return
         default:
             stopCurrentAdapter()
-            keySwitchTask = nil
+            cancelRecoveryTask()
+            cancelKeySwitchTask()
             keyPolicy.endRotation()
             await defaultPathObserver.stop()
             observedState = .disconnected
@@ -343,6 +345,7 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
                 return
             }
             logger.debug("Reconnecting from error state")
+            cancelRecoveryTask()
             stopCurrentAdapter()
             await startConnection(nextRelays: nextRelays)
         case .connecting, .connected, .reconnecting:
@@ -384,6 +387,7 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
                 blocked.reason.recoverableError()
             else { return }
             logger.debug("Network reachable, restoring connectivity from \(blocked.reason)")
+            cancelRecoveryTask()
             await startConnection(nextRelays: .random)
 
         default:
@@ -421,6 +425,9 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
                 ))
             logger.debug("Entering error state: \(reason)")
         }
+
+        cancelRecoveryTask()
+        makeRecoveryTaskIfNeeded(reason: reason)
     }
 
     // MARK: - Key rotation
@@ -667,6 +674,31 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
             isDaitaEnabled: config.isDaitaEnabled,
             obfuscationMethod: selectedRelays.obfuscation,
         )
+    }
+
+    // MARK: - Recovery
+
+    private func makeRecoveryTaskIfNeeded(reason: BlockedStateReason) {
+        guard reason.shouldRestartAutomatically else { return }
+
+        recoveryTask?.cancel()
+        recoveryTask = Task { [weak self, timings, clock] in
+            while true {
+                try? await clock.sleep(for: timings.bootRecoveryPeriodicity)
+                guard !Task.isCancelled else { return }
+                self?.eventContinuation.yield(.reconnect(.random, .userInitiated))
+            }
+        }
+    }
+
+    private func cancelRecoveryTask() {
+        recoveryTask?.cancel()
+        recoveryTask = nil
+    }
+
+    private func cancelKeySwitchTask() {
+        keySwitchTask?.cancel()
+        keySwitchTask = nil
     }
 
     // MARK: - Helpers

--- a/ios/PacketTunnelCore/GotaTun/GotaTunActor.swift
+++ b/ios/PacketTunnelCore/GotaTun/GotaTunActor.swift
@@ -23,6 +23,8 @@ private enum GotaTunEvent: Sendable {
     case reconnect(NextRelays, ActorReconnectReason)
     case networkReachability(NWPath.Status)
     case setErrorState(BlockedStateReason)
+    case notifyKeyRotation(Date?)
+    case switchKey
     case sleep
     case wake
     #if NEVER_IN_PRODUCTION
@@ -46,6 +48,8 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
 
     // MARK: - Dependencies
 
+    private let timings: GotaTunActorTimings
+    private let clock: any Clock<Duration>
     private let providerDelegate: TunnelProviderDelegate
     private let settingsReader: SettingsReaderProtocol
     private let relaySelector: RelaySelectorProtocol
@@ -73,6 +77,8 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
     /// Incremented whenever the current adapter is replaced or stopped. Events tagged with an
     /// older generation come from an adapter no longer in use and are dropped.
     private var adapterGeneration: UInt64 = 0
+    private var keySwitchTask: AutoCancellingTask?
+    private var keyPolicy = GotaTunKeyPolicy()
 
     // MARK: - Event channel
 
@@ -108,6 +114,8 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
     // MARK: - Init
 
     public init(
+        timings: GotaTunActorTimings = GotaTunActorTimings(),
+        clock: any Clock<Duration> = ContinuousClock(),
         providerDelegate: sending TunnelProviderDelegate,
         settingsReader: SettingsReaderProtocol,
         relaySelector: RelaySelectorProtocol,
@@ -115,6 +123,8 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
         blockedStateErrorMapper: BlockedStateErrorMapperProtocol,
         adapterFactory: GotaTunAdapterFactory
     ) {
+        self.timings = timings
+        self.clock = clock
         self.providerDelegate = providerDelegate
         self.settingsReader = settingsReader
         self.relaySelector = relaySelector
@@ -128,6 +138,8 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
     }
 
     deinit {
+        recoveryTask?.cancel()
+        keySwitchTask?.cancel()
         Task { [defaultPathObserver] in await defaultPathObserver.stop() }
         eventContinuation.finish()
     }
@@ -200,8 +212,9 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
         eventContinuation.yield(.reconnect(nextRelays, reconnectReason))
     }
 
-    // TODO: implement key rotation handling
-    nonisolated public func notifyKeyRotation(date: Date?) {}
+    nonisolated public func notifyKeyRotation(date: Date?) {
+        eventContinuation.yield(.notifyKeyRotation(date))
+    }
 
     nonisolated public func setErrorState(reason: BlockedStateReason) {
         eventContinuation.yield(.setErrorState(reason))
@@ -237,6 +250,10 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
             await handleNetworkReachability(pathStatus)
         case let .setErrorState(reason):
             handleSetErrorState(reason)
+        case let .notifyKeyRotation(date):
+            handleNotifyKeyRotation(date)
+        case .switchKey:
+            await handleSwitchKey()
         case .sleep:
             currentAdapter?.suspendTunnel()
         case .wake:
@@ -273,6 +290,8 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
             return
         default:
             stopCurrentAdapter()
+            keySwitchTask = nil
+            keyPolicy.endRotation()
             await defaultPathObserver.stop()
             observedState = .disconnected
             logger.debug("Stopped, entering disconnected state")
@@ -393,6 +412,8 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
 
         default:
             stopCurrentAdapter()
+            keyPolicy.endRotation()
+            cancelKeySwitchTask()
             observedState = .error(
                 ObservedBlockedState(
                     reason: reason,
@@ -400,6 +421,36 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
                 ))
             logger.debug("Entering error state: \(reason)")
         }
+    }
+
+    // MARK: - Key rotation
+
+    private func handleNotifyKeyRotation(_ date: Date?) {
+        guard case .connected = observedState else { return }
+
+        keyPolicy.beginRotation()
+
+        // Publishing the rotation date is what tells the app to reload device state from the keychain.
+        observedState.mutateConnectionState { $0.lastKeyRotation = date }
+
+        logger.debug(
+            "Key rotation notified, caching prior key and scheduling switch in \(timings.wgKeyPropagationDelay)")
+
+        keySwitchTask = Task { [weak self, timings, clock] in
+            try? await clock.sleep(for: timings.wgKeyPropagationDelay)
+            guard !Task.isCancelled else { return }
+            self?.eventContinuation.yield(.switchKey)
+        }
+    }
+
+    private func handleSwitchKey() async {
+        keyPolicy.endRotation()
+        cancelKeySwitchTask()
+
+        guard observedState.connectionState != nil else { return }
+
+        logger.debug("Key propagation delay elapsed, reconnecting with new key")
+        await restartConnection(nextRelays: .random)
     }
 
     // MARK: - Connection management
@@ -464,10 +515,12 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
             return
         }
 
+        let privateKey = keyPolicy.connectionKey(settingsKey: settings.privateKey)
+
         let config = Self.makeGotaTunConfig(
             settings: settings,
             selectedRelays: selectedRelays,
-            privateKey: settings.privateKey,
+            privateKey: privateKey,
             fd: fd,
             ipv4Address: ipv4Address,
             ipv6Address: ipv6Address,
@@ -480,7 +533,7 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
             relayConstraints: settings.tunnelSettings.relayConstraints,
             networkReachability: currentReachability,
             connectionAttemptCount: attemptCount,
-            lastKeyRotation: nil
+            lastKeyRotation: currentLastKeyRotation
         )
 
         observedState = isReconnect ? .reconnecting(connectionState) : .connecting(connectionState)
@@ -630,6 +683,10 @@ public actor GotaTunActor: PacketTunnelActorProtocol {
         default:
             return false
         }
+    }
+
+    private var currentLastKeyRotation: Date? {
+        observedState.connectionState?.lastKeyRotation
     }
 
     private static func computeEstablishTimeout(attemptCount: UInt) -> UInt32 {

--- a/ios/PacketTunnelCore/GotaTun/GotaTunActorTimings.swift
+++ b/ios/PacketTunnelCore/GotaTun/GotaTunActorTimings.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the GPLv3 License.
+// You can obtain a copy of the license at https://www.gnu.org/licenses/gpl-3.0.en.html.
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright (c) Mullvad VPN AB. All rights reserved.
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+import Foundation
+
+/// Timing configuration for the GotaTun actor.
+public struct GotaTunActorTimings: Sendable {
+    /// How long to wait after a key rotation before switching to the new key.
+    public let wgKeyPropagationDelay: Duration
+
+    public init(
+        wgKeyPropagationDelay: Duration = .seconds(120)
+    ) {
+        self.wgKeyPropagationDelay = wgKeyPropagationDelay
+    }
+}

--- a/ios/PacketTunnelCore/GotaTun/GotaTunActorTimings.swift
+++ b/ios/PacketTunnelCore/GotaTun/GotaTunActorTimings.swift
@@ -12,12 +12,17 @@ import Foundation
 
 /// Timing configuration for the GotaTun actor.
 public struct GotaTunActorTimings: Sendable {
+    /// How often the recovery task retries when in a recoverable error state.
+    public let bootRecoveryPeriodicity: Duration
+
     /// How long to wait after a key rotation before switching to the new key.
     public let wgKeyPropagationDelay: Duration
 
     public init(
+        bootRecoveryPeriodicity: Duration = .seconds(5),
         wgKeyPropagationDelay: Duration = .seconds(120)
     ) {
+        self.bootRecoveryPeriodicity = bootRecoveryPeriodicity
         self.wgKeyPropagationDelay = wgKeyPropagationDelay
     }
 }

--- a/ios/PacketTunnelCore/GotaTun/GotaTunKeyPolicy.swift
+++ b/ios/PacketTunnelCore/GotaTun/GotaTunKeyPolicy.swift
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the GPLv3 License.
+// You can obtain a copy of the license at https://www.gnu.org/licenses/gpl-3.0.en.html.
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright (c) Mullvad VPN AB. All rights reserved.
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+import Foundation
+import MullvadTypes
+
+/// Determines which WireGuard private key a connection should use across key
+/// rotation.
+///
+/// When a new key is uploaded to the API, it can take minutes before it
+/// propagates to all relays. Until then, the old key should be used.
+struct GotaTunKeyPolicy: Sendable {
+    /// The key the current adapter was configured with.
+    private var activeKey: WireGuard.PrivateKey?
+    /// The pre-rotation key, kept in use until the new one has propagated to the relay.
+    private var priorKey: WireGuard.PrivateKey?
+
+    /// Returns the key a new connection should use, recording it as active: the pre-rotation
+    /// key while it is still propagating, otherwise `settingsKey`.
+    mutating func connectionKey(settingsKey: WireGuard.PrivateKey) -> WireGuard.PrivateKey {
+        let key = priorKey ?? settingsKey
+        activeKey = key
+        return key
+    }
+
+    /// Marks the device key as rotated, keeping the currently connected key in use
+    /// until propagation completes.
+    mutating func beginRotation() {
+        priorKey = activeKey
+    }
+
+    /// Ends the propagation window; subsequent connections use the settings key.
+    mutating func endRotation() {
+        priorKey = nil
+    }
+}

--- a/ios/PacketTunnelCoreTests/GotaTunActorTests.swift
+++ b/ios/PacketTunnelCoreTests/GotaTunActorTests.swift
@@ -767,6 +767,138 @@ final class GotaTunActorTests: XCTestCase {
         XCTAssertEqual(afterRotation.connectionState?.lastKeyRotation, rotationDate)
     }
 
+    // MARK: - Cascading errors
+
+    func testCascadingErrorsWithRecovery() async throws {
+        // Settings unreadable for the first two attempts (e.g. device locked at boot), then readable.
+        // Should retry automatically via the boot recovery timer, with no adapter created until settings
+        // are actually readable.
+        var readAttempts = 0
+        let settingsReader = SettingsReaderStub {
+            readAttempts += 1
+            guard readAttempts > 2 else { throw POSIXError(.EPERM) }
+            return Settings(
+                privateKey: WireGuard.PrivateKey(),
+                interfaceAddresses: [
+                    IPAddressRange(from: "127.0.0.1/32")!,
+                    IPAddressRange(from: "fc00::1/128")!,
+                ],
+                tunnelSettings: LatestTunnelSettings()
+            )
+        }
+        let errorMapper = BlockedStateErrorMapperStub { _ in .deviceLocked }
+        let factory = GotaTunAdapterFactoryStub(outcome: .connected())
+        let clock = TestClock()
+        let timings = GotaTunActorTimings()
+        let actor = makeActor(
+            adapterFactory: factory,
+            settingsReader: settingsReader,
+            blockedStateErrorMapper: errorMapper,
+            clock: clock,
+            timings: timings
+        )
+
+        await waitFor(
+            actor, until: { $0.blockedReason == .deviceLocked }, while: { await actor.start(options: launchOptions) })
+        await actor.drainEvents()
+        XCTAssertEqual(readAttempts, 1)
+
+        await clock.waitForSleepers()
+        await clock.advance(by: timings.bootRecoveryPeriodicity)
+        await actor.drainEvents()
+        XCTAssertEqual(readAttempts, 2)
+        XCTAssertEqual(factory.adaptersCreated.count, 0, "No adapter while settings are unreadable")
+
+        await clock.waitForSleepers()
+        await waitFor(
+            actor, until: { $0.isConnected },
+            while: {
+                Task { await clock.advance(by: timings.bootRecoveryPeriodicity) }
+            })
+
+        XCTAssertEqual(readAttempts, 3, "Should have retried settings read until it succeeded")
+        XCTAssertEqual(factory.adaptersCreated.count, 1, "Adapter should only be created once settings are readable")
+    }
+
+    func testNonAutoRestartableErrorDoesNotRetry() async throws {
+        var readAttempts = 0
+        let settingsReader = SettingsReaderStub {
+            readAttempts += 1
+            throw POSIXError(.EPERM)
+        }
+        let errorMapper = BlockedStateErrorMapperStub { _ in .readSettings }
+        let factory = GotaTunAdapterFactoryStub(outcome: .connected())
+        let clock = TestClock()
+        let timings = GotaTunActorTimings()
+        let actor = makeActor(
+            adapterFactory: factory,
+            settingsReader: settingsReader,
+            blockedStateErrorMapper: errorMapper,
+            clock: clock,
+            timings: timings
+        )
+
+        await waitFor(
+            actor, until: { $0.blockedReason == .readSettings }, while: { await actor.start(options: launchOptions) })
+
+        await actor.drainEvents()
+        XCTAssertEqual(clock.sleeperCount, 0, "No recovery timer should be armed")
+
+        // Span many recovery periods instantly; nothing should be scheduled to act on them.
+        await clock.advance(by: timings.bootRecoveryPeriodicity * 20)
+        await actor.drainEvents()
+
+        XCTAssertEqual(readAttempts, 1, "readSettings is not auto-restartable and must not be retried")
+        XCTAssertEqual(factory.adaptersCreated.count, 0)
+    }
+
+    func testRecoveryStopsWhenReasonBecomesNonRestartable() async throws {
+        var readAttempts = 0
+        let settingsReader = SettingsReaderStub {
+            readAttempts += 1
+            throw POSIXError(.EPERM)
+        }
+        let errorMapper = BlockedStateErrorMapperStub { _ in .deviceLocked }
+        let factory = GotaTunAdapterFactoryStub(outcome: .connected())
+        let clock = TestClock()
+        let timings = GotaTunActorTimings()
+        let actor = makeActor(
+            adapterFactory: factory,
+            settingsReader: settingsReader,
+            blockedStateErrorMapper: errorMapper,
+            clock: clock,
+            timings: timings
+        )
+
+        await waitFor(
+            actor, until: { $0.blockedReason == .deviceLocked }, while: { await actor.start(options: launchOptions) })
+        await actor.drainEvents()
+        XCTAssertEqual(readAttempts, 1)
+
+        // Each period wakes the recovery timer exactly once. The timer is replaced on every
+        // cycle, so wait for the new one to arm before advancing again.
+        for expectedAttempts in 2...4 {
+            await clock.waitForSleepers()
+            await clock.advance(by: timings.bootRecoveryPeriodicity)
+            await actor.drainEvents()
+            XCTAssertEqual(readAttempts, expectedAttempts, "deviceLocked should be retried once per recovery period")
+        }
+
+        await waitFor(
+            actor, until: { $0.blockedReason == .deviceRevoked },
+            while: {
+                actor.setErrorState(reason: .deviceRevoked)
+            })
+
+        await actor.drainEvents()
+        XCTAssertEqual(clock.sleeperCount, 0, "Recovery timer must be cancelled")
+
+        await clock.advance(by: timings.bootRecoveryPeriodicity * 20)
+        await actor.drainEvents()
+
+        XCTAssertEqual(readAttempts, 4, "Recovery must stop once the reason is not restartable")
+    }
+
     // MARK: - Stop during connection
 
     func testStopDuringConnecting() async throws {

--- a/ios/PacketTunnelCoreTests/GotaTunActorTests.swift
+++ b/ios/PacketTunnelCoreTests/GotaTunActorTests.swift
@@ -26,9 +26,13 @@ final class GotaTunActorTests: XCTestCase {
         settingsReader: SettingsReaderProtocol = SettingsReaderStub.staticConfiguration(),
         relaySelector: RelaySelectorProtocol = RelaySelectorStub.nonFallible(),
         defaultPathObserver: GotaTunPathObserverFake = GotaTunPathObserverFake(),
-        blockedStateErrorMapper: BlockedStateErrorMapperProtocol = BlockedStateErrorMapperStub()
+        blockedStateErrorMapper: BlockedStateErrorMapperProtocol = BlockedStateErrorMapperStub(),
+        clock: TestClock = TestClock(),
+        timings: GotaTunActorTimings = GotaTunActorTimings()
     ) -> GotaTunActor {
         GotaTunActor(
+            timings: timings,
+            clock: clock,
             providerDelegate: providerDelegate,
             settingsReader: settingsReader,
             relaySelector: relaySelector,
@@ -633,6 +637,134 @@ final class GotaTunActorTests: XCTestCase {
         await waitFor(actor, until: { $0.isConnected }, while: { await pathObserver.updatePath(.satisfied) })
 
         XCTAssertEqual(factory.adaptersCreated.count, 2)
+    }
+
+    // MARK: - Key rotation
+
+    func testKeyRotationTriggersReconnect() async throws {
+        let factory = GotaTunAdapterFactoryStub(outcome: .connected())
+        let clock = TestClock()
+        let timings = GotaTunActorTimings()
+        let actor = makeActor(adapterFactory: factory, clock: clock, timings: timings)
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+
+        XCTAssertEqual(factory.adaptersCreated.count, 1)
+
+        actor.notifyKeyRotation(date: Date())
+        await actor.drainEvents()
+        XCTAssertEqual(factory.adaptersCreated.count, 1, "Must not reconnect before the key has propagated")
+
+        await clock.waitForSleepers()
+        let states = await collectStates(from: actor, count: 3) {
+            Task { await clock.advance(by: timings.wgKeyPropagationDelay) }
+        }
+
+        XCTAssertEqual(states.map(\.name), ["Connected", "Reconnecting", "Connected"])
+        XCTAssertEqual(factory.adaptersCreated.count, 2, "Should have created a new adapter for key rotation")
+    }
+
+    func testKeyRotationKeepsPriorKeyUntilPropagated() async throws {
+        let priorKey = WireGuard.PrivateKey()
+        let rotatedKey = WireGuard.PrivateKey()
+        // The app persists the new key before notifying the tunnel, so a read after the
+        // notification already returns the rotated key.
+        var hasRotated = false
+        let settingsReader = SettingsReaderStub {
+            Settings(
+                privateKey: hasRotated ? rotatedKey : priorKey,
+                interfaceAddresses: [
+                    IPAddressRange(from: "127.0.0.1/32")!,
+                    IPAddressRange(from: "fc00::1/128")!,
+                ],
+                tunnelSettings: LatestTunnelSettings()
+            )
+        }
+        let factory = GotaTunAdapterFactoryStub(outcome: .connected())
+        let clock = TestClock()
+        let timings = GotaTunActorTimings()
+        let actor = makeActor(
+            adapterFactory: factory,
+            settingsReader: settingsReader,
+            clock: clock,
+            timings: timings
+        )
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+        XCTAssertEqual(factory.adaptersCreated[0].lastConfig?.privateKey, priorKey.rawValue)
+
+        hasRotated = true
+        actor.notifyKeyRotation(date: Date())
+        await actor.drainEvents()
+
+        await collectStates(from: actor, count: 3) {
+            actor.reconnect(to: .random, reconnectReason: .userInitiated)
+        }
+        XCTAssertEqual(
+            factory.adaptersCreated[1].lastConfig?.privateKey, priorKey.rawValue,
+            "Reconnects during the propagation window must keep using the prior key")
+        XCTAssertEqual(
+            factory.adaptersCreated[1].lastConfig?.clientPublicKey, priorKey.publicKey.rawValue,
+            "The obfuscator's client public key must match the connection key, not the settings key")
+
+        await clock.waitForSleepers()
+        await collectStates(from: actor, count: 3) {
+            Task { await clock.advance(by: timings.wgKeyPropagationDelay) }
+        }
+        XCTAssertEqual(factory.adaptersCreated[2].lastConfig?.privateKey, rotatedKey.rawValue)
+    }
+
+    func testErrorStateDuringKeyRotationEndsRotation() async throws {
+        let priorKey = WireGuard.PrivateKey()
+        let rotatedKey = WireGuard.PrivateKey()
+        var hasRotated = false
+        let settingsReader = SettingsReaderStub {
+            Settings(
+                privateKey: hasRotated ? rotatedKey : priorKey,
+                interfaceAddresses: [
+                    IPAddressRange(from: "127.0.0.1/32")!,
+                    IPAddressRange(from: "fc00::1/128")!,
+                ],
+                tunnelSettings: LatestTunnelSettings()
+            )
+        }
+        let factory = GotaTunAdapterFactoryStub(outcome: .connected())
+        let pathObserver = GotaTunPathObserverFake()
+        let actor = makeActor(
+            adapterFactory: factory,
+            settingsReader: settingsReader,
+            defaultPathObserver: pathObserver
+        )
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+
+        hasRotated = true
+        actor.notifyKeyRotation(date: Date())
+        await actor.drainEvents()
+
+        await waitFor(
+            actor, until: { $0.blockedReason == .offline }, while: { await pathObserver.updatePath(.unsatisfied) })
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await pathObserver.updatePath(.satisfied) })
+        XCTAssertEqual(
+            factory.adaptersCreated[1].lastConfig?.privateKey, rotatedKey.rawValue,
+            "Reconnecting after an error state must use the rotated key, not the stale prior key")
+    }
+
+    func testKeyRotationDatePropagatesToObservedState() async throws {
+        let actor = makeActor()
+        let rotationDate = Date()
+
+        await waitFor(actor, until: { $0.isConnected }, while: { await actor.start(options: launchOptions) })
+        let beforeRotation = await actor.observedState
+        XCTAssertNil(beforeRotation.connectionState?.lastKeyRotation)
+
+        actor.notifyKeyRotation(date: rotationDate)
+        await actor.drainEvents()
+
+        // The app compares this against its own record to decide whether to reload device state.
+        let afterRotation = await actor.observedState
+        XCTAssertEqual(afterRotation.connectionState?.lastKeyRotation, rotationDate)
     }
 
     // MARK: - Stop during connection

--- a/ios/PacketTunnelCoreTests/GotaTunActorTests.swift
+++ b/ios/PacketTunnelCoreTests/GotaTunActorTests.swift
@@ -1,10 +1,12 @@
+// This Source Code Form is subject to the terms of the GPLv3 License.
+// You can obtain a copy of the license at https://www.gnu.org/licenses/gpl-3.0.en.html.
 //
-//  GotaTunActorTests.swift
-//  PacketTunnelCoreTests
+// This file incorporates work covered by the following copyright and
+// permission notice:
 //
-//  Created by Emīls on 2026-08-13.
-//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//   Copyright (c) Mullvad VPN AB. All rights reserved.
 //
+// SPDX-License-Identifier: GPL-3.0-only
 
 import MullvadTypes
 import Network

--- a/ios/PacketTunnelCoreTests/Mocks/TestClock.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/TestClock.swift
@@ -1,0 +1,163 @@
+// This Source Code Form is subject to the terms of the GPLv3 License.
+// You can obtain a copy of the license at https://www.gnu.org/licenses/gpl-3.0.en.html.
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright (c) Mullvad VPN AB. All rights reserved.
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+import Foundation
+import XCTest
+import os
+
+/// A `Clock` whose time only moves when a test moves it.
+///
+/// Sleepers suspend until `advance(by:)` passes their deadline, so code under test can use
+/// production timings without a test ever waiting in real time.
+///
+/// `advance(by:)` must not run before the code under test has actually
+/// suspended on `sleep`. Anchor each call on an awaited observation
+/// that provably follows the sleep.
+final class TestClock: Clock {
+    struct Instant: InstantProtocol {
+        var offset: Duration
+
+        func advanced(by duration: Duration) -> Instant {
+            Instant(offset: offset + duration)
+        }
+
+        func duration(to other: Instant) -> Duration {
+            other.offset - offset
+        }
+
+        static func < (lhs: Instant, rhs: Instant) -> Bool {
+            lhs.offset < rhs.offset
+        }
+    }
+
+    private struct Sleeper {
+        let deadline: Instant
+        let continuation: CheckedContinuation<Void, Error>
+    }
+
+    private enum Disposition {
+        case cancelled, elapsed, suspended
+    }
+
+    private struct State {
+        var currentInstant = Instant(offset: .zero)
+        var sleepers: [Int: Sleeper] = [:]
+        var cancelledIDs: Set<Int> = []
+        var lastID = 0
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    var now: Instant {
+        state.withLock { $0.currentInstant }
+    }
+
+    var minimumResolution: Duration {
+        .zero
+    }
+
+    /// Number of sleepers currently suspended. Lets a test assert that a timer was scheduled
+    /// or cancelled without waiting for it.
+    var sleeperCount: Int {
+        state.withLock { $0.sleepers.count }
+    }
+
+    func sleep(until deadline: Instant, tolerance: Duration? = nil) async throws {
+        let id = state.withLock { state in
+            state.lastID += 1
+            return state.lastID
+        }
+
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let disposition = state.withLock { state -> Disposition in
+                    // Cancellation may arrive before the continuation exists.
+                    guard state.cancelledIDs.remove(id) == nil else { return .cancelled }
+                    guard state.currentInstant < deadline else { return .elapsed }
+                    state.sleepers[id] = Sleeper(deadline: deadline, continuation: continuation)
+                    return .suspended
+                }
+
+                switch disposition {
+                case .cancelled: continuation.resume(throwing: CancellationError())
+                case .elapsed: continuation.resume()
+                case .suspended: break
+                }
+            }
+        } onCancel: {
+            let sleeper = state.withLock { state -> Sleeper? in
+                guard let sleeper = state.sleepers.removeValue(forKey: id) else {
+                    state.cancelledIDs.insert(id)
+                    return nil
+                }
+                return sleeper
+            }
+            sleeper?.continuation.resume(throwing: CancellationError())
+        }
+    }
+
+    /// Move time forward, waking every sleeper whose deadline is reached, in deadline order.
+    ///
+    /// Time stops at each deadline before moving on, so a periodic sleeper that reschedules
+    /// itself is woken once per period rather than once in total.
+    func advance(by duration: Duration) async {
+        let target = state.withLock { $0.currentInstant.advanced(by: duration) }
+
+        while let sleeper = takeNextSleeper(reaching: target) {
+            sleeper.continuation.resume()
+            await settle()
+        }
+
+        state.withLock { $0.currentInstant = target }
+        await settle()
+    }
+
+    /// Wait until at least `count` sleepers are suspended.
+    ///
+    /// Code under test registers its next sleep asynchronously (a periodic timer only re-arms
+    /// once the event it emitted has been handled), so `advance(by:)` needs the sleeper to exist
+    /// before it can wake it. Waiting for that is deterministic.
+    func waitForSleepers(_ count: Int = 1, file: StaticString = #filePath, line: UInt = #line) async {
+        for _ in 0..<10_000 {
+            if sleeperCount >= count { return }
+            await Task.yield()
+        }
+        XCTFail("Timed out waiting for \(count) sleeper(s), found \(sleeperCount)", file: file, line: line)
+    }
+
+    /// Wake every sleeper, however far in the future, until none are left.
+    func runToCompletion() async {
+        while let sleeper = takeNextSleeper(reaching: nil) {
+            sleeper.continuation.resume()
+            await settle()
+        }
+    }
+
+    /// Removes and returns the earliest sleeper at or before `limit`, moving time to its deadline.
+    private func takeNextSleeper(reaching limit: Instant?) -> Sleeper? {
+        state.withLock { state -> Sleeper? in
+            guard let (id, sleeper) = state.sleepers.min(by: { $0.value.deadline < $1.value.deadline })
+            else { return nil }
+
+            if let limit, sleeper.deadline > limit { return nil }
+
+            state.currentInstant = sleeper.deadline
+            state.sleepers.removeValue(forKey: id)
+            return sleeper
+        }
+    }
+
+    /// Yield to the executor to hopefully allow other tasks to register more sleep calls.
+    private func settle() async {
+        for _ in 0..<20 {
+            await Task.yield()
+        }
+    }
+}


### PR DESCRIPTION
With these changes, the GotaTun actor can now handle key rotation and failure to read settings due to the phone still being locked. 

To ease testing the various timeout driven behaviours, I've also added a `TestClock` - this mocks sleeps. We can extend it later to also mock fetching timestamps if needed.

With these changes, the last missing pieces for GotaTun, I believe, are fixing socket bumping on the Rust side - and lots of bug testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11072)
<!-- Reviewable:end -->
