### PR TITLE
Put PQ feature chip last in order

### DIFF
--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/FeatureIndicatorsViewModel.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/FeatureIndicatorsViewModel.swift
@@ -36,7 +36,6 @@ class FeatureIndicatorsViewModel: ChipViewModelProtocol {
             .connected, .pendingReconnect:
             features = [
                 DaitaFeature(state: tunnelState, settings: tunnelSettings),
-                QuantumResistanceFeature(state: tunnelState),
                 MultihopFeature(state: tunnelState, settings: tunnelSettings),
                 ObfuscationFeature(settings: tunnelSettings, state: observedState),
                 DNSFeature(settings: tunnelSettings),
@@ -44,6 +43,7 @@ class FeatureIndicatorsViewModel: ChipViewModelProtocol {
                 IncludeAllNetworksFeature(settings: tunnelSettings),
                 LocalNetworkSharingFeature(settings: tunnelSettings),
                 IPVersionFeature(state: tunnelState),
+                QuantumResistanceFeature(state: tunnelState),
             ]
 
         case .error, .waitingForConnectivity:


### PR DESCRIPTION
**Why this needs to be done**

It's on by default yet sits above Multihop etc, which provide more relevant information for the user.

**How should this be done?**

Just put it at the bottom of the feature indicator list

**Acceptance criteria**

Quantum resistance is shown last in the feature indicator order

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11108)
<!-- Reviewable:end -->
