### PR TITLE
Enable extra kotlin compiler checks

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -292,12 +292,11 @@ tasks
 kotlin {
     compilerOptions {
         allWarningsAsErrors = true
-        freeCompilerArgs =
-            listOf(
-                // Opt-in option for Koin annotation of KoinComponent.
-                "-opt-in=kotlin.RequiresOptIn",
-                "-XXLanguage:+WhenGuards",
-            )
+        freeCompilerArgs.addAll(
+            // Opt-in option for Koin annotation of KoinComponent.
+            "-opt-in=kotlin.RequiresOptIn",
+            "-XXLanguage:+WhenGuards",
+        )
     }
 }
 

--- a/android/gradle/build-logic/build.gradle.kts
+++ b/android/gradle/build-logic/build.gradle.kts
@@ -3,6 +3,13 @@ plugins {
     alias(libs.plugins.ktfmt)
 }
 
+kotlin {
+    compilerOptions {
+        allWarningsAsErrors = true
+        freeCompilerArgs.add("-Wextra")
+    }
+}
+
 ktfmt {
     kotlinLangStyle()
     maxWidth.set(100)

--- a/android/gradle/build-logic/src/main/kotlin/KotlinToolchainPlugin.kt
+++ b/android/gradle/build-logic/src/main/kotlin/KotlinToolchainPlugin.kt
@@ -1,9 +1,15 @@
+import com.android.build.gradle.api.AndroidBasePlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinBasePluginWrapper
+import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
 import utilities.libs
+
+private val COMPILER_ARGS = listOf("-Wextra")
 
 class KotlinToolchainPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -13,6 +19,18 @@ class KotlinToolchainPlugin : Plugin<Project> {
             plugins.withType(KotlinBasePluginWrapper::class.java) {
                 extensions.configure<KotlinProjectExtension> {
                     jvmToolchain(libs.findVersion("jvm-toolchain").get().toString().toInt())
+                }
+            }
+
+            plugins.withType(AndroidBasePlugin::class.java) {
+                extensions.configure<KotlinAndroidProjectExtension> {
+                    compilerOptions { freeCompilerArgs.addAll(COMPILER_ARGS) }
+                }
+            }
+
+            plugins.withType(KotlinPluginWrapper::class.java) {
+                extensions.configure<KotlinJvmProjectExtension> {
+                    compilerOptions { freeCompilerArgs.addAll(COMPILER_ARGS) }
                 }
             }
         }

--- a/android/lib/grpc/build.gradle.kts
+++ b/android/lib/grpc/build.gradle.kts
@@ -16,7 +16,16 @@ android {
         }
     }
 
-    kotlin { compilerOptions { freeCompilerArgs.add("-XXLanguage:+WhenGuards") } }
+    kotlin {
+        compilerOptions {
+            // Protobuf and gRPC Kotlin generators emits explicit visibility modifiers,
+            // so we exclude that check.
+            freeCompilerArgs.addAll(
+                "-XXLanguage:+WhenGuards",
+                "-Xwarning-level=REDUNDANT_VISIBILITY_MODIFIER:disabled",
+            )
+        }
+    }
 }
 
 protobuf {

--- a/android/lib/map/src/main/kotlin/net/mullvad/mullvadvpn/lib/map/internal/MapSurfaceView.kt
+++ b/android/lib/map/src/main/kotlin/net/mullvad/mullvadvpn/lib/map/internal/MapSurfaceView.kt
@@ -19,7 +19,7 @@ internal class MapSurfaceView(context: Context) : GLSurfaceView(context) {
             field = value
         }
 
-    private val observer = LifecycleEventObserver { source, event ->
+    private val observer = LifecycleEventObserver { _, event ->
         when (event) {
             Lifecycle.Event.ON_RESUME -> onResume()
             Lifecycle.Event.ON_PAUSE -> onPause()

--- a/android/lib/model/build.gradle.kts
+++ b/android/lib/model/build.gradle.kts
@@ -5,7 +5,16 @@ plugins {
     alias(libs.plugins.kotlin.ksp)
 }
 
-android { namespace = "net.mullvad.mullvadvpn.lib.model" }
+android {
+    namespace = "net.mullvad.mullvadvpn.lib.model"
+
+    kotlin {
+        compilerOptions {
+            // Arrow Optics emits explicit visibility modifiers, so we exclude this check.
+            freeCompilerArgs.add("-Xwarning-level=REDUNDANT_VISIBILITY_MODIFIER:disabled")
+        }
+    }
+}
 
 dependencies {
     implementation(libs.kotlinx.serialization.json)

--- a/android/lib/repository/build.gradle.kts
+++ b/android/lib/repository/build.gradle.kts
@@ -9,6 +9,14 @@ android {
     namespace = "net.mullvad.mullvadvpn.lib.repository"
 
     buildFeatures { buildConfig = true }
+
+    kotlin {
+        compilerOptions {
+            // Protobuf Kotlin generator emits explicit visibility modifiers,
+            // so we exclude that check.
+            freeCompilerArgs.add("-Xwarning-level=REDUNDANT_VISIBILITY_MODIFIER:disabled")
+        }
+    }
 }
 
 protobuf {


### PR DESCRIPTION
This PR enables a set of extra kotlin compiler checks. See the following file for the current checks as of `2.4.10`: https://github.com/JetBrains/kotlin/blob/v2.4.10/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/ExtraDeclarationCheckers.kt

Note: The `UnusedVariableAssignmentChecker` is rather limited implied by its header comment:
```
A checker for tracking local variable assignments which are unused.
```
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11106)
<!-- Reviewable:end -->
