### PR TITLE
Suppress agp warnings in devshell

### DIFF
--- a/nix/android-env.nix
+++ b/nix/android-env.nix
@@ -28,7 +28,10 @@ in
   }
   {
     name = "GRADLE_OPTS";
-    value = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${android-sdk}/share/android-sdk/build-tools/${buildToolsVersion}/aapt2";
+    value = builtins.concatStringsSep " " [
+      "-Dorg.gradle.project.android.aapt2FromMavenOverride=${android-sdk}/share/android-sdk/build-tools/${buildToolsVersion}/aapt2"
+      "-Dorg.gradle.project.android.sync.suppressAgpWarnings=UNSUPPORTED_PROJECT_OPTION_USE"
+    ];
   }
   {
     name = "ANDROID_HOME";


### PR DESCRIPTION
Done to hide the warning about `aapt2FromMavenOverride` being experimental, which it might be forever.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11104)
<!-- Reviewable:end -->
