### PR TITLE
Adjust padding on MullvadStateView buttons

### DIFF
--- a/ios/MullvadVPN/Views/MullvadStateView.swift
+++ b/ios/MullvadVPN/Views/MullvadStateView.swift
@@ -127,7 +127,7 @@ extension MullvadStateViewStyle.TextStyle {
 private enum Layout {
     static let topPadding: CGFloat = 0
     static let horizontalPadding: CGFloat = 16
-    static let buttonHorizontalPadding: CGFloat = 8
+    static let buttonHorizontalPadding: CGFloat = 24
     static let bottomPadding: CGFloat = 24
     static let sectionSpacing: CGFloat = 24
     static let bannerSpacing: CGFloat = 16

--- a/ios/MullvadVPN/Views/MullvadStateView.swift
+++ b/ios/MullvadVPN/Views/MullvadStateView.swift
@@ -127,7 +127,7 @@ extension MullvadStateViewStyle.TextStyle {
 private enum Layout {
     static let topPadding: CGFloat = 0
     static let horizontalPadding: CGFloat = 16
-    static let buttonHorizontalPadding: CGFloat = 24
+    static let buttonHorizontalPadding: CGFloat = 16
     static let bottomPadding: CGFloat = 24
     static let sectionSpacing: CGFloat = 24
     static let bannerSpacing: CGFloat = 16


### PR DESCRIPTION
The padding was in `MullvadStateView`.  The design says it should be 24, which is what I have set it to.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11102)
<!-- Reviewable:end -->
