### PR TITLE
Reuse the tunnel interface between connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Reuse the tunnel adapter when reconnecting instead of creating a new one every time. This saves
   around 0.2 s when reconnecting.
+- Rename the tunnel adapter used by GotaTun to "Mullvad GotaTun". Both it and the "Mullvad" adapter
+  used by WireGuardNT are now kept alive between connections, so they cannot share a name.
 - Make the timestamps embedded in the Rust Windows binaries + winfw.dll deterministic.
   Required for reproducible builds.
 - Stop embedding absolute build machine PDB paths in the Rust Windows binaries + winfw.dll.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ Line wrap the file at 100 chars.                                              Th
   from Debian. `.rpm` packages are still signed, since dnf does verify that signature.
 
 #### Windows
+- Reuse the wintun adapter when reconnecting instead of creating a new one every time. This saves
+  around 0.2 s when reconnecting using GotaTun.
 - Make the timestamps embedded in the Rust Windows binaries + winfw.dll deterministic.
   Required for reproducible builds.
 - Stop embedding absolute build machine PDB paths in the Rust Windows binaries + winfw.dll.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,8 @@ Line wrap the file at 100 chars.                                              Th
   from Debian. `.rpm` packages are still signed, since dnf does verify that signature.
 
 #### Windows
-- Reuse the wintun adapter when reconnecting instead of creating a new one every time. This saves
-  around 0.2 s when reconnecting using GotaTun.
+- Reuse the tunnel adapter when reconnecting instead of creating a new one every time. This saves
+  around 0.2 s when reconnecting.
 - Make the timestamps embedded in the Rust Windows binaries + winfw.dll deterministic.
   Required for reproducible builds.
 - Stop embedding absolute build machine PDB paths in the Rust Windows binaries + winfw.dll.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6177,6 +6177,7 @@ dependencies = [
  "tokio",
  "tun 0.8.14",
  "windows-sys 0.61.2",
+ "wintun-bindings",
 ]
 
 [[package]]

--- a/talpid-tunnel/Cargo.toml
+++ b/talpid-tunnel/Cargo.toml
@@ -30,6 +30,7 @@ rtnetlink.workspace = true
 
 [target."cfg(windows)".dependencies]
 talpid-windows = { path = "../talpid-windows" }
+wintun-bindings = "0.7.39"
 
 [target."cfg(windows)".dependencies.windows-sys]
 workspace = true

--- a/talpid-tunnel/src/tun_provider/windows.rs
+++ b/talpid-tunnel/src/tun_provider/windows.rs
@@ -129,6 +129,28 @@ impl WindowsTunProvider {
         self.configured_addresses.clear();
     }
 
+    /// Remove the IP addresses that were added to the adapter, keeping the adapter itself alive.
+    ///
+    /// The tunnel addresses do not depend on which tunnel implementation is used, and Windows only
+    /// lets one interface have a given address, so an idle adapter must not hold on to them. The
+    /// adapter is destroyed, which also releases the addresses, if they cannot be removed.
+    pub fn release_addresses(&mut self) {
+        let Some(luid) = self.adapter.as_ref().map(|adapter| adapter.get_luid()) else {
+            return;
+        };
+
+        for address in std::mem::take(&mut self.configured_addresses) {
+            if let Err(error) = talpid_windows::net::delete_ip_address_for_interface(luid, address)
+            {
+                log::warn!(
+                    "Discarding the tunnel adapter, as an address could not be removed: {error}"
+                );
+                self.close_adapter();
+                return;
+            }
+        }
+    }
+
     fn open_tun_inner(&mut self) -> Result<WindowsTun, Error> {
         let has_ipv4 = self.config.addresses.iter().any(|addr| addr.is_ipv4());
         let has_ipv6 = self.config.addresses.iter().any(|addr| addr.is_ipv6());

--- a/talpid-tunnel/src/tun_provider/windows.rs
+++ b/talpid-tunnel/src/tun_provider/windows.rs
@@ -1,9 +1,19 @@
 use super::TunConfig;
+use std::sync::Arc;
 use std::time::Duration;
 use std::{io, net::IpAddr, ops::Deref};
 use tun::{self, AbstractDeviceExt};
 use tun::{AbstractDevice, AsyncDevice, Configuration};
 use windows_sys::Win32::NetworkManagement::Ndis::NET_LUID_LH;
+use wintun_bindings::Adapter;
+
+/// Tunnel adapter name
+const ADAPTER_NAME: &str = "Mullvad";
+/// Tunnel adapter GUID.
+/// Reuse the same ID, if possible. This prevents Windows from thinking it's a
+/// "new network".
+// {AFE43773-E1F8-4EBB-8536-576AB86AFE9A}
+const ADAPTER_GUID: u128 = 0xAFE4_3773_E1F8_4EBB_8536_576A_B86A_FE9A;
 
 /// Maximum time to wait for the tunnel IP addresses to complete duplicate address detection.
 const WAIT_FOR_ADDRESSES_TIMEOUT: Duration = Duration::from_secs(5);
@@ -14,6 +24,22 @@ pub enum Error {
     /// Failed to set IP address
     #[error("Failed to set IPv6 address")]
     SetIp(#[source] talpid_windows::net::Error),
+
+    /// Failed to remove an IP address that is no longer in use
+    #[error("Failed to remove a stale IP address")]
+    RemoveIp(#[source] talpid_windows::net::Error),
+
+    /// Failed to list the IP addresses of the tunnel device
+    #[error("Failed to list the addresses of the tunnel device")]
+    ListIps(#[source] talpid_windows::net::Error),
+
+    /// Failed to load wintun.dll
+    #[error("Failed to load wintun.dll")]
+    LoadWintun(#[source] wintun_bindings::Error),
+
+    /// Failed to create the wintun adapter
+    #[error("Failed to create the wintun adapter")]
+    CreateAdapter(#[source] wintun_bindings::Error),
 
     /// Unable to open a tunnel device
     #[error("Unable to open a tunnel device")]
@@ -51,11 +77,26 @@ pub enum Error {
 /// Factory of tunnel devices on Unix systems.
 pub struct WindowsTunProvider {
     config: TunConfig,
+    /// Keeps the wintun adapter alive between connections.
+    ///
+    /// Creating the adapter takes on the order of 200 ms, whereas opening an existing one takes
+    /// about 20 ms. Without this handle the adapter is destroyed as soon as the tunnel device is
+    /// dropped, and has to be created again for the next connection.
+    adapter: Option<Arc<Adapter>>,
+    /// The addresses that have been added to the adapter, so that they can be removed again.
+    ///
+    /// Only addresses added here are ever removed. Addresses that Windows assigns by itself, such
+    /// as link-local ones, are left alone.
+    configured_addresses: Vec<IpAddr>,
 }
 
 impl WindowsTunProvider {
     pub const fn new(config: TunConfig) -> Self {
-        WindowsTunProvider { config }
+        WindowsTunProvider {
+            config,
+            adapter: None,
+            configured_addresses: vec![],
+        }
     }
 
     /// Get the current tunnel config. Note that the tunnel must be recreated for any changes to
@@ -65,9 +106,28 @@ impl WindowsTunProvider {
     }
 
     /// Open a tunnel using the current tunnel config.
+    ///
+    /// The wintun adapter is reused if one is already open, and created otherwise. If anything
+    /// goes wrong the adapter is discarded, so that the next attempt starts from a new one.
     pub fn open_tun(&mut self) -> Result<WindowsTun, Error> {
+        self.open_tun_inner().inspect_err(|error| {
+            log::warn!("Discarding the tunnel adapter after a failure: {error}");
+            self.close_adapter();
+        })
+    }
+
+    /// Destroy the wintun adapter, if there is one. It is created again by the next
+    /// [`Self::open_tun`].
+    pub fn close_adapter(&mut self) {
+        self.adapter = None;
+        self.configured_addresses.clear();
+    }
+
+    fn open_tun_inner(&mut self) -> Result<WindowsTun, Error> {
         let has_ipv4 = self.config.addresses.iter().any(|addr| addr.is_ipv4());
         let has_ipv6 = self.config.addresses.iter().any(|addr| addr.is_ipv6());
+
+        self.open_adapter()?;
 
         let mut tunnel_device = {
             let mut builder = TunnelDeviceBuilder::default();
@@ -77,14 +137,6 @@ impl WindowsTunProvider {
             // routes the highest possible priority.
             builder.config.metric(1);
             builder.config.mtu(self.config.mtu);
-
-            /// Tunnel adapter name
-            const ADAPTER_NAME: &str = "Mullvad";
-            /// Tunnel adapter GUID.
-            /// Reuse the same ID, if possible. This prevents Windows from thinking it's a
-            /// "new network".
-            // {AFE43773-E1F8-4EBB-8536-576AB86AFE9A}
-            const ADAPTER_GUID: u128 = 0xAFE4_3773_E1F8_4EBB_8536_576A_B86A_FE9A;
 
             builder.config.tun_name(ADAPTER_NAME);
             builder
@@ -106,9 +158,7 @@ impl WindowsTunProvider {
 
         // TODO: `tun` currently cannot handle IPv6 without using netsh,
         // so we add IPs ourselves.
-        for ip in &self.config.addresses {
-            tunnel_device.set_ip(*ip)?;
-        }
+        self.configure_addresses(tunnel_device.luid())?;
 
         tunnel_device.set_up(true)?;
 
@@ -127,6 +177,60 @@ impl WindowsTunProvider {
         .map_err(Error::WaitForAddresses)?;
 
         Ok(WindowsTun(tunnel_device))
+    }
+
+    /// Create the wintun adapter, unless one is already open.
+    ///
+    /// Holding on to the adapter is what keeps it from being destroyed when the tunnel device is
+    /// dropped. `tun` opens the existing adapter by name rather than creating a new one.
+    fn open_adapter(&mut self) -> Result<(), Error> {
+        if self.adapter.is_some() {
+            return Ok(());
+        }
+
+        let wintun_path = self.config.resource_dir.join("wintun.dll");
+        // SAFETY: `wintun_path` refers to the wintun.dll shipped with the app.
+        let wintun =
+            unsafe { wintun_bindings::load_from_path(&wintun_path) }.map_err(Error::LoadWintun)?;
+        let adapter = Adapter::create(&wintun, ADAPTER_NAME, ADAPTER_NAME, Some(ADAPTER_GUID))
+            .map_err(Error::CreateAdapter)?;
+
+        self.adapter = Some(adapter);
+        self.configured_addresses.clear();
+
+        Ok(())
+    }
+
+    /// Give the tunnel device exactly the addresses in the current config.
+    ///
+    /// A reused adapter still has the addresses of the previous connection, and adding an address
+    /// that is already configured fails, so the addresses that are no longer wanted have to be
+    /// removed first.
+    fn configure_addresses(&mut self, luid: NET_LUID_LH) -> Result<(), Error> {
+        let addresses = self.config.addresses.clone();
+
+        for address in &self.configured_addresses {
+            if !addresses.contains(address) {
+                talpid_windows::net::delete_ip_address_for_interface(luid, *address)
+                    .map_err(Error::RemoveIp)?;
+            }
+        }
+
+        // The adapter may also have addresses that we did not add ourselves, either because it
+        // outlived a previous daemon or because Windows assigned them.
+        let existing =
+            talpid_windows::net::get_ip_addresses_for_interface(luid).map_err(Error::ListIps)?;
+
+        for address in &addresses {
+            if !existing.contains(address) {
+                talpid_windows::net::add_ip_address_for_interface(luid, *address)
+                    .map_err(Error::SetIp)?;
+            }
+        }
+
+        self.configured_addresses = addresses;
+
+        Ok(())
     }
 }
 
@@ -182,10 +286,10 @@ impl Default for TunnelDeviceBuilder {
 }
 
 impl TunnelDevice {
-    fn set_ip(&mut self, ip: IpAddr) -> Result<(), Error> {
-        let luid = self.dev.tun_luid();
-        let luid = NET_LUID_LH { Value: luid };
-        talpid_windows::net::add_ip_address_for_interface(luid, ip).map_err(Error::SetIp)
+    fn luid(&self) -> NET_LUID_LH {
+        NET_LUID_LH {
+            Value: self.dev.tun_luid(),
+        }
     }
 
     fn set_up(&mut self, up: bool) -> Result<(), Error> {

--- a/talpid-tunnel/src/tun_provider/windows.rs
+++ b/talpid-tunnel/src/tun_provider/windows.rs
@@ -7,8 +7,14 @@ use tun::{AbstractDevice, AsyncDevice, Configuration};
 use windows_sys::Win32::NetworkManagement::Ndis::NET_LUID_LH;
 use wintun_bindings::Adapter;
 
-/// Tunnel adapter name
-const ADAPTER_NAME: &str = "Mullvad";
+/// Tunnel adapter name.
+///
+/// This must differ from the name of the wireguard-nt adapter, since both adapters are kept alive
+/// between connections and Windows requires interface names to be unique.
+const ADAPTER_NAME: &str = "Mullvad GotaTun";
+/// Tunnel adapter type. Unlike the name, this does not have to be unique. It ends up in the
+/// description of the network adapter.
+const ADAPTER_TYPE: &str = "Mullvad";
 /// Tunnel adapter GUID.
 /// Reuse the same ID, if possible. This prevents Windows from thinking it's a
 /// "new network".
@@ -192,7 +198,7 @@ impl WindowsTunProvider {
         // SAFETY: `wintun_path` refers to the wintun.dll shipped with the app.
         let wintun =
             unsafe { wintun_bindings::load_from_path(&wintun_path) }.map_err(Error::LoadWintun)?;
-        let adapter = Adapter::create(&wintun, ADAPTER_NAME, ADAPTER_NAME, Some(ADAPTER_GUID))
+        let adapter = Adapter::create(&wintun, ADAPTER_NAME, ADAPTER_TYPE, Some(ADAPTER_GUID))
             .map_err(Error::CreateAdapter)?;
 
         self.adapter = Some(adapter);

--- a/talpid-windows/src/net.rs
+++ b/talpid-windows/src/net.rs
@@ -20,9 +20,10 @@ use windows_sys::{
             IpHelper::{
                 ConvertInterfaceAliasToLuid, ConvertInterfaceLuidToAlias,
                 ConvertInterfaceLuidToGuid, ConvertInterfaceLuidToIndex,
-                CreateUnicastIpAddressEntry, FreeMibTable, GetUnicastIpAddressTable,
-                InitializeUnicastIpAddressEntry, MIB_IPINTERFACE_ROW, MIB_UNICASTIPADDRESS_ROW,
-                MIB_UNICASTIPADDRESS_TABLE, MibAddInstance, SetIpInterfaceEntry,
+                CreateUnicastIpAddressEntry, DeleteUnicastIpAddressEntry, FreeMibTable,
+                GetUnicastIpAddressTable, InitializeUnicastIpAddressEntry, MIB_IPINTERFACE_ROW,
+                MIB_UNICASTIPADDRESS_ROW, MIB_UNICASTIPADDRESS_TABLE, MibAddInstance,
+                SetIpInterfaceEntry,
             },
             Ndis::{IF_MAX_STRING_SIZE, NET_LUID_LH},
         },
@@ -62,6 +63,11 @@ pub enum Error {
     #[cfg(windows)]
     #[error("Failed to create unicast IP address")]
     CreateUnicastEntry(#[source] io::Error),
+
+    /// Error returned from `DeleteUnicastIpAddressEntry`
+    #[cfg(windows)]
+    #[error("Failed to delete unicast IP address")]
+    DeleteUnicastEntry(#[source] io::Error),
 
     /// Unexpected DAD state returned for a unicast address
     #[cfg(windows)]
@@ -666,6 +672,34 @@ pub fn add_ip_address_for_interface(luid: NET_LUID_LH, address: IpAddr) -> Resul
 
     win32_err!(unsafe { CreateUnicastIpAddressEntry(&raw const row) })
         .map_err(Error::CreateUnicastEntry)
+}
+
+/// Returns every unicast IP address for the given interface.
+pub fn get_ip_addresses_for_interface(luid: NET_LUID_LH) -> Result<Vec<IpAddr>> {
+    get_unicast_table(None)
+        .map_err(Error::ObtainUnicastAddress)?
+        .into_iter()
+        .filter(|row| {
+            // SAFETY: This is always valid as a `u64`.
+            unsafe { row.InterfaceLuid.Value == luid.Value }
+        })
+        .map(|row| Ok(try_socketaddr_from_inet_sockaddr(row.Address)?.ip()))
+        .collect()
+}
+
+/// Removes a unicast IP address from the given interface.
+pub fn delete_ip_address_for_interface(luid: NET_LUID_LH, address: IpAddr) -> Result<()> {
+    let mut row = MIB_UNICASTIPADDRESS_ROW::default();
+    // SAFETY: `row` is a valid pointer to a zeroed `MIB_UNICASTIPADDRESS_ROW`.
+    unsafe { InitializeUnicastIpAddressEntry(&raw mut row) };
+
+    row.InterfaceLuid = luid;
+    row.Address = inet_sockaddr_from_socketaddr(SocketAddr::new(address, 0));
+
+    // SAFETY: `row` has been initialized with `InitializeUnicastIpAddressEntry` and populated
+    // with a valid `InterfaceLuid` and `Address`.
+    win32_err!(unsafe { DeleteUnicastIpAddressEntry(&raw const row) })
+        .map_err(Error::DeleteUnicastEntry)
 }
 
 /// Sets MTU on the specified network interface identified by `luid`.

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -228,6 +228,16 @@ impl WireguardMonitor {
             &bypass,
         )?;
 
+        // Do not reuse the tunnel adapter that the previous attempt left behind. This is a
+        // precaution in case the interface gets broken in some way. Creating a new interface
+        // is cheap compared to being unable to connect.
+        #[cfg(target_os = "windows")]
+        if args.retry_attempt > 0 {
+            log::debug!("Creating a new tunnel adapter, since the previous attempt failed");
+            args.tun_provider.lock().unwrap().close_adapter();
+            wireguard_nt::close_cached_adapter();
+        }
+
         #[cfg(target_os = "windows")]
         let (setup_done_tx, setup_done_rx) = mpsc::channel(0);
         let tunnel = Self::open_tunnel(

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -709,12 +709,8 @@ impl WireguardMonitor {
     ) -> Result<TunnelType> {
         log::debug!("Tunnel MTU: {}", config.mtu);
 
-        // Both implementations keep their tunnel adapter alive between connections, and both
-        // adapters have the same name, so destroy the one that is not about to be used.
         if userspace_wireguard {
             log::debug!("Using userspace WireGuard implementation");
-
-            wireguard_nt::close_cached_adapter();
 
             let tunnel = runtime
                 .block_on(gotatun::open_gotatun_tunnel(config, tun_provider, bypass))
@@ -722,8 +718,6 @@ impl WireguardMonitor {
             Ok(tunnel)
         } else {
             log::debug!("Using kernel WireGuard implementation");
-
-            tun_provider.lock().unwrap().close_adapter();
 
             wireguard_nt::WgNtTunnel::start_tunnel(config, _log_path, resource_dir, setup_done_tx)
                 .map(|tun| Box::new(tun) as Box<dyn Tunnel + 'static>)

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -100,11 +100,6 @@ pub enum Error {
     #[cfg(windows)]
     #[error("Failed to set up IP interfaces")]
     IpInterfacesError,
-
-    /// Failed to set IP addresses on WireGuard interface
-    #[cfg(target_os = "windows")]
-    #[error("Failed to set IP addresses on WireGuard interface")]
-    SetIpAddressesError(#[source] talpid_windows::net::Error),
 }
 
 impl Error {
@@ -282,8 +277,7 @@ impl WireguardMonitor {
             let obfuscator = moved_obfuscator;
             #[cfg(windows)]
             if !userspace_wireguard {
-                Self::add_device_ip_addresses(&iface_name, &config.tunnel.addresses, setup_done_rx)
-                    .await?;
+                Self::wait_for_device_setup(setup_done_rx).await?;
             }
 
             let metadata = Self::tunnel_metadata(&iface_name, &config);
@@ -675,10 +669,10 @@ impl WireguardMonitor {
         AllowedTunnelTraffic::All
     }
 
+    /// Wait for the tunnel device to be configured, including its IP addresses, by
+    /// [`wireguard_nt`].
     #[cfg(windows)]
-    async fn add_device_ip_addresses(
-        iface_name: &str,
-        addresses: &[std::net::IpAddr],
+    async fn wait_for_device_setup(
         mut setup_done_rx: mpsc::Receiver<std::result::Result<(), BoxedError>>,
     ) -> std::result::Result<(), CloseMsg> {
         use futures::StreamExt;
@@ -694,29 +688,6 @@ impl WireguardMonitor {
                 log::error!(
                     "{}",
                     error.display_chain_with_msg("Failed to configure tunnel interface")
-                );
-            })
-            .map_err(|_| CloseMsg::SetupError(Error::IpInterfacesError))?;
-
-        // TODO: The LUID can be obtained directly.
-        let luid = talpid_windows::net::luid_from_alias(iface_name).map_err(|error| {
-            log::error!("Failed to obtain tunnel interface LUID: {}", error);
-            CloseMsg::SetupError(Error::IpInterfacesError)
-        })?;
-        for address in addresses {
-            talpid_windows::net::add_ip_address_for_interface(luid, *address)
-                .map_err(|error| CloseMsg::SetupError(Error::SetIpAddressesError(error)))?;
-        }
-
-        // Wait for the addresses to become usable. Until they are, they cannot be selected as
-        // source addresses, so connections made this early may be routed out another interface and
-        // blocked (WSAEACCES). Suspected, not confirmed: they are normally usable right away.
-        talpid_windows::net::wait_for_addresses(luid, addresses.to_vec())
-            .await
-            .inspect_err(|error| {
-                log::error!(
-                    "{}",
-                    error.display_chain_with_msg("Failed to wait for tunnel IP addresses")
                 );
             })
             .map_err(|_| CloseMsg::SetupError(Error::IpInterfacesError))?;
@@ -738,8 +709,12 @@ impl WireguardMonitor {
     ) -> Result<TunnelType> {
         log::debug!("Tunnel MTU: {}", config.mtu);
 
+        // Both implementations keep their tunnel adapter alive between connections, and both
+        // adapters have the same name, so destroy the one that is not about to be used.
         if userspace_wireguard {
             log::debug!("Using userspace WireGuard implementation");
+
+            wireguard_nt::close_cached_adapter();
 
             let tunnel = runtime
                 .block_on(gotatun::open_gotatun_tunnel(config, tun_provider, bypass))
@@ -747,6 +722,8 @@ impl WireguardMonitor {
             Ok(tunnel)
         } else {
             log::debug!("Using kernel WireGuard implementation");
+
+            tun_provider.lock().unwrap().close_adapter();
 
             wireguard_nt::WgNtTunnel::start_tunnel(config, _log_path, resource_dir, setup_done_tx)
                 .map(|tun| Box::new(tun) as Box<dyn Tunnel + 'static>)

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -729,6 +729,11 @@ impl WireguardMonitor {
         } else {
             log::debug!("Using kernel WireGuard implementation");
 
+            // The wintun adapter is kept alive between connections, and it holds the very
+            // addresses that this tunnel is about to configure. A wireguard-nt adapter releases
+            // them when it is parked, so there is nothing to do in the other direction.
+            tun_provider.lock().unwrap().release_addresses();
+
             wireguard_nt::WgNtTunnel::start_tunnel(config, _log_path, resource_dir, setup_done_tx)
                 .map(|tun| Box::new(tun) as Box<dyn Tunnel + 'static>)
                 .map_err(Error::TunnelError)

--- a/talpid-wireguard/src/wireguard_nt/mod.rs
+++ b/talpid-wireguard/src/wireguard_nt/mod.rs
@@ -21,7 +21,10 @@ use std::{
     path::Path,
     pin::Pin,
     ptr,
-    sync::{Arc, LazyLock, Mutex},
+    sync::{
+        Arc, LazyLock, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use talpid_tunnel_config_client::DaitaSettings;
@@ -41,6 +44,8 @@ use windows_sys::{
 };
 
 static WG_NT_DLL: OnceCell<WgNtDll> = OnceCell::new();
+/// The adapter that is kept alive between connections. See [`WgNtAdapter::open`].
+static CACHED_ADAPTER: Mutex<Option<Arc<WgNtAdapter>>> = Mutex::new(None);
 static ADAPTER_TYPE: LazyLock<U16CString> =
     LazyLock::new(|| U16CString::from_str("Mullvad").unwrap());
 static ADAPTER_ALIAS: LazyLock<U16CString> =
@@ -133,6 +138,22 @@ pub enum Error {
     /// Error listening to tunnel IP interfaces
     #[error("Failed to wait on tunnel IP interfaces")]
     IpInterfaces(#[source] io::Error),
+
+    /// Failed to set an IP address on the tunnel device
+    #[error("Failed to set IP address")]
+    SetIp(#[source] net::Error),
+
+    /// Failed to remove an IP address that is no longer in use
+    #[error("Failed to remove a stale IP address")]
+    RemoveIp(#[source] net::Error),
+
+    /// Failed to list the IP addresses of the tunnel device
+    #[error("Failed to list the addresses of the tunnel device")]
+    ListIps(#[source] net::Error),
+
+    /// Timeout waiting for the tunnel IP addresses to become usable
+    #[error("Failed to wait for tunnel IP addresses")]
+    WaitForAddresses(#[source] net::Error),
 
     /// Failed to set MTU and metric on tunnel device
     #[error("Failed to set tunnel interface MTU")]
@@ -401,7 +422,6 @@ struct WgInterface {
 /// See `WIREGUARD_ADAPTER_LOG_STATE` at <https://git.zx2c4.com/wireguard-nt/tree/api/wireguard.h>.
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 #[repr(C)]
-#[expect(dead_code)]
 enum WgAdapterState {
     Down = 0,
     Up = 1,
@@ -437,8 +457,7 @@ impl WgNtTunnel {
     ) -> Result<Self> {
         let dll = load_wg_nt_dll(resource_dir)?;
         let logger_handle = LoggerHandle::new(dll, log_path)?;
-        let device = WgNtAdapter::create(dll, &ADAPTER_ALIAS, &ADAPTER_TYPE, Some(ADAPTER_GUID))
-            .map_err(Error::CreateTunnelDevice)?;
+        let device = WgNtAdapter::open(dll).map_err(Error::CreateTunnelDevice)?;
 
         let interface_name = device.name().map_err(Error::ObtainAlias)?.to_string_lossy();
 
@@ -449,13 +468,11 @@ impl WgNtTunnel {
             );
         }
         device.set_config(config)?;
-        let device2 = Arc::new(device);
-        let device = Some(device2.clone());
 
-        let setup_future = setup_ip_listener(
-            device2.clone(),
+        let setup_future = setup_tunnel_device(
+            device.clone(),
             u32::from(config.mtu),
-            config.tunnel.addresses.iter().any(|addr| addr.is_ipv6()),
+            config.tunnel.addresses.clone(),
         );
         let setup_handle = tokio::spawn(async move {
             let _ = done_tx
@@ -465,7 +482,7 @@ impl WgNtTunnel {
 
         Ok(WgNtTunnel {
             config: Arc::new(Mutex::new(config.clone())),
-            device,
+            device: Some(device),
             interface_name,
             setup_handle,
             _logger_handle: logger_handle,
@@ -474,15 +491,36 @@ impl WgNtTunnel {
 
     fn stop_tunnel(&mut self) {
         self.setup_handle.abort();
-        let _ = self.device.take();
+        if let Some(device) = self.device.take() {
+            device.park();
+        }
     }
 }
 
-async fn setup_ip_listener(device: Arc<WgNtAdapter>, mtu: u32, has_ipv6: bool) -> Result<()> {
+/// Configure the tunnel IP interfaces and bring the adapter up.
+///
+/// The adapter is discarded rather than reused if this fails, since it is then in an unknown
+/// state.
+async fn setup_tunnel_device(
+    device: Arc<WgNtAdapter>,
+    mtu: u32,
+    addresses: Vec<IpAddr>,
+) -> Result<()> {
+    setup_tunnel_device_inner(&device, mtu, addresses)
+        .await
+        .inspect_err(|error| {
+            log::warn!("Discarding the tunnel adapter after a failure: {error}");
+            device.mark_broken();
+        })
+}
+
+async fn setup_tunnel_device_inner(
+    device: &WgNtAdapter,
+    mtu: u32,
+    addresses: Vec<IpAddr>,
+) -> Result<()> {
+    let has_ipv6 = addresses.iter().any(|address| address.is_ipv6());
     let luid = device.luid();
-    let luid = NET_LUID_LH {
-        Value: unsafe { luid.Value },
-    };
 
     log::debug!("Waiting for tunnel IP interfaces to arrive");
     net::wait_for_interfaces(luid, true, has_ipv6)
@@ -497,9 +535,28 @@ async fn setup_ip_listener(device: Arc<WgNtAdapter>, mtu: u32, has_ipv6: bool) -
     )
     .map_err(Error::SetTunnelMtu)?;
 
+    device.configure_addresses(luid, &addresses)?;
+
     device
         .set_state(WgAdapterState::Up)
-        .map_err(Error::EnableTunnel)
+        .map_err(Error::EnableTunnel)?;
+
+    // Wait for the addresses to become usable. Until they are, they cannot be selected as source
+    // addresses, so connections made this early may be routed out another interface and blocked
+    // (WSAEACCES). Suspected, not confirmed: they are normally usable right away.
+    net::wait_for_addresses(luid, addresses)
+        .await
+        .map_err(Error::WaitForAddresses)
+}
+
+/// Destroy the adapter that is being kept alive for the next connection, if there is one.
+///
+/// Used to make sure that only one tunnel adapter exists at a time, since the userspace tunnel
+/// implementation creates an adapter of its own with the same name.
+pub fn close_cached_adapter() {
+    if CACHED_ADAPTER.lock().unwrap().take().is_some() {
+        log::debug!("Destroyed the cached WireGuard adapter");
+    }
 }
 
 impl Drop for WgNtTunnel {
@@ -553,6 +610,13 @@ impl Drop for LoggerHandle {
 struct WgNtAdapter {
     dll_handle: &'static WgNtDll,
     handle: RawHandle,
+    /// The addresses that have been added to the adapter, so that they can be removed again.
+    ///
+    /// Only addresses added here are ever removed. Addresses that Windows assigns by itself, such
+    /// as link-local ones, are left alone.
+    configured_addresses: Mutex<Vec<IpAddr>>,
+    /// Whether the adapter may be reused by the next connection. See [`Self::mark_broken`].
+    reusable: AtomicBool,
 }
 
 impl fmt::Debug for WgNtAdapter {
@@ -567,14 +631,70 @@ unsafe impl Send for WgNtAdapter {}
 unsafe impl Sync for WgNtAdapter {}
 
 impl WgNtAdapter {
+    /// Return the adapter that the previous connection left behind, or create a new one.
+    ///
+    /// Creating the adapter is the slowest part of setting up the tunnel. Closing the handle that
+    /// `WireGuardCreateAdapter` returned removes the adapter, so the handle itself is what is kept
+    /// around by [`Self::park`].
+    fn open(dll_handle: &'static WgNtDll) -> io::Result<Arc<Self>> {
+        if let Some(adapter) = CACHED_ADAPTER.lock().unwrap().take() {
+            log::debug!("Reusing the existing WireGuard adapter");
+            return Ok(adapter);
+        }
+        Self::create(
+            dll_handle,
+            &ADAPTER_ALIAS,
+            &ADAPTER_TYPE,
+            Some(ADAPTER_GUID),
+        )
+    }
+
     fn create(
         dll_handle: &'static WgNtDll,
         name: &U16CStr,
         tunnel_type: &U16CStr,
         requested_guid: Option<GUID>,
-    ) -> io::Result<Self> {
+    ) -> io::Result<Arc<Self>> {
         let handle = dll_handle.create_adapter(name, tunnel_type, requested_guid)?;
-        Ok(Self { dll_handle, handle })
+        Ok(Arc::new(Self {
+            dll_handle,
+            handle,
+            configured_addresses: Mutex::new(vec![]),
+            reusable: AtomicBool::new(true),
+        }))
+    }
+
+    /// Keep the adapter alive so that the next connection can reuse it, unless it may be in a bad
+    /// state.
+    ///
+    /// The WireGuard config, including the private key, is discarded and the adapter is brought
+    /// down first, so that a parked adapter can neither pass traffic nor hold on to any keys.
+    fn park(self: Arc<Self>) {
+        if !self.reusable.load(Ordering::Relaxed) {
+            log::debug!("Destroying the WireGuard adapter instead of reusing it");
+            return;
+        }
+        if let Err(error) = self.clear_config() {
+            log::warn!(
+                "{}",
+                error.display_chain_with_msg("Failed to clear the WireGuard config")
+            );
+            return;
+        }
+        if let Err(error) = self.set_state(WgAdapterState::Down) {
+            log::warn!(
+                "{}",
+                error.display_chain_with_msg("Failed to disable the WireGuard adapter")
+            );
+            return;
+        }
+        *CACHED_ADAPTER.lock().unwrap() = Some(self);
+    }
+
+    /// Prevent the adapter from being reused, because an operation on it has failed and it may be
+    /// in a bad state. It is destroyed by [`Self::park`] instead.
+    fn mark_broken(&self) {
+        self.reusable.store(false, Ordering::Relaxed);
     }
 
     fn name(&self) -> io::Result<U16CString> {
@@ -588,12 +708,57 @@ impl WgNtAdapter {
     }
 
     fn set_config(&self, config: &Config) -> Result<()> {
-        let config_buffer = serialize_config(config)?;
+        self.write_config(&serialize_config(config)?)
+    }
+
+    /// Remove the private key and every peer from the adapter, so that it cannot pass any traffic.
+    fn clear_config(&self) -> Result<()> {
+        let header = WgInterface {
+            flags: WgInterfaceFlag::HAS_PRIVATE_KEY | WgInterfaceFlag::REPLACE_PEERS,
+            listen_port: 0,
+            private_key: [0u8; WIREGUARD_KEY_LENGTH],
+            public_key: [0u8; WIREGUARD_KEY_LENGTH],
+            peers_count: 0,
+        };
+        self.write_config(as_uninit_byte_slice(&header))
+    }
+
+    fn write_config(&self, config: &[MaybeUninit<u8>]) -> Result<()> {
         unsafe {
             self.dll_handle
-                .set_config(self.handle, config_buffer.as_ptr(), config_buffer.len())
-                .map_err(Error::SetWireGuardConfig)
+                .set_config(self.handle, config.as_ptr(), config.len())
         }
+        .map_err(Error::SetWireGuardConfig)
+        .inspect_err(|_| self.mark_broken())
+    }
+
+    /// Give the tunnel device exactly the addresses in `addresses`.
+    ///
+    /// A reused adapter still has the addresses of the previous connection, and adding an address
+    /// that is already configured fails, so the addresses that are no longer wanted have to be
+    /// removed first.
+    fn configure_addresses(&self, luid: NET_LUID_LH, addresses: &[IpAddr]) -> Result<()> {
+        let mut configured_addresses = self.configured_addresses.lock().unwrap();
+
+        for address in configured_addresses.iter() {
+            if !addresses.contains(address) {
+                net::delete_ip_address_for_interface(luid, *address).map_err(Error::RemoveIp)?;
+            }
+        }
+
+        // The adapter may also have addresses that we did not add ourselves, either because it
+        // outlived a previous daemon or because Windows assigned them.
+        let existing = net::get_ip_addresses_for_interface(luid).map_err(Error::ListIps)?;
+
+        for address in addresses {
+            if !existing.contains(address) {
+                net::add_ip_address_for_interface(luid, *address).map_err(Error::SetIp)?;
+            }
+        }
+
+        *configured_addresses = addresses.to_vec();
+
+        Ok(())
     }
 
     #[expect(clippy::type_complexity)]
@@ -610,6 +775,7 @@ impl WgNtAdapter {
 
     fn set_state(&self, state: WgAdapterState) -> io::Result<()> {
         unsafe { self.dll_handle.set_adapter_state(self.handle, state) }
+            .inspect_err(|_| self.mark_broken())
     }
 
     fn set_logging(&self, state: WireGuardAdapterLogState) -> io::Result<()> {

--- a/talpid-wireguard/src/wireguard_nt/mod.rs
+++ b/talpid-wireguard/src/wireguard_nt/mod.rs
@@ -46,8 +46,14 @@ use windows_sys::{
 static WG_NT_DLL: OnceCell<WgNtDll> = OnceCell::new();
 /// The adapter that is kept alive between connections. See [`WgNtAdapter::open`].
 static CACHED_ADAPTER: Mutex<Option<Arc<WgNtAdapter>>> = Mutex::new(None);
+/// Tunnel adapter type. Unlike the alias, this does not have to be unique. It ends up in the
+/// description of the network adapter.
 static ADAPTER_TYPE: LazyLock<U16CString> =
     LazyLock::new(|| U16CString::from_str("Mullvad").unwrap());
+/// Tunnel adapter name.
+///
+/// This must differ from the name of the wintun adapter, since both adapters are kept alive
+/// between connections and Windows requires interface names to be unique.
 static ADAPTER_ALIAS: LazyLock<U16CString> =
     LazyLock::new(|| U16CString::from_str("Mullvad").unwrap());
 
@@ -547,16 +553,6 @@ async fn setup_tunnel_device_inner(
     net::wait_for_addresses(luid, addresses)
         .await
         .map_err(Error::WaitForAddresses)
-}
-
-/// Destroy the adapter that is being kept alive for the next connection, if there is one.
-///
-/// Used to make sure that only one tunnel adapter exists at a time, since the userspace tunnel
-/// implementation creates an adapter of its own with the same name.
-pub fn close_cached_adapter() {
-    if CACHED_ADAPTER.lock().unwrap().take().is_some() {
-        log::debug!("Destroyed the cached WireGuard adapter");
-    }
 }
 
 impl Drop for WgNtTunnel {

--- a/talpid-wireguard/src/wireguard_nt/mod.rs
+++ b/talpid-wireguard/src/wireguard_nt/mod.rs
@@ -671,11 +671,19 @@ impl WgNtAdapter {
     /// Keep the adapter alive so that the next connection can reuse it, unless it may be in a bad
     /// state.
     ///
-    /// The WireGuard config, including the private key, is discarded and the adapter is brought
-    /// down first, so that a parked adapter can neither pass traffic nor hold on to any keys.
+    /// The IP addresses and the WireGuard config, including the private key, are discarded and the
+    /// adapter is brought down first, so that a parked adapter can neither pass traffic nor hold
+    /// on to any keys or addresses.
     fn park(self: Arc<Self>) {
         if !self.reusable.load(Ordering::Relaxed) {
             log::debug!("Destroying the WireGuard adapter instead of reusing it");
+            return;
+        }
+        if let Err(error) = self.release_addresses() {
+            log::warn!(
+                "{}",
+                error.display_chain_with_msg("Failed to remove the tunnel IP addresses")
+            );
             return;
         }
         if let Err(error) = self.clear_config() {
@@ -761,6 +769,21 @@ impl WgNtAdapter {
         }
 
         *configured_addresses = addresses.to_vec();
+
+        Ok(())
+    }
+
+    /// Remove the IP addresses that were added to the adapter.
+    ///
+    /// The tunnel addresses do not depend on which tunnel implementation is used, and Windows only
+    /// lets one interface have a given address, so an idle adapter must not hold on to them.
+    fn release_addresses(&self) -> Result<()> {
+        let luid = self.luid();
+        let mut configured_addresses = self.configured_addresses.lock().unwrap();
+
+        for address in configured_addresses.drain(..) {
+            net::delete_ip_address_for_interface(luid, address).map_err(Error::RemoveIp)?;
+        }
 
         Ok(())
     }

--- a/talpid-wireguard/src/wireguard_nt/mod.rs
+++ b/talpid-wireguard/src/wireguard_nt/mod.rs
@@ -555,6 +555,14 @@ async fn setup_tunnel_device_inner(
         .map_err(Error::WaitForAddresses)
 }
 
+/// Destroy the adapter that is kept alive for the next connection, if there is one. A new adapter
+/// is created by the next [`WgNtTunnel::start_tunnel`].
+pub fn close_cached_adapter() {
+    if CACHED_ADAPTER.lock().unwrap().take().is_some() {
+        log::debug!("Destroyed the cached WireGuard adapter");
+    }
+}
+
 impl Drop for WgNtTunnel {
     fn drop(&mut self) {
         self.stop_tunnel();


### PR DESCRIPTION
This creates a wintun/wgnt adapter only on first use, and reuses it after that. This saves about ~0.2 s on reconnects. Tunnel devices are destroyed when the daemon is killed or when reusing a device fails.

Five iterations on a Windows 11 host (`tun_timing` example):

    adapter        min      median   max
    destroyed      187.9ms  207.5ms  275.1ms
    kept alive      16.1ms   17.4ms   21.5ms

Fix DES-2970

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11100)
<!-- Reviewable:end -->
