### PR TITLE
Update Snapfile to be compatible with newer runner

### DIFF
--- a/.github/workflows/ios-screenshots-creation.yml
+++ b/.github/workflows/ios-screenshots-creation.yml
@@ -50,8 +50,30 @@ jobs:
         run: bundle exec fastlane snapshot --cloned_source_packages_path "$SOURCE_PACKAGES_PATH"
         working-directory: ios
 
+      - name: Determine artifact name
+        id: artifact-name
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          SHA: ${{ github.sha }}
+        run: |
+          if [ "$REF_TYPE" = "tag" ]; then
+            name="$REF_NAME"
+          else
+            name="${HEAD_REF:-$REF_NAME}-$(date -u +%Y%m%d)-${SHA:0:7}"
+          fi
+          stripped_name=$(printf '%s' "$name" | \
+                                  sed -e 's/[^[:alnum:]_-]/-/g' \
+                                    -e 's/--*/-/g' \
+                                    -e 's/^-//' \
+                                    -e 's/-$//')
+
+          # Artifact names may not contain path separators or other reserved characters.
+          echo "name=ios-screenshots-${stripped_name}" >> "$GITHUB_OUTPUT"
+
       - name: Upload screenshot artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: ios-screenshots
+          name: ${{ steps.artifact-name.outputs.name }}
           path: ios/Screenshots

--- a/ios/Snapfile
+++ b/ios/Snapfile
@@ -1,12 +1,9 @@
-ios_version '18.5'
-
-# A list of devices you want to take the screenshots from
+# A list of devices you want to take the screenshots from.
 devices([
-  "iPhone SE (3rd generation)",
-  "iPhone 16 Pro",
-  "iPhone 16 Pro Max",
-  "iPad Pro 11-inch (M4)",
-  "iPad Pro 13-inch (M4)"
+  "iPhone 17 Pro Max",
+  "iPhone 17",
+  "iPad Pro 13-inch (M5)",
+  "iPad Pro 11-inch (M5)"
 ])
 
 languages([

--- a/ios/TestPlans/MullvadVPNScreenshots.xctestplan
+++ b/ios/TestPlans/MullvadVPNScreenshots.xctestplan
@@ -19,7 +19,7 @@
   "testTargets" : [
     {
       "selectedTests" : [
-        "ScreenshotTests\/testTakeScreenshotOfAQuantumSecuredConnection()",
+        "ScreenshotTests\/testTakeScreenshotOfQuantumSecuredConnection()",
         "ScreenshotTests\/testTakeScreenshotOfAccount()",
         "ScreenshotTests\/testTakeScreenshotOfCustomListSelected()",
         "ScreenshotTests\/testTakeScreenshotOfDNSSettings()",


### PR DESCRIPTION
I've gone and udpated the `Snapfile` for the actual screenshots our CI job takes, and I've added another item to the xcode migration checklist. Since different GitHub runner images provide different devices, this job failed when we migrated to a newer Xcode version, I think.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11098)
<!-- Reviewable:end -->
