### PR TITLE
Enforce `X25519MLKEM768` key exchange in TLS to `api.mullvad.net`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Line wrap the file at 100 chars.                                              Th
 - Remove `mullvad tunnel set daita-direct-only` command. Superseded by automatic multihop setting.
 - Improve obfuscation performance by using GotaTun. This mainly affects Shadowsocks.
 - Do not show dialog when rendering the map fails due to disabled GPU acceleration.
+- Require the post-quantum X25519MLKEM768 key exchange for TLS connections to the Mullvad API.
 
 #### Linux
 - Remove dependency on `iproute2` when using GotaTun with IPv6.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,11 @@ reqwest = { version = "0.12.23", default-features = false, features = [
   "rustls-tls-webpki-roots-no-provider"
 ] }
 rtnetlink = "0.21.0"
-rustls = { version = "0.23", default-features = false }
+# `prefer-post-quantum` is a rustls default that `default-features = false`
+# would otherwise drop. It puts X25519MLKEM768 first among the key exchange
+# groups, so every client that does not pin its own groups offers the hybrid
+# ahead of the classical ones and gets it wherever the server agrees.
+rustls = { version = "0.23", default-features = false, features = ["prefer-post-quantum"] }
 rustls-pki-types = "1.13.1"
 safelog = "0.8.2"
 serde = "1.0.204"

--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -22,6 +22,8 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+### Changed
+- Require the post-quantum X25519MLKEM768 key exchange for TLS connections to the Mullvad API.
 
 
 ## [android/2026.9-beta1] - 2026-08-20

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -23,6 +23,9 @@ Line wrap the file at 100 chars.                                              Th
 
 ## UNRELEASED
 
+### Changed
+- Require the post-quantum X25519MLKEM768 key exchange for TLS connections to the Mullvad API.
+
 ### Fixed
 - Locale-aware sorting of relay list on iOS
 

--- a/mullvad-api/src/tls_stream.rs
+++ b/mullvad-api/src/tls_stream.rs
@@ -1,5 +1,7 @@
 //! Provides a TLS 1.3 stream, accepting only LE for root cert.
-//! SNI is disabled.
+//! SNI is disabled. The only allowed key exchange group is the
+//! post-quantum hybrid X25519MLKEM768, so handshakes fail if the
+//! server will not negotiate it.
 use std::{
     io::{self, ErrorKind},
     pin::Pin,
@@ -23,14 +25,18 @@ pub struct TlsStream<S: AsyncRead + AsyncWrite + Unpin> {
 }
 
 static TLS_CONFIG: LazyLock<Arc<ClientConfig>> = LazyLock::new(|| {
+    // Restrict the key exchange to X25519MLKEM768. Offering only this group
+    // means the server must select it, otherwise the handshake aborts.
+    let provider = rustls::crypto::CryptoProvider {
+        kx_groups: vec![rustls::crypto::aws_lc_rs::kx_group::X25519MLKEM768],
+        ..rustls::crypto::aws_lc_rs::default_provider()
+    };
     let config = {
-        let mut config = ClientConfig::builder_with_provider(Arc::new(
-            rustls::crypto::aws_lc_rs::default_provider(),
-        ))
-        .with_protocol_versions(&[&rustls::version::TLS13])
-        .expect("aws-lc-rs crypto provider should support TLS 1.3")
-        .with_root_certificates(read_cert_store().expect("Failed to parse pem file"))
-        .with_no_client_auth();
+        let mut config = ClientConfig::builder_with_provider(Arc::new(provider))
+            .with_protocol_versions(&[&rustls::version::TLS13])
+            .expect("aws-lc-rs crypto provider should support TLS 1.3")
+            .with_root_certificates(read_cert_store().expect("Failed to parse pem file"))
+            .with_no_client_auth();
         // This assumes that the server hello/certificates will include certificate for the domain.
         config.enable_sni = false;
         config


### PR DESCRIPTION
Offering only this group means the TLS 1.3 handshake aborts unless the server negotiates the post-quantum hybrid, making PQ a hard requirement rather than best-effort. Prevents potential downgrades to non-PQ safe TLS key exchanges.

The installer-downloader also talks to api.mullvad.net. This PR does not enforce `X25519MLKEM768` there. This PR only focus on the actual VPN app itself. We can do the same enforcement in the installer-downloader later, if we deem this to work well enough. And probably after we do some other TLS related cleanups that are not ready yet.

This change makes the ClientHello more fingerprintable sadly. Since the publicly visible key exchange is now *only* `X25519MLKEM768`, and browsers etc generally don't do that. So it depends on if we see that as a problem or not. We still have API access methods that will be used when a plain connection does not work, and this PR does not lower the anti-censorship qualities of those. We also disable SNI, which browsers generally don't. So that's probably a much more clear signal than this to any censor anyway.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11086)
<!-- Reviewable:end -->
