### PR TITLE
Update netlink crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3884,33 +3884,32 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
-dependencies = [
- "paste",
-]
+checksum = "2d6e2daf9a8c2e21302714706860a0e6be02e03d17294ecc66b354ea7d4059dd"
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.30.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+checksum = "59d48ffc8b73a506e1ff0878528c72668f2bfbc3d875b6be890a96be5d0d5576"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
  "log",
  "netlink-packet-core",
+ "zerocopy",
 ]
 
 [[package]]
 name = "netlink-proto"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
+checksum = "97e03ae6247c6cdb499e8f14e98c72b83954d85822b687056e3a21150b438f2b"
 dependencies = [
  "bytes",
- "futures",
+ "futures-channel",
+ "futures-util",
  "log",
  "netlink-packet-core",
  "netlink-sys",
@@ -3919,9 +3918,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-sys"
-version = "0.8.8"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
+checksum = "c99d38e00b420df49e940fe0826e667c3dad82ac68eb4c2bbf754c1c14a83a10"
 dependencies = [
  "bytes",
  "futures-util",
@@ -4498,12 +4497,6 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
@@ -5301,9 +5294,9 @@ checksum = "33046892e4d999dc17e3790cb23ade37b8308f4bd2f3b05ed51bc5351762c94b"
 
 [[package]]
 name = "rtnetlink"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc19f84f710fa2f337617f9bc0400260a94224bde7bae28fd8879f3771ca5784"
+checksum = "90f60a3ee149005c5819e03e3d73ba4a470bc18b52b0c8422cfe1bea2cae63c6"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -5313,7 +5306,7 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "nix 0.30.1",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
  "tokio",
 ]
 
@@ -6137,7 +6130,6 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-packet-route",
- "netlink-sys",
  "nix 0.31.3",
  "rtnetlink",
  "system-configuration",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,10 +89,10 @@ ipnetwork = "0.21.1"
 itertools = "0.14"
 log = "0.4"
 mockito = "1.7.2"
-netlink-packet-core = "0.8.1"
-netlink-packet-route = "0.30.0"
-netlink-proto = "0.12.0"
-netlink-sys = "0.8.8"
+netlink-packet-core = "0.9.0"
+netlink-packet-route = "0.33.0"
+netlink-proto = "0.13.0"
+netlink-sys = "0.9.0"
 nix = "0.31.2"
 # TODO: if tauri publishes `nsis-plugin-api` to crates.io, remove vendored dependency.
 nsis-plugin-api = { path = "./mullvad-nsis/vendor/nsis-plugin-api" }
@@ -105,7 +105,7 @@ rand = "0.9.3"
 reqwest = { version = "0.12.23", default-features = false, features = [
   "rustls-tls-webpki-roots-no-provider"
 ] }
-rtnetlink = "0.21.0"
+rtnetlink = "0.23.0"
 # `prefer-post-quantum` is a rustls default that `default-features = false`
 # would otherwise drop. It puts X25519MLKEM768 first among the key exchange
 # groups, so every client that does not pin its own groups offers the hybrid

--- a/deny.toml
+++ b/deny.toml
@@ -37,9 +37,6 @@ ignore = [
   # Bincode is unmaintained. Version 1.3.3 is considered "complete" and can still be used
   "RUSTSEC-2025-0141",
 
-  # Paste unmaintained, but considered complete and trusted by the community.
-  "RUSTSEC-2024-0436",
-
   # pqcrypto-* crates are unmaintained, but there are no viable alternative for the HQC algorithm.
   "RUSTSEC-2026-0162",  # pqcrypto-traits
   "RUSTSEC-2026-0163",  # pqcrypto-internals

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -79,15 +79,6 @@ Bincode is unmaintained. maybenot depend on it.
 Version 1.3.3 is considered "complete" and can still be used safely.
 """
 
-# paste is unmaintained. Ignored for six months since the code has no known issues.
-[[IgnoredVulns]]
-id = "RUSTSEC-2024-0436"
-ignoreUntil = 2026-10-25
-reason = """
-Paste unmaintained, but considered complete and trusted by the community.
-netlink-packet-core depends on it.
-"""
-
 # pqcrypto-* crates are unmaintained, but there are no viable alternative for the HQC algorithm.
 
 # pqcrypto-hqc

--- a/talpid-routing/Cargo.toml
+++ b/talpid-routing/Cargo.toml
@@ -24,7 +24,6 @@ jnix = { version = "0.5.2", features = ["derive"] }
 libc = "0.2"
 netlink-packet-core = { workspace = true }
 netlink-packet-route = { workspace = true }
-netlink-sys = { workspace = true }
 rtnetlink = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/talpid-routing/src/unix/linux.rs
+++ b/talpid-routing/src/unix/linux.rs
@@ -12,7 +12,7 @@ use netlink_packet_core::{
     NetlinkPayload,
 };
 use netlink_packet_route::route::RouteFlags;
-use netlink_sys::AsyncSocket;
+use rtnetlink::sys::AsyncSocket;
 use talpid_types::ErrorExt;
 
 use futures::{


### PR DESCRIPTION
Bump netlink-* crates. Doing so got rid of the last dependency on paste. This allowed us to stop ignoring RUSTSEC-2024-0436 (paste is unmaintained).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11127)
<!-- Reviewable:end -->
