### PR TITLE
Fix latest bug bash bugs

### DIFF
--- a/ios/MullvadVPN/Coordinators/Settings/DAITA/SettingsDAITAView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/DAITA/SettingsDAITAView.swift
@@ -75,7 +75,7 @@ struct SettingsDAITAView<ViewModel>: View where ViewModel: TunnelSettingsObserva
                     userInteraction: .enabledWithoutHighlight,
                     accessibilityIdentifier: .daitaSwitch,
                     leading: {
-                        itemFactory.leading(for: .generic(title: "Enable"))
+                        itemFactory.leading(for: .generic(title: NSLocalizedString("Enable", comment: "")))
                     },
                     trailing: {
                         itemFactory.trailing(for: .toggle(isOn: daitaIsEnabled, isDisabled: false))

--- a/ios/MullvadVPN/Coordinators/Settings/VPNSettingsView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/VPNSettingsView.swift
@@ -143,7 +143,7 @@ struct VPNSettingsView: View {
                 leading: {
                     itemFactory.leading(
                         for: .generic(
-                            title: "WireGuard port",
+                            title: NSLocalizedString("WireGuard port", comment: ""),
                             isSelected: false
                         )
                     )

--- a/ios/MullvadVPN/View controllers/VPNSettings/CustomDNSViewController.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/CustomDNSViewController.swift
@@ -44,19 +44,20 @@ class CustomDNSViewController: UITableViewController {
         tableView.estimatedSectionHeaderHeight = tableView.estimatedRowHeight
 
         let editButtonTopMargin: CGFloat = 8
+        let editButtonBottomMargin: CGFloat = 24
         let footerView = UIView(
             frame: .init(
                 x: 0,
                 y: 0,
                 width: tableView.frame.width,
-                height: UIMetrics.Button.minimumTappableAreaSize.height + editButtonTopMargin
+                height: UIMetrics.Button.minimumTappableAreaSize.height + editButtonTopMargin + editButtonBottomMargin
             ))
         footerView.addConstrainedSubviews([editButton]) {
             editButton.pinEdgesToSuperview(
                 .init([
                     .top(editButtonTopMargin),
                     .leading(UIMetrics.contentInsets.left),
-                    .bottom(0),
+                    .bottom(editButtonBottomMargin),
                     .trailing(UIMetrics.contentInsets.right),
                 ]))
         }


### PR DESCRIPTION
Fixes bugs found in latest bug bash:

- DAITA "enabled" text not being translated
- "WireGuard port" cell title not being translated
- DNS settings button having no padding at the bottom

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11103)
<!-- Reviewable:end -->
