### PR TITLE
Fix ephemeral peer TCP options

### DIFF
--- a/talpid-tunnel-config-client/Cargo.toml
+++ b/talpid-tunnel-config-client/Cargo.toml
@@ -28,7 +28,7 @@ prost = { workspace = true }
 # ml-kem still depends on rand_core 0.6 as of ml-kem 0.21
 rand_core = { version = "0.6", features = ["getrandom"] }
 sha2 = { workspace = true }
-socket2 = { workspace = true}
+socket2 = { workspace = true }
 talpid-types = { path = "../talpid-types" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tonic = { workspace = true }

--- a/talpid-tunnel-config-client/Cargo.toml
+++ b/talpid-tunnel-config-client/Cargo.toml
@@ -28,7 +28,7 @@ prost = { workspace = true }
 # ml-kem still depends on rand_core 0.6 as of ml-kem 0.21
 rand_core = { version = "0.6", features = ["getrandom"] }
 sha2 = { workspace = true }
-socket2 = { workspace = true }
+socket2 = { workspace = true}
 talpid-types = { path = "../talpid-types" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tonic = { workspace = true }

--- a/talpid-tunnel-config-client/src/socket.rs
+++ b/talpid-tunnel-config-client/src/socket.rs
@@ -18,9 +18,10 @@ const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Number of unacknowledged keepalive probes before giving up.
 ///
-/// NOTE: only effective on macOS. On Linux this is overridden by
-/// `TCP_USER_TIMEOUT` and it is a noop on Windows.
-const KEEPALIVE_RETRIES: u32 = 3;
+/// Together with the one-second idle time and interval, this gives an
+/// unresponsive peer roughly eleven seconds to recover. On Linux,
+/// `TCP_USER_TIMEOUT` takes precedence.
+const KEEPALIVE_RETRIES: u32 = 10;
 
 /// TCP socket with parameters that prioritize reliability.
 ///
@@ -39,7 +40,7 @@ impl TcpSocket {
         let socket = TokioTcpSocket::new_v4()?;
         // Send small gRPC frames immediately.
         if let Err(e) = socket.set_nodelay(true) {
-            log::warn!("Failed to set TCP_NODELAY on tunnel config socket: {e}");
+            log_socket_option_error("TCP_NODELAY", e);
         }
 
         let sock_ref = socket2::SockRef::from(&socket);
@@ -51,7 +52,7 @@ impl TcpSocket {
             .with_interval(KEEPALIVE_INTERVAL)
             .with_retries(KEEPALIVE_RETRIES);
         if let Err(e) = sock_ref.set_tcp_keepalive(&keepalive) {
-            log::warn!("Failed to set TCP keepalive on tunnel config socket: {e}");
+            log_socket_option_error("TCP keepalive", e);
         }
 
         #[cfg(unix)]
@@ -104,8 +105,7 @@ impl std::os::windows::io::AsSocket for TcpSocket {
 ///
 /// - `TCP_RTO_MAX_MS` sets an upper bound on time between retries for unAck'ed data.
 /// - `TCP_SYNCNT` sets the number of retries for the `SYN` packet, i.e. handshake inits.
-/// - `TCP_USER_TIMEOUT` sets a timeout on ACKs for transmitted data, but only comes into
-///   effect after the handshake is complete.
+/// - `TCP_USER_TIMEOUT` bounds how long transmitted data may remain unACK'ed.
 ///
 /// Together with the keepalives, which only prove the connection when no data is exchanged,
 /// they should cover the three phases: handshake, sending the `EphemeralPeerRequestV1` and
@@ -114,39 +114,31 @@ impl std::os::windows::io::AsSocket for TcpSocket {
 fn set_linux_reliability_params(socket: &TokioTcpSocket) {
     use nix::sys::socket::sockopt::TcpUserTimeout;
 
-    // SYN retransmits before aborting the handshake. Default is 6.
+    // SYN retransmits before aborting the handshake. The default is 6. Keep this above
+    // the default so that the one-second RTO cap does not exhaust the retry count before
+    // TCP_USER_TIMEOUT.
     const TCP_SYNCNT_VALUE: u32 = 10;
 
     // Cap on the retransmit timeout. Default is 120 seconds.
-    // Only support on Linux 6.15+; older kernels return `ENOPROTOOPT`.
+    // Only supported on Linux 6.15+.
     const TCP_RTO_MAX_MS_VALUE: u32 = 1_000;
 
-    // The default values of these parameters cause handshakes to time out
-    // after ~127 s. The new parameters lower this to ~10 seconds.
+    // On Linux 6.15+, TCP_SYNCNT and the RTO cap allow roughly ten rapid SYN
+    // retransmissions. On older kernels, TCP_USER_TIMEOUT bounds the handshake.
 
-    // Progress-based deadline (ms) for the established phase: measured from
-    // the oldest unACK'ed data, so it advances on ACK progress and only fires
-    // when there is none. Set below the outer 30 s app timeout.
+    // Progress-based deadline (ms) for unACK'ed data: measured from the oldest
+    // unACK'ed data, so it advances on ACK progress and only fires when there is
+    // none. On older Linux kernels, this does not apply to the TCP handshake.
     const USER_TIMEOUT_MS: u32 = 12_000;
 
-    if let Err(e) = nix::sys::socket::setsockopt(socket, sockopt::TcpSyncnt, &TCP_SYNCNT_VALUE) {
-        log::warn!("Failed to set TCP_SYNCNT on tunnel config socket: {e}");
-    }
-
-    if let Err(e) =
-        nix::sys::socket::setsockopt(socket, sockopt::TcpRtoMaxMs, &TCP_RTO_MAX_MS_VALUE)
-    {
-        log::debug!("Failed to set TCP_RTO_MAX_MS on tunnel config socket: {e}");
-    }
-
-    if let Err(e) = nix::sys::socket::setsockopt(socket, TcpUserTimeout, &USER_TIMEOUT_MS) {
-        log::warn!("Failed to set TCP_USER_TIMEOUT on tunnel config socket: {e}");
-    }
+    set_socket_option(socket, linux_sockopt::TcpSyncnt, &TCP_SYNCNT_VALUE);
+    set_socket_option(socket, linux_sockopt::TcpRtoMaxMs, &TCP_RTO_MAX_MS_VALUE);
+    set_socket_option(socket, TcpUserTimeout, &USER_TIMEOUT_MS);
 }
 
 /// nix 0.31 sockopt types for `TCP_SYNCNT` and `TCP_RTO_MAX_MS`.
 #[cfg(target_os = "linux")]
-mod sockopt {
+mod linux_sockopt {
     use nix::{getsockopt_impl, setsockopt_impl, sockopt_impl};
 
     sockopt_impl!(TcpSyncnt, Both, libc::IPPROTO_TCP, libc::TCP_SYNCNT, u32);
@@ -161,43 +153,36 @@ mod sockopt {
 ///
 /// - `TCP_CONNECTIONTIMEOUT`: timeout (seconds) for the handshake phase.
 /// - `TCP_RXT_CONNDROPTIME`: time (seconds) after which a connection is dropped
-///   if retransmissions keep failing. Unlike Linux's `TCP_USER_TIMEOUT`, this
-///   is a flat timer. It does not reset on progress. Keepalives (with retries)
+///   during a retransmission episode. ACK progress resets the episode. Keepalives
 ///   cover the idle wait for the response.
 #[cfg(target_os = "macos")]
 fn set_macos_reliability_params(socket: &TokioTcpSocket) {
-    use nix::sys::socket::{setsockopt, sockopt};
-
     // Handshake timeout (seconds). Default is system-wide (net.inet.tcp.keepinit,
     // ~75 s). Set lower to fail fast on a dead relay.
     const TCP_CONNECTIONTIMEOUT_VALUE: u32 = 10;
 
-    // Flat deadline (seconds) for retransmit storms in the established phase.
-    // Drops the connection after this many seconds of failed retransmits.
+    // Deadline (seconds) for a retransmission episode in the established phase.
+    // ACK progress resets the episode.
     const TCP_RXT_CONNDROPTIME_VALUE: u32 = 12;
 
-    if let Err(e) = setsockopt(
+    set_socket_option(
         socket,
-        sockopt::TcpConnectionTimeout,
+        macos_sockopt::TcpConnectionTimeout,
         &TCP_CONNECTIONTIMEOUT_VALUE,
-    ) {
-        log::warn!("Failed to set TCP_CONNECTIONTIMEOUT on tunnel config socket: {e}");
-    }
+    );
 
-    if let Err(e) = setsockopt(
+    set_socket_option(
         socket,
-        sockopt::TcpRxtConnDropTime,
+        macos_sockopt::TcpRxtConnDropTime,
         &TCP_RXT_CONNDROPTIME_VALUE,
-    ) {
-        log::warn!("Failed to set TCP_RXT_CONNDROPTIME on tunnel config socket: {e}");
-    }
+    );
 }
 
 /// nix 0.31 does not expose sockopt types for `TCP_CONNECTIONTIMEOUT` or
 /// `TCP_RXT_CONNDROPTIME`. Neither constant is in libc, so they are declared
 /// locally.
 #[cfg(target_os = "macos")]
-mod sockopt {
+mod macos_sockopt {
     use nix::{getsockopt_impl, setsockopt_impl, sockopt_impl};
 
     // From <netinet/tcp.h> on macOS.
@@ -221,6 +206,41 @@ mod sockopt {
     );
 }
 
+/// Set a nix socket option, logging unsupported options quietly while
+/// surfacing invalid values and other unexpected failures.
+#[cfg(unix)]
+fn set_socket_option<F, O>(socket: &F, option: O, value: &O::Val)
+where
+    F: std::os::fd::AsFd,
+    O: nix::sys::socket::SetSockOpt + std::fmt::Debug,
+{
+    if let Err(error) = option.set(socket, value) {
+        log_socket_option_error(&format!("{option:?}"), error);
+    }
+}
+
+/// Log unavailable socket options quietly while surfacing invalid values and
+/// other unexpected failures.
+fn log_socket_option_error(option: &str, error: impl Into<io::Error>) {
+    let error = error.into();
+    if error.raw_os_error().is_some_and(unsupported_socket_option) {
+        log::debug!("Socket option {option} is not supported: {error}");
+    } else {
+        log::warn!("Failed to set socket option {option}: {error}");
+    }
+}
+
+#[cfg(unix)]
+fn unsupported_socket_option(code: i32) -> bool {
+    code == libc::ENOPROTOOPT || code == libc::EOPNOTSUPP
+}
+
+#[cfg(windows)]
+fn unsupported_socket_option(code: i32) -> bool {
+    use windows_sys::Win32::Networking::WinSock::{WSAENOPROTOOPT, WSAEOPNOTSUPP};
+    code == WSAENOPROTOOPT || code == WSAEOPNOTSUPP
+}
+
 /// MTU to set on the tunnel config client socket. We want a low value to prevent fragmentation.
 /// Especially on Android, we've found that the real MTU is often lower than the default MTU, and
 /// we cannot lower it further. This causes the outer packets to be dropped. Also, MTU detection
@@ -232,13 +252,11 @@ const CONFIG_CLIENT_MTU: u16 = 576;
 
 #[cfg(unix)]
 fn try_set_tcp_sock_mtu(sock: &impl std::os::fd::AsFd) {
-    use nix::sys::socket::{setsockopt, sockopt::TcpMaxSeg};
+    use nix::sys::socket::sockopt::TcpMaxSeg;
 
     let mss = u32::from(desired_mss());
     log::debug!("Tunnel config TCP socket MSS: {mss}");
-    if let Err(e) = setsockopt(sock, TcpMaxSeg, &mss) {
-        log::warn!("Failed to set MSS on tunnel config TCP socket: {e}");
-    };
+    set_socket_option(sock, TcpMaxSeg, &mss);
 }
 
 #[cfg(unix)]

--- a/talpid-tunnel-config-client/src/socket.rs
+++ b/talpid-tunnel-config-client/src/socket.rs
@@ -16,6 +16,20 @@ const KEEPALIVE_TIME: Duration = Duration::from_secs(1);
 /// Time between keepalive probes.
 const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(1);
 
+/// Number of unacknowledged keepalive probes before giving up.
+///
+/// NOTE: only effective on macOS. On Linux this is overridden by
+/// `TCP_USER_TIMEOUT` and it is a noop on Windows.
+const KEEPALIVE_RETRIES: u32 = 3;
+
+/// TCP socket with parameters that prioritize reliability.
+///
+/// This has various platform specific parameters to make the ephemeral peer handshake
+/// more reliable under poor network conditions.
+///
+/// This is achieved by increasing retransmissions and tuning timeout parameters, so that
+/// the session is kept alive for longer if progress is made, or shorter for dead
+/// connections.
 pub struct TcpSocket {
     socket: TokioTcpSocket,
 }
@@ -23,9 +37,31 @@ pub struct TcpSocket {
 impl TcpSocket {
     pub fn new() -> io::Result<Self> {
         let socket = TokioTcpSocket::new_v4()?;
+        // Send small gRPC frames immediately.
+        if let Err(e) = socket.set_nodelay(true) {
+            log::warn!("Failed to set TCP_NODELAY on tunnel config socket: {e}");
+        }
+
+        let sock_ref = socket2::SockRef::from(&socket);
+        // Increase keepalive frequency. This only affects the connection
+        // when no data is being sent, i.e. after sending the request and
+        // while waiting for the response.
+        let keepalive = socket2::TcpKeepalive::new()
+            .with_time(KEEPALIVE_TIME)
+            .with_interval(KEEPALIVE_INTERVAL)
+            .with_retries(KEEPALIVE_RETRIES);
+        if let Err(e) = sock_ref.set_tcp_keepalive(&keepalive) {
+            log::warn!("Failed to set TCP keepalive on tunnel config socket: {e}");
+        }
+
         #[cfg(unix)]
         try_set_tcp_sock_mtu(&socket);
-        set_reliability_params(&socket);
+
+        #[cfg(target_os = "linux")]
+        set_linux_reliability_params(&socket);
+
+        #[cfg(target_os = "macos")]
+        set_macos_reliability_params(&socket);
         Ok(Self { socket })
     }
 
@@ -64,35 +100,6 @@ impl std::os::windows::io::AsSocket for TcpSocket {
     }
 }
 
-/// Set TCP parameters that prioritize reliability.
-///
-/// This sets various platform specific parameters to make the ephemeral peer handshake
-/// more reliable under poor network conditions.
-///
-/// We do this by increasing retransmissions and tuning timeout parameters, so that
-/// the session is kept alive for longer if progress is made, or shorter for dead
-/// connections.
-fn set_reliability_params(socket: &TokioTcpSocket) {
-    // Send small gRPC frames immediately.
-    if let Err(e) = socket.set_nodelay(true) {
-        log::error!("Failed to set TCP_NODELAY on tunnel config socket: {e}");
-    }
-
-    let sock_ref = socket2::SockRef::from(socket);
-    // Increase keepalive frequency. This only affects the connection
-    // when no data is being sent, i.e. after sending the request and
-    // while waiting for the response.
-    let keepalive = socket2::TcpKeepalive::new()
-        .with_time(KEEPALIVE_TIME)
-        .with_interval(KEEPALIVE_INTERVAL);
-    if let Err(e) = sock_ref.set_tcp_keepalive(&keepalive) {
-        log::error!("Failed to set TCP keepalive on tunnel config socket: {e}");
-    }
-
-    #[cfg(target_os = "linux")]
-    set_linux_reliability_params(socket);
-}
-
 /// Sets the following TCP options to increase reliability:
 ///
 /// - `TCP_RTO_MAX_MS` sets an upper bound on time between retries for unAck'ed data.
@@ -123,7 +130,7 @@ fn set_linux_reliability_params(socket: &TokioTcpSocket) {
     const USER_TIMEOUT_MS: u32 = 12_000;
 
     if let Err(e) = nix::sys::socket::setsockopt(socket, sockopt::TcpSyncnt, &TCP_SYNCNT_VALUE) {
-        log::error!("Failed to set TCP_SYNCNT on tunnel config socket: {e}");
+        log::warn!("Failed to set TCP_SYNCNT on tunnel config socket: {e}");
     }
 
     if let Err(e) =
@@ -133,7 +140,7 @@ fn set_linux_reliability_params(socket: &TokioTcpSocket) {
     }
 
     if let Err(e) = nix::sys::socket::setsockopt(socket, TcpUserTimeout, &USER_TIMEOUT_MS) {
-        log::error!("Failed to set TCP_USER_TIMEOUT on tunnel config socket: {e}");
+        log::warn!("Failed to set TCP_USER_TIMEOUT on tunnel config socket: {e}");
     }
 }
 
@@ -148,6 +155,70 @@ mod sockopt {
     const TCP_RTO_MAX_MS: libc::c_int = 44;
 
     sockopt_impl!(TcpRtoMaxMs, Both, libc::IPPROTO_TCP, TCP_RTO_MAX_MS, u32);
+}
+
+/// Sets the following macOS-specific TCP options to increase reliability:
+///
+/// - `TCP_CONNECTIONTIMEOUT`: timeout (seconds) for the handshake phase.
+/// - `TCP_RXT_CONNDROPTIME`: time (seconds) after which a connection is dropped
+///   if retransmissions keep failing. Unlike Linux's `TCP_USER_TIMEOUT`, this
+///   is a flat timer. It does not reset on progress. Keepalives (with retries)
+///   cover the idle wait for the response.
+#[cfg(target_os = "macos")]
+fn set_macos_reliability_params(socket: &TokioTcpSocket) {
+    use nix::sys::socket::{setsockopt, sockopt};
+
+    // Handshake timeout (seconds). Default is system-wide (net.inet.tcp.keepinit,
+    // ~75 s). Set lower to fail fast on a dead relay.
+    const TCP_CONNECTIONTIMEOUT_VALUE: u32 = 10;
+
+    // Flat deadline (seconds) for retransmit storms in the established phase.
+    // Drops the connection after this many seconds of failed retransmits.
+    const TCP_RXT_CONNDROPTIME_VALUE: u32 = 12;
+
+    if let Err(e) = setsockopt(
+        socket,
+        sockopt::TcpConnectionTimeout,
+        &TCP_CONNECTIONTIMEOUT_VALUE,
+    ) {
+        log::warn!("Failed to set TCP_CONNECTIONTIMEOUT on tunnel config socket: {e}");
+    }
+
+    if let Err(e) = setsockopt(
+        socket,
+        sockopt::TcpRxtConnDropTime,
+        &TCP_RXT_CONNDROPTIME_VALUE,
+    ) {
+        log::warn!("Failed to set TCP_RXT_CONNDROPTIME on tunnel config socket: {e}");
+    }
+}
+
+/// nix 0.31 does not expose sockopt types for `TCP_CONNECTIONTIMEOUT` or
+/// `TCP_RXT_CONNDROPTIME`. Neither constant is in libc, so they are declared
+/// locally.
+#[cfg(target_os = "macos")]
+mod sockopt {
+    use nix::{getsockopt_impl, setsockopt_impl, sockopt_impl};
+
+    // From <netinet/tcp.h> on macOS.
+    const TCP_CONNECTIONTIMEOUT: libc::c_int = 0x20;
+    const TCP_RXT_CONNDROPTIME: libc::c_int = 0x80;
+
+    sockopt_impl!(
+        TcpConnectionTimeout,
+        Both,
+        libc::IPPROTO_TCP,
+        TCP_CONNECTIONTIMEOUT,
+        u32
+    );
+
+    sockopt_impl!(
+        TcpRxtConnDropTime,
+        Both,
+        libc::IPPROTO_TCP,
+        TCP_RXT_CONNDROPTIME,
+        u32
+    );
 }
 
 /// MTU to set on the tunnel config client socket. We want a low value to prevent fragmentation.
@@ -166,7 +237,7 @@ fn try_set_tcp_sock_mtu(sock: &impl std::os::fd::AsFd) {
     let mss = u32::from(desired_mss());
     log::debug!("Tunnel config TCP socket MSS: {mss}");
     if let Err(e) = setsockopt(sock, TcpMaxSeg, &mss) {
-        log::error!("Failed to set MSS on tunnel config TCP socket: {e}");
+        log::warn!("Failed to set MSS on tunnel config TCP socket: {e}");
     };
 }
 

--- a/talpid-tunnel-config-client/src/socket.rs
+++ b/talpid-tunnel-config-client/src/socket.rs
@@ -128,7 +128,7 @@ fn set_linux_reliability_params(socket: &TokioTcpSocket) {
 
     // Progress-based deadline (ms) for unACK'ed data: measured from the oldest
     // unACK'ed data, so it advances on ACK progress and only fires when there is
-    // none. On older Linux kernels, this does not apply to the TCP handshake.
+    // none. On Linux kernels older than 4.19, this does not apply to the TCP handshake.
     const USER_TIMEOUT_MS: u32 = 12_000;
 
     set_socket_option(socket, linux_sockopt::TcpSyncnt, &TCP_SYNCNT_VALUE);

--- a/talpid-tunnel-config-client/src/socket.rs
+++ b/talpid-tunnel-config-client/src/socket.rs
@@ -20,10 +20,10 @@ use tokio::net::TcpStream;
 const KEEPALIVE_TIME: Duration = Duration::from_secs(1);
 
 /// Time between keepalive probes.
-const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(2);
+const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Number of unacknowledged keepalive probes before giving up.
-const KEEPALIVE_RETRIES: u32 = 3;
+const KEEPALIVE_RETRIES: u32 = 10;
 
 pub struct TcpSocket {
     socket: TokioTcpSocket,

--- a/talpid-tunnel-config-client/src/socket.rs
+++ b/talpid-tunnel-config-client/src/socket.rs
@@ -1,11 +1,5 @@
 //! A TCP stream configured for reliability over throughput.
 //!
-//! The socket is configured with:
-//! - Low MSS (prevents MTU fragmentation)
-//! - TCP_NODELAY
-//! - TCP keepalives (detect dead connections quickly)
-//! - TCP_USER_TIMEOUT on Linux (kernel gives up if data isn't ACKed in time)
-//!
 //! On non-Windows targets the MSS is lowered via `setsockopt`. On Windows
 //! this doesn't work, so the MTU is temporarily lowered instead — see
 //! `talpid-wireguard/src/ephemeral.rs`.
@@ -21,9 +15,6 @@ const KEEPALIVE_TIME: Duration = Duration::from_secs(1);
 
 /// Time between keepalive probes.
 const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(1);
-
-/// Number of unacknowledged keepalive probes before giving up.
-const KEEPALIVE_RETRIES: u32 = 10;
 
 pub struct TcpSocket {
     socket: TokioTcpSocket,
@@ -73,7 +64,14 @@ impl std::os::windows::io::AsSocket for TcpSocket {
     }
 }
 
-/// Set TCP parameters that prioritize reliability and low latency over throughput.
+/// Set TCP parameters that prioritize reliability.
+///
+/// This sets various platform specific parameters to make the ephemeral peer handshake
+/// more reliable under poor network conditions.
+///
+/// We do this by increasing retransmissions and tuning timeout parameters, so that
+/// the session is kept alive for longer if progress is made, or shorter for dead
+/// connections.
 fn set_reliability_params(socket: &TokioTcpSocket) {
     // Send small gRPC frames immediately.
     if let Err(e) = socket.set_nodelay(true) {
@@ -81,13 +79,75 @@ fn set_reliability_params(socket: &TokioTcpSocket) {
     }
 
     let sock_ref = socket2::SockRef::from(socket);
+    // Increase keepalive frequency. This only affects the connection
+    // when no data is being sent, i.e. after sending the request and
+    // while waiting for the response.
     let keepalive = socket2::TcpKeepalive::new()
         .with_time(KEEPALIVE_TIME)
-        .with_interval(KEEPALIVE_INTERVAL)
-        .with_retries(KEEPALIVE_RETRIES);
+        .with_interval(KEEPALIVE_INTERVAL);
     if let Err(e) = sock_ref.set_tcp_keepalive(&keepalive) {
         log::error!("Failed to set TCP keepalive on tunnel config socket: {e}");
     }
+
+    #[cfg(target_os = "linux")]
+    set_linux_reliability_params(socket);
+}
+
+/// Sets the following TCP options to increase reliability:
+///
+/// - `TCP_RTO_MAX_MS` sets an upper bound on time between retries for unAck'ed data.
+/// - `TCP_SYNCNT` sets the number of retries for the `SYN` packet, i.e. handshake inits.
+/// - `TCP_USER_TIMEOUT` sets a timeout on ACKs for transmitted data, but only comes into
+///   effect after the handshake is complete.
+///
+/// Together with the keepalives, which only prove the connection when no data is exchanged,
+/// they should cover the three phases: handshake, sending the `EphemeralPeerRequestV1` and
+/// receiving the `EphemeralPeerResponseV1`.
+#[cfg(target_os = "linux")]
+fn set_linux_reliability_params(socket: &TokioTcpSocket) {
+    use nix::sys::socket::sockopt::TcpUserTimeout;
+
+    // SYN retransmits before aborting the handshake. Default is 6.
+    const TCP_SYNCNT_VALUE: u32 = 10;
+
+    // Cap on the retransmit timeout. Default is 120 seconds.
+    // Only support on Linux 6.15+; older kernels return `ENOPROTOOPT`.
+    const TCP_RTO_MAX_MS_VALUE: u32 = 1_000;
+
+    // The default values of these parameters cause handshakes to time out
+    // after ~127 s. The new parameters lower this to ~10 seconds.
+
+    // Progress-based deadline (ms) for the established phase: measured from
+    // the oldest unACK'ed data, so it advances on ACK progress and only fires
+    // when there is none. Set below the outer 30 s app timeout.
+    const USER_TIMEOUT_MS: u32 = 12_000;
+
+    if let Err(e) = nix::sys::socket::setsockopt(socket, sockopt::TcpSyncnt, &TCP_SYNCNT_VALUE) {
+        log::error!("Failed to set TCP_SYNCNT on tunnel config socket: {e}");
+    }
+
+    if let Err(e) =
+        nix::sys::socket::setsockopt(socket, sockopt::TcpRtoMaxMs, &TCP_RTO_MAX_MS_VALUE)
+    {
+        log::debug!("Failed to set TCP_RTO_MAX_MS on tunnel config socket: {e}");
+    }
+
+    if let Err(e) = nix::sys::socket::setsockopt(socket, TcpUserTimeout, &USER_TIMEOUT_MS) {
+        log::error!("Failed to set TCP_USER_TIMEOUT on tunnel config socket: {e}");
+    }
+}
+
+/// nix 0.31 sockopt types for `TCP_SYNCNT` and `TCP_RTO_MAX_MS`.
+#[cfg(target_os = "linux")]
+mod sockopt {
+    use nix::{getsockopt_impl, setsockopt_impl, sockopt_impl};
+
+    sockopt_impl!(TcpSyncnt, Both, libc::IPPROTO_TCP, libc::TCP_SYNCNT, u32);
+
+    // Requires Linux 6.15+ and is not yet exposed by libc.
+    const TCP_RTO_MAX_MS: libc::c_int = 44;
+
+    sockopt_impl!(TcpRtoMaxMs, Both, libc::IPPROTO_TCP, TCP_RTO_MAX_MS, u32);
 }
 
 /// MTU to set on the tunnel config client socket. We want a low value to prevent fragmentation.

--- a/talpid-tunnel-config-client/src/socket.rs
+++ b/talpid-tunnel-config-client/src/socket.rs
@@ -17,7 +17,7 @@ use tokio::net::TcpSocket as TokioTcpSocket;
 use tokio::net::TcpStream;
 
 /// Time before TCP starts sending keepalive probes.
-const KEEPALIVE_TIME: Duration = Duration::from_secs(5);
+const KEEPALIVE_TIME: Duration = Duration::from_secs(1);
 
 /// Time between keepalive probes.
 const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(2);
@@ -87,20 +87,6 @@ fn set_reliability_params(socket: &TokioTcpSocket) {
         .with_retries(KEEPALIVE_RETRIES);
     if let Err(e) = sock_ref.set_tcp_keepalive(&keepalive) {
         log::error!("Failed to set TCP keepalive on tunnel config socket: {e}");
-    }
-
-    // Linux: set TCP_USER_TIMEOUT so the kernel gives up if our data
-    // isn't ACKed within the specified time.
-    #[cfg(target_os = "linux")]
-    {
-        const USER_TIMEOUT_MS: u32 = 30_000;
-        if let Err(e) = nix::sys::socket::setsockopt(
-            socket,
-            nix::sys::socket::sockopt::TcpUserTimeout,
-            &USER_TIMEOUT_MS,
-        ) {
-            log::error!("Failed to set TCP_USER_TIMEOUT on tunnel config socket: {e}");
-        }
     }
 }
 

--- a/talpid-wireguard/src/ephemeral.rs
+++ b/talpid-wireguard/src/ephemeral.rs
@@ -280,7 +280,7 @@ async fn request_ephemeral_peer(
     );
     // On other platforms, we rely on TCP parameters for the timeout, and this
     // serves only as an upper bound. We do this as the kernel level timeouts
-    // are reset when we receive ACK's, allowing for longer attempts when when
+    // are reset when we receive ACK's, allowing for longer attempts when
     // progress is being made.
     #[cfg(not(windows))]
     let timeout = MAX_PSK_EXCHANGE_TIMEOUT;

--- a/talpid-wireguard/src/ephemeral.rs
+++ b/talpid-wireguard/src/ephemeral.rs
@@ -15,7 +15,13 @@ use talpid_tunnel_config_client::{DaitaSettings, EphemeralPeer};
 use talpid_types::net::wireguard::{PrivateKey, PublicKey};
 use tokio::sync::Mutex as AsyncMutex;
 
-const MAX_PSK_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_PSK_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(48);
+
+#[cfg(windows)]
+const INITIAL_PSK_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(8);
+
+#[cfg(windows)]
+const PSK_EXCHANGE_TIMEOUT_MULTIPLIER: u32 = 2;
 
 #[cfg(windows)]
 pub async fn config_ephemeral_peers(
@@ -263,6 +269,15 @@ async fn request_ephemeral_peer(
 ) -> std::result::Result<EphemeralPeer, CloseMsg> {
     log::debug!("Requesting ephemeral peer");
 
+    // Windows uses an exponential backup retry strategy, as we can't set socket
+    // parameters to time out when no progress is made.
+    #[cfg(windows)]
+    let timeout = std::cmp::min(
+        MAX_PSK_EXCHANGE_TIMEOUT,
+        INITIAL_PSK_EXCHANGE_TIMEOUT
+            .saturating_mul(PSK_EXCHANGE_TIMEOUT_MULTIPLIER.saturating_pow(retry_attempt)),
+    );
+    #[cfg(not(windows))]
     let timeout = MAX_PSK_EXCHANGE_TIMEOUT;
 
     // TCP socket with extra reliability settings

--- a/talpid-wireguard/src/ephemeral.rs
+++ b/talpid-wireguard/src/ephemeral.rs
@@ -279,9 +279,9 @@ async fn request_ephemeral_peer(
             .saturating_mul(PSK_EXCHANGE_TIMEOUT_MULTIPLIER.saturating_pow(retry_attempt)),
     );
     // On other platforms, we rely on TCP parameters for the timeout, and this
-    // servers only as an upper bound. We do this as the kernel level timeouts
-    // are reset we receive ACK's, allowing for longer attemps when when progress
-    // is being made.
+    // serves only as an upper bound. We do this as the kernel level timeouts
+    // are reset when we receive ACK's, allowing for longer attempts when when
+    // progress is being made.
     #[cfg(not(windows))]
     let timeout = MAX_PSK_EXCHANGE_TIMEOUT;
 

--- a/talpid-wireguard/src/ephemeral.rs
+++ b/talpid-wireguard/src/ephemeral.rs
@@ -18,7 +18,9 @@ use tokio::sync::Mutex as AsyncMutex;
 const MAX_PSK_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(48);
 
 #[cfg(windows)]
-const INITIAL_PSK_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(8);
+// Match the socket-level no-progress windows used on Linux and macOS. Later
+// attempts give a responsive-but-slow server progressively more time.
+const INITIAL_PSK_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(12);
 
 #[cfg(windows)]
 const PSK_EXCHANGE_TIMEOUT_MULTIPLIER: u32 = 2;
@@ -269,14 +271,17 @@ async fn request_ephemeral_peer(
 ) -> std::result::Result<EphemeralPeer, CloseMsg> {
     log::debug!("Requesting ephemeral peer");
 
-    // Windows uses an exponential backup retry strategy, as we can't set socket
-    // parameters to time out when no progress is made.
+    // Windows uses an exponential backoff retry strategy.
     #[cfg(windows)]
     let timeout = std::cmp::min(
         MAX_PSK_EXCHANGE_TIMEOUT,
         INITIAL_PSK_EXCHANGE_TIMEOUT
             .saturating_mul(PSK_EXCHANGE_TIMEOUT_MULTIPLIER.saturating_pow(retry_attempt)),
     );
+    // On other platforms, we rely on TCP parameters for the timeout, and this
+    // servers only as an upper bound. We do this as the kernel level timeouts
+    // are reset we receive ACK's, allowing for longer attemps when when progress
+    // is being made.
     #[cfg(not(windows))]
     let timeout = MAX_PSK_EXCHANGE_TIMEOUT;
 

--- a/talpid-wireguard/src/ephemeral.rs
+++ b/talpid-wireguard/src/ephemeral.rs
@@ -15,7 +15,7 @@ use talpid_tunnel_config_client::{DaitaSettings, EphemeralPeer};
 use talpid_types::net::wireguard::{PrivateKey, PublicKey};
 use tokio::sync::Mutex as AsyncMutex;
 
-const MAX_PSK_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(48);
+const MAX_PSK_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[cfg(windows)]
 pub async fn config_ephemeral_peers(

--- a/talpid-wireguard/src/ephemeral.rs
+++ b/talpid-wireguard/src/ephemeral.rs
@@ -15,9 +15,7 @@ use talpid_tunnel_config_client::{DaitaSettings, EphemeralPeer};
 use talpid_types::net::wireguard::{PrivateKey, PublicKey};
 use tokio::sync::Mutex as AsyncMutex;
 
-const INITIAL_PSK_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(8);
 const MAX_PSK_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(48);
-const PSK_EXCHANGE_TIMEOUT_MULTIPLIER: u32 = 2;
 
 #[cfg(windows)]
 pub async fn config_ephemeral_peers(
@@ -265,11 +263,7 @@ async fn request_ephemeral_peer(
 ) -> std::result::Result<EphemeralPeer, CloseMsg> {
     log::debug!("Requesting ephemeral peer");
 
-    let timeout = std::cmp::min(
-        MAX_PSK_EXCHANGE_TIMEOUT,
-        INITIAL_PSK_EXCHANGE_TIMEOUT
-            .saturating_mul(PSK_EXCHANGE_TIMEOUT_MULTIPLIER.saturating_pow(retry_attempt)),
-    );
+    let timeout = MAX_PSK_EXCHANGE_TIMEOUT;
 
     // TCP socket with extra reliability settings
     let tcp_socket = talpid_tunnel_config_client::socket::TcpSocket::new()
@@ -287,24 +281,18 @@ async fn request_ephemeral_peer(
         &tcp_socket,
     );
 
-    let ephemeral = match tokio::time::timeout(timeout, request_future).await {
-        Ok(result) => result
-            .map_err(Error::EphemeralPeerNegotiationError)
-            .map_err(CloseMsg::SetupError)?,
-        Err(_) => {
-            let elapsed = start_time.elapsed();
-            log::warn!(
-                "Timeout while negotiating ephemeral peer \
-                 (retry {retry_attempt}, timeout {timeout:?}, PQ={enable_pq}, \
-                 DAITA={enable_daita}, elapsed {elapsed:?})"
-            );
-            if let Some(info) = tcp_socket.query_tcp_info() {
-                log::warn!("{info:?}");
-            }
-
-            return Err(CloseMsg::EphemeralPeerNegotiationTimeout);
-        }
+    let msg = match tokio::time::timeout(timeout, request_future).await {
+        Ok(Ok(ephemeral)) => return Ok(ephemeral),
+        Ok(Err(err)) => CloseMsg::SetupError(Error::EphemeralPeerNegotiationError(err)),
+        Err(_) => CloseMsg::EphemeralPeerNegotiationTimeout,
     };
-
-    Ok(ephemeral)
+    let elapsed = start_time.elapsed();
+    log::warn!(
+        "Ephemeral peer negotiation failed after {elapsed:?}\
+        (retry {retry_attempt}, PQ={enable_pq}, DAITA={enable_daita})"
+    );
+    if let Some(info) = tcp_socket.query_tcp_info() {
+        log::warn!("{info:?}");
+    }
+    Err(msg)
 }


### PR DESCRIPTION
Follow up to #10999. The TCP options set in that PR weren't very effective, and the TCP info dump would only trigger if the outer tokio timeout triggered, not on the socket-level timeouts.

We now set several platform specific TCP socket parameters, except on Windows where they are not available at socket level.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11093)
<!-- Reviewable:end -->
