### PR TITLE
Space optimisation for iOS end-to-end-tests

### DIFF
--- a/.github/workflows/ios-end-to-end-tests.yml
+++ b/.github/workflows/ios-end-to-end-tests.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           mkdir -p "$JOB_OUTPUTS_DIRECTORY/derived-data"
           cp -R ios/derived-data "$JOB_OUTPUTS_DIRECTORY"
-          rsync -a --exclude='.git' . "$JOB_OUTPUTS_DIRECTORY/mullvadvpn-app" \
+          rsync -a --exclude='.git' --exclude='target' . "$JOB_OUTPUTS_DIRECTORY/mullvadvpn-app" \
             --stats --human-readable
         shell: bash
         env:

--- a/.github/workflows/ios-end-to-end-tests.yml
+++ b/.github/workflows/ios-end-to-end-tests.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Copy build output and project to output directory
         run: |
           mkdir -p "$JOB_OUTPUTS_DIRECTORY/derived-data"
-          cp -R ios/derived-data "$JOB_OUTPUTS_DIRECTORY"
+          cp -RLl ios/derived-data "$JOB_OUTPUTS_DIRECTORY/derived-data"
           rsync -a --exclude='.git' --exclude='target' . "$JOB_OUTPUTS_DIRECTORY/mullvadvpn-app" \
             --stats --human-readable
         shell: bash


### PR DESCRIPTION
- Copy with hardlinks instead of a recursive copy

    Hardlinked files link to the same inode, and do not use more space
    than one folder does. Similar to a pointer linking to the same memory
    address, but then for hard-drives.

- Do not copy `target` folder when preparing for iOS UI Tests

    This seems to be Rust-specific, and is not needed after the app has
    been built.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11116)
<!-- Reviewable:end -->
