### PR TITLE
Document the post-quantum key exchange requirement for the API

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -141,7 +141,7 @@ Linux all applications running as root are able to reach the API in blocking sta
 All API connections use TLS 1.3 with certificate pinning. The app comes bundled with the
 [Let's encrypt root certificate](../mullvad-api/le_root_cert.pem) and only accepts connections
 with servers having a valid certificate issued to `api.mullvad.net` and signed with this
-bundled certificate.
+bundled certificate. The post-quantum X25519MLKEM768 key exchange is required.
 
 TLS session tickets are disabled. Resuming a session identifies the client to the server as one
 it has served before, which would let the Mullvad API server link connections made from different


### PR DESCRIPTION
The `X25519MLKEM768` requirement landed without a matching note among the other properties this connection is locked down to.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11111)
<!-- Reviewable:end -->
