### PR TITLE
Bump `android-nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776717890,
-        "narHash": "sha256-Sa+pki/B361TigSv2Ipkj0qSoJw8P44c4rUjqhmiUQs=",
+        "lastModified": 1788473784,
+        "narHash": "sha256-EwAe3zYEbHBdD0Sz1Ix68fT5DVBcS5qoDnYXfBjYdss=",
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "77f1c65db15624af98a6b670e386f4cb57b2d62b",
+        "rev": "617ce582adcb7bd8fce6b261fa6f1ae710a29c2f",
         "type": "github"
       },
       "original": {
@@ -30,11 +30,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768818222,
-        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
+        "lastModified": 1788342953,
+        "narHash": "sha256-EWkNM4JzBhZ/Yn1PG6lP4/QJuFAFeHYlY5gVxXu940Y=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
+        "rev": "a67c0f87b63bcbdbdcb56785bec0205a2e3d6026",
         "type": "github"
       },
       "original": {

--- a/nix/android-toolchain.nix
+++ b/nix/android-toolchain.nix
@@ -34,7 +34,9 @@ let
           (builtins.getAttr "platforms-android-${compileSdkVersion}-${compileSdkMinorVersion}" sdkPkgs)
           (builtins.getAttr "build-tools-${builtins.replaceStrings [ "." ] [ "-" ] buildToolsVersion}" sdkPkgs)
           (builtins.getAttr "ndk-${builtins.replaceStrings [ "." ] [ "-" ] ndkVersion}" sdkPkgs)
-          cmdline-tools-latest
+          # Pin command line tools to version 22 due to version 23 introducing nix breaking changes.
+          # https://github.com/tadfisher/android-nixpkgs/issues/134
+          cmdline-tools-22-0
           platform-tools
         ]
       );


### PR DESCRIPTION
Bump `android-nixpkgs` to make newer SDK versions and tools available.

Also pins the command line tools to version 22 due to version 23 introducing nix breaking changes with the new Android CLI. See the following issue for more information: https://github.com/tadfisher/android-nixpkgs/issues/134

Follow-up to: #11070 
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11092)
<!-- Reviewable:end -->
