### PR TITLE
Put bundles under additional_files

### DIFF
--- a/ci/buildserver-upload.sh
+++ b/ci/buildserver-upload.sh
@@ -66,7 +66,7 @@ while true; do
             file_upload_dir="$upload_path/$version"
             if [[ $platform == "desktop" && ! $filename == MullvadVPN-* ]]; then
                 file_upload_dir="$file_upload_dir/additional-files"
-            elif [[ $platform == "android" && ! $filename =~ MullvadVPN-"$version"(.apk|.play.apk|.play.aab) ]]; then
+            elif [[ $platform == "android" && ! $filename =~ MullvadVPN-"$version"(.apk|.play.apk) ]]; then
                 file_upload_dir="$file_upload_dir/additional-files"
             fi
 


### PR DESCRIPTION
This PR demotes app bundles (`.aab`) to `additional_files` for CDN uploads since those are kept only as a fallback to the automatic Google Play upload. The bundles are also only relevant to us since users will need to install the app as regular APK:s. This change primarily declutters the root dir of each release, which is relevant since we expect new and more relevant files to be published along with each release.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11117)
<!-- Reviewable:end -->
