### PR TITLE
Bump changelog and version

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -30,7 +30,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Show obfuscation type in connection view.
 
-## [2026.5]
+## [2026.5 - 2026-09-08]
 ### Fixed
 - Locale-aware sorting of relay list on iOS.
 

--- a/ios/Configurations/Version.xcconfig
+++ b/ios/Configurations/Version.xcconfig
@@ -2,7 +2,7 @@
 VERSIONING_SYSTEM = apple-generic
 
 // Marketing version, aka major.minor
-MARKETING_VERSION = 2026.5
+MARKETING_VERSION = 2026.6
 
 // Build number
 // Normally we reset the build number to 1 after bumping MARKETING_VERSION.


### PR DESCRIPTION
Adding a datestamp for 2026.5 release and bumping version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11114)
<!-- Reviewable:end -->
