### PR TITLE
Attempt to fix connect failing due to `WSAEACCES`/`10013` during ephemeral peer exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@ Line wrap the file at 100 chars.                                              Th
 - Parse the `resolv.conf` format using `resolv-conf` crate. This will lead to fewer false negatives
   when detecting if NetworkManager manages DNS.
 
+#### Windows
+- Wait for the tunnel routes to become usable, and retry the connection to the tunnel config
+  service if the tunnel is not ready yet. This may help with connection failures that occur
+  immediately after the tunnel is set up, when using quantum-resistant tunnels or DAITA.
+
 ### Security
 #### macOS
 - Fix local privilege escalation attack in the uninstall script. This could be used by admin users

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6220,6 +6220,7 @@ name = "talpid-windows"
 version = "0.0.0"
 dependencies = [
  "futures",
+ "log",
  "socket2",
  "talpid-types",
  "thiserror 2.0.19",

--- a/talpid-tunnel-config-client/src/lib.rs
+++ b/talpid-tunnel-config-client/src/lib.rs
@@ -320,6 +320,99 @@ fn xor_assign(dst: &mut [u8; 32], src: &[u8; 32]) {
     }
 }
 
+/// Connects to the config service at `addr`.
+#[cfg(not(any(target_os = "windows", target_os = "ios")))]
+async fn connect_to_config_service(
+    socket: socket::TcpSocket,
+    addr: SocketAddr,
+) -> std::io::Result<tokio::net::TcpStream> {
+    socket.connect(addr).await
+}
+
+// TODO: Remove this if waiting for the tunnel addresses turns out to be enough on its own. The
+// retry is here because we do not know that it is, and it hides the symptom rather than fixing it
+// -- if the logs stop showing retries that succeed, it has nothing left to do.
+/// Connects to the config service at `addr`, retrying briefly for as long as the firewall blocks
+/// the connection.
+///
+/// The tunnel is configured very shortly before this runs, and we suspect that a connection made
+/// before it is ready is blocked instead of being routed through the tunnel, which surfaces as
+/// WSAEACCES. A connection that only succeeds on a retry would confirm it, so every attempt is
+/// logged.
+#[cfg(target_os = "windows")]
+async fn connect_to_config_service(
+    socket: socket::TcpSocket,
+    addr: SocketAddr,
+) -> std::io::Result<tokio::net::TcpStream> {
+    use std::time::Duration;
+
+    /// How long to keep retrying.
+    const RETRY_TIMEOUT: Duration = Duration::from_secs(1);
+    /// How long to wait between those retries.
+    const RETRY_INTERVAL: Duration = Duration::from_millis(50);
+
+    let start = Instant::now();
+    let mut attempts = 0u32;
+    let mut last_error = None;
+
+    loop {
+        attempts += 1;
+        let error = match socket.try_clone()?.connect(addr).await {
+            Ok(stream) => {
+                if let Some(err) = last_error {
+                    log::warn!(
+                        "Connection to {addr} succeeded on attempt {attempts} after {:?}. \
+                         Earlier attempts failed with: {err}",
+                        start.elapsed(),
+                    );
+                }
+                return Ok(stream);
+            }
+            Err(error) => error,
+        };
+
+        if !tunnel_not_ready_error(&error) {
+            return Err(error);
+        }
+
+        if start.elapsed() >= RETRY_TIMEOUT {
+            log::warn!(
+                "Giving up on {addr} after {attempts} failed attempts over {:?}: {error}",
+                start.elapsed(),
+            );
+            return Err(error);
+        }
+
+        log::debug!("Connection to {addr} failed, retrying: {error}");
+        last_error = Some(error);
+
+        tokio::time::sleep(RETRY_INTERVAL).await;
+    }
+}
+
+/// Returns whether `error` means the tunnel was not ready, and might succeed on a retry.
+#[cfg(target_os = "windows")]
+fn tunnel_not_ready_error(error: &std::io::Error) -> bool {
+    use windows_sys::Win32::Networking::WinSock::{
+        WSAEACCES, WSAEADDRNOTAVAIL, WSAEHOSTUNREACH, WSAENETUNREACH,
+    };
+
+    let Some(raw_err) = error.raw_os_error() else {
+        return false;
+    };
+
+    matches!(
+        raw_err,
+        // Blocked by the firewall, because the connection was not classified against the tunnel.
+        WSAEACCES |
+        // No source address on the tunnel interface is usable yet.
+        WSAEADDRNOTAVAIL |
+        // No route through the tunnel yet.
+        WSAENETUNREACH |
+        WSAEHOSTUNREACH
+    )
+}
+
 /// Create a new `RelayConfigService` connected to the given IP.
 ///
 /// On non-Windows platforms the connection is made with a socket where the MSS
@@ -340,7 +433,7 @@ async fn connect_relay_config_client(
             let clone = socket.try_clone();
             async move {
                 let socket = clone?;
-                let stream = socket.connect(addr).await?;
+                let stream = connect_to_config_service(socket, addr).await?;
                 Ok::<_, std::io::Error>(TokioIo::new(stream))
             }
         }))

--- a/talpid-tunnel/src/tun_provider/windows.rs
+++ b/talpid-tunnel/src/tun_provider/windows.rs
@@ -5,6 +5,9 @@ use tun::{self, AbstractDeviceExt};
 use tun::{AbstractDevice, AsyncDevice, Configuration};
 use windows_sys::Win32::NetworkManagement::Ndis::NET_LUID_LH;
 
+/// Maximum time to wait for the tunnel IP addresses to complete duplicate address detection.
+const WAIT_FOR_ADDRESSES_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Errors that can occur while setting up a tunnel device.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -31,6 +34,10 @@ pub enum Error {
     /// Timeout waiting for IP interfaces
     #[error("Error waiting for IP interfaces")]
     WaitForInterfaces(#[source] talpid_windows::net::Error),
+
+    /// Timeout waiting for the tunnel IP addresses to become usable
+    #[error("Error waiting for tunnel IP addresses")]
+    WaitForAddresses(#[source] talpid_windows::net::Error),
 
     /// Failed to configure IP interfaces
     #[error("Failed to configure MTU and metric")]
@@ -104,6 +111,20 @@ impl WindowsTunProvider {
         }
 
         tunnel_device.set_up(true)?;
+
+        // Wait for the addresses to become usable. Until they are, they cannot be selected as
+        // source addresses, so connections made this early may be routed out another interface and
+        // blocked (WSAEACCES). Suspected, not confirmed: they are normally usable right away.
+        // TODO: Like the interface wait above, this isn't cancellable by the user or TSM.
+        let luid = NET_LUID_LH {
+            Value: tunnel_device.dev.tun_luid(),
+        };
+        talpid_windows::net::wait_for_addresses_sync(
+            luid,
+            &self.config.addresses,
+            WAIT_FOR_ADDRESSES_TIMEOUT,
+        )
+        .map_err(Error::WaitForAddresses)?;
 
         Ok(WindowsTun(tunnel_device))
     }

--- a/talpid-windows/Cargo.toml
+++ b/talpid-windows/Cargo.toml
@@ -23,6 +23,7 @@ features = ["Win32_Storage", "Win32_Storage_FileSystem"]
 
 [target."cfg(windows)".dependencies]
 futures = { workspace = true }
+log = { workspace = true }
 socket2 = { workspace = true }
 talpid-types = { path = "../talpid-types" }
 thiserror = { workspace = true }

--- a/talpid-windows/src/net.rs
+++ b/talpid-windows/src/net.rs
@@ -7,6 +7,7 @@ use std::{
     mem::MaybeUninit,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
     os::windows::ffi::{OsStrExt, OsStringExt},
+    panic::RefUnwindSafe,
     ptr::NonNull,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
@@ -14,15 +15,14 @@ use std::{
 use talpid_types::win32_err;
 use windows_sys::{
     Win32::{
-        Foundation::{ERROR_NOT_FOUND, HANDLE},
+        Foundation::{ERROR_NOT_FOUND, HANDLE, WIN32_ERROR},
         NetworkManagement::{
             IpHelper::{
                 ConvertInterfaceAliasToLuid, ConvertInterfaceLuidToAlias,
                 ConvertInterfaceLuidToGuid, ConvertInterfaceLuidToIndex,
-                CreateUnicastIpAddressEntry, FreeMibTable, GetUnicastIpAddressEntry,
-                GetUnicastIpAddressTable, InitializeUnicastIpAddressEntry, MIB_IPINTERFACE_ROW,
-                MIB_UNICASTIPADDRESS_ROW, MIB_UNICASTIPADDRESS_TABLE, MibAddInstance,
-                SetIpInterfaceEntry,
+                CreateUnicastIpAddressEntry, FreeMibTable, GetUnicastIpAddressTable,
+                InitializeUnicastIpAddressEntry, MIB_IPINTERFACE_ROW, MIB_UNICASTIPADDRESS_ROW,
+                MIB_UNICASTIPADDRESS_TABLE, MibAddInstance, SetIpInterfaceEntry,
             },
             Ndis::{IF_MAX_STRING_SIZE, NET_LUID_LH},
         },
@@ -39,7 +39,6 @@ use windows_sys::{
 pub type Result<T> = std::result::Result<T, Error>;
 
 const DAD_CHECK_TIMEOUT: Duration = Duration::from_secs(5);
-const DAD_CHECK_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Errors returned by some functions in this module.
 #[derive(thiserror::Error, Debug)]
@@ -73,6 +72,10 @@ pub enum Error {
     #[cfg(windows)]
     #[error("Error waiting on IP interfaces")]
     StartIpInterfaceNotify(#[source] io::Error),
+
+    /// Failed to start unicast address check.
+    #[error("Error waiting on unicast IP addresses")]
+    StartUnicastAddressNotify(#[source] io::Error),
 
     /// Interface check failed.
     #[cfg(windows)]
@@ -145,18 +148,24 @@ impl AddressFamily {
     }
 }
 
-type InnerCallback = Box<Mutex<dyn FnMut(&MIB_IPINTERFACE_ROW, i32) + Send + 'static>>;
+/// A user-provided callback function to be called from a raw `Notify*Change` callback
+/// function. `T` is type that the notification carries.
+type InnerCallback<T> = Box<Mutex<dyn FnMut(&T, i32) + Send + 'static>>;
 
-/// Context for [`notify_ip_interface_change`]. When it is dropped,
-/// the callback is unregistered.
-pub struct IpNotifierHandle {
-    callback: Option<NonNull<InnerCallback>>,
+/// The callback function passed to the `Notify*Change` functions. `T` is the row type that the
+/// notification carries.
+type ChangeCallback<T> = unsafe extern "system" fn(*const core::ffi::c_void, *const T, i32);
+
+/// Context for [`notify_ip_interface_change`] and [`notify_unicast_ip_address_change`].
+/// When it is dropped, the callback is unregistered.
+pub struct IpNotifierHandle<T: 'static> {
+    callback: Option<NonNull<InnerCallback<T>>>,
     handle: Option<NonNull<core::ffi::c_void>>,
 }
 
-unsafe impl Send for IpNotifierHandle {}
+unsafe impl<T> Send for IpNotifierHandle<T> {}
 
-impl Drop for IpNotifierHandle {
+impl<T> Drop for IpNotifierHandle<T> {
     fn drop(&mut self) {
         #[cfg(not(test))]
         use windows_sys::Win32::NetworkManagement::IpHelper::CancelMibChangeNotify2;
@@ -175,26 +184,56 @@ impl Drop for IpNotifierHandle {
             .expect("callback is Some until drop is called");
         let callback = callback.as_ptr();
         // SAFETY:
-        // - Callback was constructed in `notify_ip_interface_change` using `Box::into_raw`.
+        // - Callback was constructed in `register_change_notifier` using `Box::into_raw`.
         // - `CancelMibChangeNotify2` ensures that the callback is removed, so we can safely take ownership.
-        let _inner_callback: Box<InnerCallback> = unsafe { Box::from_raw(callback) };
+        let _inner_callback: Box<InnerCallback<T>> = unsafe { Box::from_raw(callback) };
     }
 }
 
-unsafe extern "system" fn outer_callback(
+unsafe extern "system" fn outer_callback<T: RefUnwindSafe>(
     context: *const std::ffi::c_void,
-    row: *const MIB_IPINTERFACE_ROW,
+    row: *const T,
     notify_type: i32,
 ) {
-    // SAFETY: `context` is a valid pointer to an `InnerCallback` constructed in `notify_ip_interface_change`.
+    // SAFETY: `context` is a valid pointer to an `InnerCallback` constructed in `register_change_notifier`.
     // `outer_callback` is never called after `CancelMibChangeNotify2` has completed, and `CancelMibChangeNotify2`
     // blocks until the function returns if it is currently being called.
-    let cb = unsafe { &*context.cast::<InnerCallback>() };
+    let cb = unsafe { &*context.cast::<InnerCallback<T>>() };
     // SAFETY: `row` is set when type is not `MibInitialNotification`, which we do not use.
     let row = unsafe { &*row };
     _ = std::panic::catch_unwind(|| {
-        cb.lock().expect("NotifyIpInterfaceChange mutex poisoned")(row, notify_type)
+        cb.lock().expect("notification mutex poisoned")(row, notify_type)
     });
+}
+
+/// Registers `callback` to be invoked for every notification delivered by the `Notify*Change`
+/// function that `register` calls. `register` is handed the callback function and context pointer
+/// to register, along with the out pointer for the notification handle.
+fn register_change_notifier<T: RefUnwindSafe + 'static>(
+    callback: impl FnMut(&T, i32) + Send + 'static,
+    register: impl FnOnce(ChangeCallback<T>, *const core::ffi::c_void, *mut HANDLE) -> WIN32_ERROR,
+) -> io::Result<IpNotifierHandle<T>> {
+    // Box mutex because fat pointer
+    let callback = Box::new(Mutex::new(callback)) as Box<Mutex<_>>;
+    let callback: Box<InnerCallback<T>> = Box::new(callback);
+    let callback = NonNull::new(Box::into_raw(callback)).unwrap();
+
+    let mut handle = HANDLE::default();
+
+    if let Err(error) = win32_err!(register(
+        outer_callback::<T>,
+        callback.as_ptr().cast(),
+        &raw mut handle,
+    )) {
+        // SAFETY: The callback was never registered, so we still have sole ownership of it.
+        drop(unsafe { Box::from_raw(callback.as_ptr()) });
+        return Err(error);
+    }
+
+    Ok(IpNotifierHandle {
+        callback: Some(callback),
+        handle: Some(NonNull::new(handle).expect("non-null because registration succeeded")),
+    })
 }
 
 /// Registers a callback function that is invoked when an interface is added, removed,
@@ -202,38 +241,58 @@ unsafe extern "system" fn outer_callback(
 pub fn notify_ip_interface_change<T: FnMut(&MIB_IPINTERFACE_ROW, i32) + Send + 'static>(
     callback: T,
     family: Option<AddressFamily>,
-) -> io::Result<IpNotifierHandle> {
-    // Box mutex because fat pointer
-    let callback = Box::new(Mutex::new(callback)) as Box<Mutex<_>>;
-    let callback: Box<InnerCallback> = Box::new(callback);
-    let callback = NonNull::new(Box::into_raw(callback)).unwrap();
-
+) -> io::Result<IpNotifierHandle<MIB_IPINTERFACE_ROW>> {
     #[cfg(not(test))]
     use windows_sys::Win32::NetworkManagement::IpHelper::NotifyIpInterfaceChange;
 
     #[cfg(test)]
     use tests::fake_notify_ip_interface_change as NotifyIpInterfaceChange;
 
-    let mut handle = HANDLE::default();
+    register_change_notifier(callback, |callback, context, handle| {
+        // SAFETY: `context` points at the boxed callback owned by the returned handle, which does
+        // not free it until `CancelMibChangeNotify2` has returned, so it outlives every callback.
+        unsafe {
+            NotifyIpInterfaceChange(
+                af_family_from_family(family),
+                Some(callback),
+                context,
+                false,
+                handle,
+            )
+        }
+    })
+}
 
-    win32_err!(unsafe {
-        NotifyIpInterfaceChange(
-            af_family_from_family(family),
-            Some(outer_callback),
-            callback.as_ptr().cast(),
-            false,
-            &raw mut handle,
-        )
-    })?;
+/// Registers a callback function that is invoked when a unicast IP address is added, removed,
+/// or changed.
+///
+/// Note that the row passed to `callback` contains incomplete data. Use
+/// [`get_unicast_ip_address_entry`] to obtain the current state of the address.
+pub fn notify_unicast_ip_address_change<
+    T: FnMut(&MIB_UNICASTIPADDRESS_ROW, i32) + Send + 'static,
+>(
+    callback: T,
+    family: Option<AddressFamily>,
+) -> io::Result<IpNotifierHandle<MIB_UNICASTIPADDRESS_ROW>> {
+    #[cfg(not(test))]
+    use windows_sys::Win32::NetworkManagement::IpHelper::NotifyUnicastIpAddressChange;
 
-    let context = IpNotifierHandle {
-        callback: Some(callback),
-        handle: Some(
-            NonNull::new(handle).expect("non-null because NotifyIpInterfaceChange succeeded"),
-        ),
-    };
+    #[cfg(test)]
+    use tests::fake_notify_unicast_ip_address_change as NotifyUnicastIpAddressChange;
 
-    Ok(context)
+    register_change_notifier(callback, |callback, context, handle| {
+        // SAFETY: `context` points at the boxed callback owned by the returned handle, which does
+        // not free it until `CancelMibChangeNotify2` has returned, so it outlives every callback.
+        unsafe {
+            NotifyUnicastIpAddressChange(
+                af_family_from_family(family),
+                Some(callback),
+                context,
+                false,
+                handle,
+            )
+        }
+    })
 }
 
 /// Returns information about a network IP interface.
@@ -309,9 +368,9 @@ pub fn wait_for_interfaces_sync(
     }
 }
 
-enum StartNotifyResult {
+enum StartNotifyResult<T: 'static> {
     AlreadyExist,
-    Waiting(IpNotifierHandle),
+    Waiting(IpNotifierHandle<T>),
 }
 
 /// Begins to wait until the specified IP interfaces have attached to a given network interface.
@@ -325,7 +384,7 @@ fn start_wait_for_interfaces(
     ipv4: bool,
     ipv6: bool,
     on_found: impl FnOnce() + Send + 'static,
-) -> io::Result<StartNotifyResult> {
+) -> io::Result<StartNotifyResult<MIB_IPINTERFACE_ROW>> {
     struct FoundInterfaces {
         ipv4: bool,
         ipv6: bool,
@@ -381,51 +440,203 @@ fn start_wait_for_interfaces(
     Ok(StartNotifyResult::Waiting(handle))
 }
 
-/// Wait for addresses to be usable on an network adapter.
-pub async fn wait_for_addresses(luid: NET_LUID_LH) -> Result<()> {
-    // Obtain unicast IP addresses
-    let mut unicast_rows: Vec<MIB_UNICASTIPADDRESS_ROW> = get_unicast_table(None)
-        .map_err(Error::ObtainUnicastAddress)?
-        .into_iter()
-        .filter(|row| unsafe { row.InterfaceLuid.Value == luid.Value })
-        .collect();
-    if unicast_rows.is_empty() {
-        return Err(Error::NoUnicastAddress);
-    }
-
-    let (tx, rx) = futures::channel::oneshot::channel();
-    let mut addr_check_thread = move || {
-        // Poll DAD status using GetUnicastIpAddressEntry
-        // https://docs.microsoft.com/en-us/windows/win32/api/netioapi/nf-netioapi-createunicastipaddressentry
-
-        let deadline = Instant::now() + DAD_CHECK_TIMEOUT;
-        while Instant::now() < deadline {
-            let mut ready = true;
-
-            for row in &mut unicast_rows {
-                win32_err!(unsafe { GetUnicastIpAddressEntry(row) })
-                    .map_err(Error::ObtainUnicastAddress)?;
-                if row.DadState == IpDadStateTentative {
-                    ready = false;
-                    break;
-                }
-                if row.DadState != IpDadStatePreferred {
-                    return Err(Error::DadStateError(DadStateError::from(row.DadState)));
-                }
-            }
-
-            if ready {
-                return Ok(());
-            }
-            std::thread::sleep(DAD_CHECK_INTERVAL);
-        }
-
-        Err(Error::DeviceReadyTimeout)
+/// Returns the current state of the unicast address `address` on the interface `luid`.
+pub fn get_unicast_ip_address_entry(
+    luid: NET_LUID_LH,
+    address: IpAddr,
+) -> io::Result<MIB_UNICASTIPADDRESS_ROW> {
+    let mut row = MIB_UNICASTIPADDRESS_ROW {
+        InterfaceLuid: luid,
+        Address: inet_sockaddr_from_socketaddr(SocketAddr::new(address, 0)),
+        ..Default::default()
     };
+
+    #[cfg(not(test))]
+    use windows_sys::Win32::NetworkManagement::IpHelper::GetUnicastIpAddressEntry;
+
+    #[cfg(test)]
+    use tests::fake_get_unicast_ip_address_entry as GetUnicastIpAddressEntry;
+
+    win32_err!(unsafe { GetUnicastIpAddressEntry(&raw mut row) })?;
+    Ok(row)
+}
+
+/// Returns whether an address in the given DAD state is ready to be used, or an error if
+/// duplicate address detection has failed for it.
+#[expect(non_upper_case_globals)]
+fn address_is_ready(state: NL_DAD_STATE) -> Result<bool> {
+    match state {
+        IpDadStatePreferred => Ok(true),
+        IpDadStateTentative => Ok(false),
+        state => Err(Error::DadStateError(DadStateError::from(state))),
+    }
+}
+
+/// Waits until all of `addresses` have been added to the interface `luid` and are usable, i.e.
+/// until duplicate address detection has completed for each of them.
+///
+/// This blocks for at most `timeout`.
+pub fn wait_for_addresses_sync(
+    luid: NET_LUID_LH,
+    addresses: &[IpAddr],
+    timeout: Duration,
+) -> Result<()> {
+    let (tx, rx) = std::sync::mpsc::sync_channel(1);
+
+    let on_ready = move |result| {
+        let _ = tx.send(result);
+    };
+    match start_wait_for_addresses(luid, addresses, on_ready)? {
+        StartNotifyResult::AlreadyExist => Ok(()),
+        StartNotifyResult::Waiting(_handle) => {
+            let start = Instant::now();
+            let result = rx
+                .recv_timeout(timeout)
+                .unwrap_or(Err(Error::DeviceReadyTimeout));
+            log::debug!(
+                "Waited {:?} for duplicate address detection: {}",
+                start.elapsed(),
+                if result.is_ok() { "done" } else { "failed" },
+            );
+            result
+        }
+    }
+}
+
+/// Waits until all of `addresses` have been added to the interface `luid` and are usable, i.e.
+/// until duplicate address detection has completed for each of them.
+///
+/// This waits for at most [`DAD_CHECK_TIMEOUT`].
+pub async fn wait_for_addresses(luid: NET_LUID_LH, addresses: Vec<IpAddr>) -> Result<()> {
+    let (tx, rx) = futures::channel::oneshot::channel();
+    // The wait blocks on a notification, so it is moved off of the async runtime.
     std::thread::spawn(move || {
-        let _ = tx.send(addr_check_thread());
+        let _ = tx.send(wait_for_addresses_sync(luid, &addresses, DAD_CHECK_TIMEOUT));
     });
     rx.await.map_err(|_| Error::UnicastSenderDropped)?
+}
+
+/// Begins to wait until all of `addresses` have been added to the interface `luid` and have
+/// completed duplicate address detection.
+///
+/// `StartNotifyResult::AlreadyExist` is returned if all of them are already preferred.
+///
+/// Otherwise, on success, `on_ready` is called when the remaining addresses have been added and
+/// become preferred, or as soon as duplicate address detection fails for one of them.
+/// The wait is cancelled if the returned handle is dropped.
+fn start_wait_for_addresses(
+    luid: NET_LUID_LH,
+    addresses: &[IpAddr],
+    on_ready: impl FnOnce(Result<()>) + Send + 'static,
+) -> Result<StartNotifyResult<MIB_UNICASTIPADDRESS_ROW>> {
+    /// Why an address is not usable yet.
+    #[derive(Debug)]
+    enum Pending {
+        /// The address has not been added to the interface yet.
+        Missing(IpAddr),
+        /// The address exists, but duplicate address detection has not completed.
+        Tentative(IpAddr),
+    }
+
+    impl Pending {
+        const fn address(&self) -> &IpAddr {
+            let (Pending::Missing(address) | Pending::Tentative(address)) = self;
+            address
+        }
+    }
+
+    // Addresses that are not usable yet. Both missing and tentative addresses are waited for, so
+    // that an address that has not been plumbed at all is not mistaken for a ready one.
+    let pending: Arc<Mutex<Vec<Pending>>> = Arc::new(Mutex::new(vec![]));
+
+    let mut on_ready = Some(on_ready);
+    let pending2 = pending.clone();
+    let expected = addresses.to_vec();
+
+    let handle = notify_unicast_ip_address_change(
+        move |row, notification_type| {
+            // SAFETY: This is always valid as a `u64`.
+            if unsafe { row.InterfaceLuid.Value != luid.Value } {
+                return;
+            }
+            let Ok(address) = try_socketaddr_from_inet_sockaddr(row.Address) else {
+                return;
+            };
+            let address = address.ip();
+
+            if notification_type == MibAddInstance && !expected.contains(&address) {
+                log::debug!("Unexpected address added to the tunnel interface: {address}");
+                return;
+            }
+
+            let mut pending = pending2.lock().unwrap();
+            if !pending.iter().any(|pending| pending.address() == &address) {
+                return;
+            }
+
+            // The row handed to the callback contains incomplete data, so the current state of the
+            // address has to be queried separately.
+            let ready = match get_unicast_ip_address_entry(luid, address) {
+                Ok(row) => address_is_ready(row.DadState),
+                // The address is not there (yet). Keep waiting for it to be added.
+                Err(error) if error.raw_os_error() == Some(ERROR_NOT_FOUND as i32) => return,
+                Err(error) => Err(Error::ObtainUnicastAddress(error)),
+            };
+
+            let result = match ready {
+                Ok(true) => {
+                    pending.retain(|pending| pending.address() != &address);
+                    if !pending.is_empty() {
+                        return;
+                    }
+                    Ok(())
+                }
+                // Added, but still tentative. Keep waiting.
+                Ok(false) => return,
+                // Duplicate address detection failed. Give up immediately.
+                Err(error) => Err(error),
+            };
+
+            if let Some(on_ready) = on_ready.take() {
+                on_ready(result);
+            }
+        },
+        None,
+    )
+    .map_err(Error::StartUnicastAddressNotify)?;
+
+    // Check the current state while holding the lock, so that the callback cannot observe an empty
+    // set of pending addresses and discard a change that we have not seen yet.
+    //
+    // NOTE: This guard must be declared after `handle`, so that it is released first on the early
+    // returns below. Dropping `handle` waits for any in-flight callback, which may be blocked on
+    // this very lock.
+    let mut pending = pending.lock().unwrap();
+
+    for &address in addresses {
+        match get_unicast_ip_address_entry(luid, address) {
+            Ok(row) => {
+                if !address_is_ready(row.DadState)? {
+                    pending.push(Pending::Tentative(address));
+                }
+            }
+            Err(error) if error.raw_os_error() == Some(ERROR_NOT_FOUND as i32) => {
+                pending.push(Pending::Missing(address));
+            }
+            Err(error) => return Err(Error::ObtainUnicastAddress(error)),
+        }
+    }
+
+    if pending.is_empty() {
+        return Ok(StartNotifyResult::AlreadyExist);
+    }
+
+    log::debug!(
+        "Waiting for tunnel addresses to become usable: {:?}",
+        *pending
+    );
+
+    Ok(StartNotifyResult::Waiting(handle))
 }
 
 /// Returns the first unicast IP address for the given interface.
@@ -617,8 +828,8 @@ impl fmt::Display for AddressFamily {
 mod tests {
     use std::sync::LazyLock;
 
-    use windows_sys::Win32::{
-        Foundation::WIN32_ERROR, NetworkManagement::IpHelper::PIPINTERFACE_CHANGE_CALLBACK,
+    use windows_sys::Win32::NetworkManagement::IpHelper::{
+        PIPINTERFACE_CHANGE_CALLBACK, PUNICAST_IPADDRESS_CHANGE_CALLBACK,
     };
 
     use super::*;
@@ -719,6 +930,118 @@ mod tests {
         unsafe { *notificationhandle = h as *mut core::ffi::c_void };
 
         0
+    }
+
+    struct AddressSettings {
+        expected_luid: NET_LUID_LH,
+        /// DAD state reported by [`fake_get_unicast_ip_address_entry`] for each address.
+        /// Addresses that are absent here are reported as `ERROR_NOT_FOUND`.
+        dad_states: Vec<(IpAddr, NL_DAD_STATE)>,
+        /// Replaces `dad_states` just before notifications are delivered. This models addresses
+        /// that are plumbed after the wait has already begun.
+        dad_states_on_notify: Option<Vec<(IpAddr, NL_DAD_STATE)>>,
+        /// Addresses to deliver `MibAddInstance` notifications for.
+        send_add_event_for_addresses: Vec<IpAddr>,
+        sleep_duration: Option<Duration>,
+    }
+
+    impl Default for AddressSettings {
+        fn default() -> Self {
+            AddressSettings {
+                expected_luid: NET_LUID_LH { Value: 1 },
+                dad_states: vec![],
+                dad_states_on_notify: None,
+                send_add_event_for_addresses: vec![],
+                sleep_duration: None,
+            }
+        }
+    }
+
+    static ADDRESS_SETTINGS: LazyLock<Mutex<AddressSettings>> =
+        LazyLock::new(|| Mutex::new(AddressSettings::default()));
+
+    pub unsafe fn fake_notify_unicast_ip_address_change(
+        family: u16,
+        callback: PUNICAST_IPADDRESS_CHANGE_CALLBACK,
+        callercontext: *const core::ffi::c_void,
+        initialnotification: bool,
+        notificationhandle: *mut HANDLE,
+    ) -> WIN32_ERROR {
+        assert_eq!(family, AF_UNSPEC);
+        assert!(!initialnotification);
+
+        struct Context {
+            callback: PUNICAST_IPADDRESS_CHANGE_CALLBACK,
+            callercontext: *const core::ffi::c_void,
+        }
+        unsafe impl Send for Context {}
+        let ctx = Context {
+            callback,
+            callercontext,
+        };
+
+        let thread = std::thread::spawn(move || {
+            let ctx = ctx;
+
+            if let Some(duration) = ADDRESS_SETTINGS.lock().unwrap().sleep_duration {
+                std::thread::sleep(duration);
+            }
+
+            let cb = ctx.callback.unwrap();
+
+            // Do not hold the lock while invoking the callback: it queries the address state.
+            let (luid, addresses) = {
+                let mut settings = ADDRESS_SETTINGS.lock().unwrap();
+                if let Some(dad_states) = settings.dad_states_on_notify.take() {
+                    settings.dad_states = dad_states;
+                }
+                (
+                    settings.expected_luid,
+                    settings.send_add_event_for_addresses.clone(),
+                )
+            };
+
+            for address in addresses {
+                // Only the address and LUID are populated, mirroring the incomplete row that
+                // Windows hands to the callback.
+                let row = MIB_UNICASTIPADDRESS_ROW {
+                    InterfaceLuid: luid,
+                    Address: inet_sockaddr_from_socketaddr(SocketAddr::new(address, 0)),
+                    ..MIB_UNICASTIPADDRESS_ROW::default()
+                };
+                // SAFETY: Caller provided valid cb.
+                unsafe { cb(ctx.callercontext, &raw const row, MibAddInstance) };
+            }
+        });
+
+        let h = Box::into_raw(Box::new(NotifyHandle { handle: thread }));
+        // SAFETY: Valid receiver for a `c_void` pointer.
+        unsafe { *notificationhandle = h as *mut core::ffi::c_void };
+
+        0
+    }
+
+    pub unsafe fn fake_get_unicast_ip_address_entry(
+        row: *mut MIB_UNICASTIPADDRESS_ROW,
+    ) -> WIN32_ERROR {
+        // SAFETY: The caller passes an initialized row containing an address and LUID.
+        let address = try_socketaddr_from_inet_sockaddr(unsafe { (*row).Address })
+            .unwrap()
+            .ip();
+
+        let settings = ADDRESS_SETTINGS.lock().unwrap();
+        match settings
+            .dad_states
+            .iter()
+            .find(|(candidate, _)| candidate == &address)
+        {
+            Some(&(_, dad_state)) => {
+                // SAFETY: See above.
+                unsafe { (*row).DadState = dad_state };
+                0
+            }
+            None => ERROR_NOT_FOUND,
+        }
     }
 
     pub unsafe fn fake_cancel_mib_change_notify2(notificationhandle: HANDLE) -> WIN32_ERROR {
@@ -823,5 +1146,82 @@ mod tests {
 
         let luid = NOTIFY_SETTINGS.lock().unwrap().expected_luid;
         wait_for_interfaces_sync(luid, true, true, Duration::from_secs(1)).unwrap();
+    }
+
+    const ADDR_V4: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 64, 0, 2));
+    const ADDR_V6: IpAddr = IpAddr::V6(Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 2));
+
+    /// Test [`wait_for_addresses_sync`] using mocked notifications.
+    // This can be tested with miri:
+    //
+    // ```rust
+    // cargo +nightly miri test -p talpid-windows -- test_wait_for_addresses_sync
+    // ```
+    #[test]
+    fn test_wait_for_addresses_sync() {
+        let _guard = NOTIFY_LOCK.blocking_lock();
+
+        let luid = ADDRESS_SETTINGS.lock().unwrap().expected_luid;
+
+        // The addresses are already preferred
+        {
+            let mut settings = ADDRESS_SETTINGS.lock().unwrap();
+            *settings = AddressSettings::default();
+            settings.dad_states = vec![
+                (ADDR_V4, IpDadStatePreferred),
+                (ADDR_V6, IpDadStatePreferred),
+            ];
+        }
+        wait_for_addresses_sync(luid, &[ADDR_V4, ADDR_V6], Duration::from_secs(1)).unwrap();
+
+        // The addresses have not been added yet, and show up preferred later on
+        {
+            let mut settings = ADDRESS_SETTINGS.lock().unwrap();
+            *settings = AddressSettings::default();
+            settings.sleep_duration = Some(Duration::from_millis(10));
+            settings.dad_states_on_notify = Some(vec![
+                (ADDR_V4, IpDadStatePreferred),
+                (ADDR_V6, IpDadStatePreferred),
+            ]);
+            settings.send_add_event_for_addresses = vec![ADDR_V4, ADDR_V6];
+        }
+        wait_for_addresses_sync(luid, &[ADDR_V4, ADDR_V6], Duration::from_secs(1)).unwrap();
+
+        // The address is added, but remains tentative
+        {
+            let mut settings = ADDRESS_SETTINGS.lock().unwrap();
+            *settings = AddressSettings::default();
+            settings.dad_states_on_notify = Some(vec![(ADDR_V4, IpDadStateTentative)]);
+            settings.send_add_event_for_addresses = vec![ADDR_V4];
+        }
+        wait_for_addresses_sync(luid, &[ADDR_V4], Duration::from_millis(50)).unwrap_err();
+
+        // Only one of the two addresses is ever added
+        {
+            let mut settings = ADDRESS_SETTINGS.lock().unwrap();
+            *settings = AddressSettings::default();
+            settings.dad_states_on_notify = Some(vec![(ADDR_V4, IpDadStatePreferred)]);
+            settings.send_add_event_for_addresses = vec![ADDR_V4];
+        }
+        wait_for_addresses_sync(luid, &[ADDR_V4, ADDR_V6], Duration::from_millis(50)).unwrap_err();
+
+        // Duplicate address detection fails
+        {
+            let mut settings = ADDRESS_SETTINGS.lock().unwrap();
+            *settings = AddressSettings::default();
+            settings.dad_states_on_notify = Some(vec![(ADDR_V4, IpDadStateDuplicate)]);
+            settings.send_add_event_for_addresses = vec![ADDR_V4];
+        }
+        wait_for_addresses_sync(luid, &[ADDR_V4], Duration::from_secs(1)).unwrap_err();
+
+        // The address is never added at all
+        {
+            let mut settings = ADDRESS_SETTINGS.lock().unwrap();
+            *settings = AddressSettings::default();
+        }
+        wait_for_addresses_sync(luid, &[ADDR_V4], Duration::from_millis(10)).unwrap_err();
+
+        // Waiting for no addresses at all succeeds immediately
+        wait_for_addresses_sync(luid, &[], Duration::from_millis(1)).unwrap();
     }
 }

--- a/talpid-wireguard/src/ephemeral.rs
+++ b/talpid-wireguard/src/ephemeral.rs
@@ -40,6 +40,10 @@ pub async fn config_ephemeral_peers(
     log::trace!("Temporarily lowering tunnel MTU before ephemeral peer config");
     try_set_ipv4_mtu(&iface_name, talpid_tunnel::MIN_IPV4_MTU);
 
+    // A route on an interface that is not connected cannot be used, and we are about to connect
+    // to the config service through the tunnel.
+    wait_for_connected_interface(&iface_name).await;
+
     config_ephemeral_peers_inner(
         tunnel,
         config,
@@ -54,6 +58,75 @@ pub async fn config_ephemeral_peers(
     try_set_ipv4_mtu(&iface_name, config.mtu);
 
     Ok(())
+}
+
+/// Waits briefly for the tunnel IPv4 interface to report itself as connected. Logs if it is not
+/// already connected, since that means we were about to use a tunnel that Windows had not
+/// finished plumbing.
+///
+/// A route on an interface that is not connected cannot be used, so the connect that follows
+/// would be routed out some other interface and blocked by the firewall, surfacing as WSAEACCES.
+/// Whether that is what actually happens to the config service connect is not established -- the
+/// log line is here to tell us.
+///
+/// This never fails the tunnel: it is a diagnostic, and the connection is attempted either way.
+#[cfg(target_os = "windows")]
+async fn wait_for_connected_interface(alias: &str) {
+    use talpid_types::ErrorExt;
+    use talpid_windows::net::{AddressFamily, get_ip_interface_entry, luid_from_alias};
+
+    /// How long to wait for the interface to report itself as connected.
+    const CONNECTED_CHECK_TIMEOUT: Duration = Duration::from_millis(500);
+    /// How long to wait between those checks.
+    const CONNECTED_CHECK_INTERVAL: Duration = Duration::from_millis(10);
+
+    let luid = match luid_from_alias(alias) {
+        Ok(luid) => luid,
+        Err(error) => {
+            log::error!(
+                "{}",
+                error.display_chain_with_msg("Failed to obtain tunnel interface LUID")
+            );
+            return;
+        }
+    };
+
+    let start = Instant::now();
+    let mut was_disconnected = false;
+
+    loop {
+        match get_ip_interface_entry(AddressFamily::Ipv4, &luid) {
+            Ok(row) if row.Connected => {
+                if was_disconnected {
+                    log::debug!(
+                        "Tunnel IP interface became connected after {:?}",
+                        start.elapsed()
+                    );
+                }
+                return;
+            }
+            Ok(_) => {
+                if !was_disconnected {
+                    log::debug!("Tunnel IP interface is not connected yet");
+                    was_disconnected = true;
+                }
+            }
+            Err(error) => {
+                log::error!("Failed to obtain tunnel IP interface: {error}");
+                return;
+            }
+        }
+
+        if start.elapsed() >= CONNECTED_CHECK_TIMEOUT {
+            log::warn!(
+                "Tunnel IP interface is still not connected after {:?}",
+                start.elapsed()
+            );
+            return;
+        }
+
+        tokio::time::sleep(CONNECTED_CHECK_INTERVAL).await;
+    }
 }
 
 #[cfg(windows)]

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -690,13 +690,13 @@ impl WireguardMonitor {
                 // Tunnel was shut down early
                 CloseMsg::SetupError(Error::IpInterfacesError)
             })?
-            .map_err(|error| {
+            .inspect_err(|error| {
                 log::error!(
                     "{}",
                     error.display_chain_with_msg("Failed to configure tunnel interface")
                 );
-                CloseMsg::SetupError(Error::IpInterfacesError)
-            })?;
+            })
+            .map_err(|_| CloseMsg::SetupError(Error::IpInterfacesError))?;
 
         // TODO: The LUID can be obtained directly.
         let luid = talpid_windows::net::luid_from_alias(iface_name).map_err(|error| {
@@ -707,6 +707,20 @@ impl WireguardMonitor {
             talpid_windows::net::add_ip_address_for_interface(luid, *address)
                 .map_err(|error| CloseMsg::SetupError(Error::SetIpAddressesError(error)))?;
         }
+
+        // Wait for the addresses to become usable. Until they are, they cannot be selected as
+        // source addresses, so connections made this early may be routed out another interface and
+        // blocked (WSAEACCES). Suspected, not confirmed: they are normally usable right away.
+        talpid_windows::net::wait_for_addresses(luid, addresses.to_vec())
+            .await
+            .inspect_err(|error| {
+                log::error!(
+                    "{}",
+                    error.display_chain_with_msg("Failed to wait for tunnel IP addresses")
+                );
+            })
+            .map_err(|_| CloseMsg::SetupError(Error::IpInterfacesError))?;
+
         Ok(())
     }
 

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -3782,6 +3782,7 @@ name = "talpid-windows"
 version = "0.0.0"
 dependencies = [
  "futures",
+ "log",
  "socket2 0.6.5",
  "talpid-types",
  "thiserror 2.0.18",


### PR DESCRIPTION
Some users reported that connecting to the ephemeral peer service failed due to `WSAEACCES`/`10013` in 2026.4, and also in 2026.3, but less often:

```
[2026-08-24 13:23:41.070] DEBUG talpid_wireguard::wireguard_nt: Waiting for tunnel IP interfaces to arrive
[2026-08-24 13:23:41.071] DEBUG talpid_wireguard::wireguard_nt: Waiting for tunnel IP interfaces: Done
[2026-08-24 13:23:41.287] DEBUG talpid_wireguard::ephemeral: Requesting ephemeral peer
[2026-08-24 13:23:41.287] DEBUG talpid_tunnel_config_client: Connecting to relay config service at [REDACTED]
[2026-08-24 13:23:41.290] DEBUG talpid_wireguard: Tunnel was closed: Ok(
    SetupError(
        EphemeralPeerNegotiationError(
            GrpcConnectError(
                tonic::transport::Error(
                    Transport,
                    ConnectError(
                        Os {
                            code: 10013,
                            kind: PermissionDenied,
                            message: "An attempt was made to access a socket in a way forbidden by its access permissions.",
                        },
                    ),
                ),
            ),
        ),
    ),
)
```

A plausible explanation is that `10.64.0.1` is routed to the default interface and blocked by WFP.

This PR adds 3 mitigations:
* Wait for the tunnel IP addresses (and routes) to become usable after adding them. [`CreateUnicastIpAddressEntry`](https://learn.microsoft.com/en-us/windows/win32/api/netioapi/nf-netioapi-createunicastipaddressentry) docs mention this, though it's not entirely clear if it's necessary even when duplicate address detection is disabled (which it is in our case).
* Wait for the `Connected` field of [`MIB_IPINTERFACE_ROW`](https://learn.microsoft.com/en-us/windows/win32/api/netioapi/ns-netioapi-mib_ipinterface_row) to flip to true. Same theory: route might be ignored if it is racy for whatever reason.
* Belt and suspenders: Retry the `connect()` call itself if it fails. The issue was present for some of these users in 2026.3 but only *sometimes*, which is a hint that it's a race. So retrying should help.

## Testing

* Re-enabled DAD on the TUN device. `wait_for_addresses[_sync]` handled this case as expected. I wasn't able to reproduce the racy `MibAddInstance` case without DAD.
* I used `netsh advfirewall` to temporarily block `10.64.0.1:1337/TCP` the `connect()` call. Retry logic worked as intended and recovered when the rule was removed:

```
[2026-09-04 13:54:48.400] DEBUG talpid_tunnel_config_client: Connecting to relay config service at 10.64.0.1
[2026-09-04 13:54:48.574] DEBUG talpid_tunnel_config_client: Connection to 10.64.0.1:1337 failed with WSAEACCES. Retrying
...
[2026-09-04 13:54:49.035] DEBUG talpid_tunnel_config_client: Connection to 10.64.0.1:1337 failed with WSAEACCES. Retrying
[2026-09-04 13:54:49.204]  WARN talpid_tunnel_config_client: Connection to 10.64.0.1:1337 succeeded on attempt 9 after 631.1683ms, having failed with WSAEACCES
[2026-09-04 13:54:49.205] DEBUG talpid_tunnel_config_client: Connected to relay config service at 10.64.0.1
[2026-09-04 13:54:49.237] DEBUG talpid_tunnel_config_client: Generated quantum-resistant key exchange material in 31 ms
```

* I could not reproduce `Connected=false`, so I could not test that case.

Fix DES-3193

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11089)
<!-- Reviewable:end -->
