### PR TITLE
Stop enabling `mullvad-update`'s `client` feature where unused

### DIFF
--- a/mullvad-api/Cargo.toml
+++ b/mullvad-api/Cargo.toml
@@ -58,7 +58,7 @@ talpid-time = { path = "../talpid-time", features = ["test"] }
 tokio = { workspace = true, features = ["test-util", "time"] }
 
 [target.'cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))'.dependencies]
-mullvad-update = { path = "../mullvad-update", features = ["client"] }
+mullvad-update = { path = "../mullvad-update" }
 
 [features]
 # Allow the API server to use to be configured via MULLVAD_API_HOST and MULLVAD_API_ADDR.

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -118,7 +118,10 @@ insta = { workspace = true, features = ["json"] }
 talpid-time = { path = "../talpid-time", features = ["test"] }
 tokio = { workspace = true, features = ["test-util"] }
 
-[target."cfg(any(unix, windows))".dependencies]
+# In-app upgrades exist on Windows and macOS only, so only they need the
+# download-and-install half of `mullvad-update`. Keep in sync with the
+# `in_app_upgrade` cfg set in `build.rs`.
+[target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
 mullvad-update = { path = "../mullvad-update", features = ["client"] }
 
 [target.'cfg(target_os="android")'.dependencies]
@@ -138,6 +141,9 @@ notify = "8.0.0"
 objc2-foundation = { version = "0.3.1", features = ["NSProcessInfo", "NSString", "NSURL"] }
 objc2-service-management = { version = "0.3.1", features = ["SMAppService", "objc2"] }
 talpid-macos = { path = "../talpid-macos" }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+mullvad-update = { path = "../mullvad-update" }
 
 [target."cfg(unix)".dependencies]
 nix = { workspace = true, features = ["signal", "user"] }

--- a/mullvad-update/Cargo.toml
+++ b/mullvad-update/Cargo.toml
@@ -49,6 +49,7 @@ tokio = { workspace = true, features = ["fs", "macros", "test-util", "time"] }
 
 [features]
 default = []
+# Downloading, verifying and running app installers. Without it, only version metadata handling.
 client = ["reqwest", "rustls", "rustls-pki-types", "thiserror", "tokio", "webpki-roots"]
 sign = ["clap", "rand_core"]
 

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -1606,7 +1606,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1628,16 +1627,13 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
- "ipnet",
  "libc",
- "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.5",
  "tokio",
@@ -1888,16 +1884,6 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
  "serde",
 ]
 
@@ -2433,16 +2419,10 @@ dependencies = [
  "mullvad-api-constants",
  "mullvad-version",
  "rand 0.9.4",
- "reqwest",
- "rustls",
- "rustls-pki-types",
  "serde",
  "serde_json",
  "sha2",
- "thiserror 2.0.18",
- "tokio",
  "vec1",
- "webpki-roots",
  "zeroize",
 ]
 
@@ -3156,43 +3136,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3704,9 +3647,6 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
 
 [[package]]
 name = "synstructure"
@@ -4277,24 +4217,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-http"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
-dependencies = [
- "bitflags 2.11.1",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "iri-string",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4606,16 +4528,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.70"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4679,16 +4591,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.97"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]


### PR DESCRIPTION
`mullvad-api` only uses the metadata format and version selection parts of `mullvad-update`, never the downloader, so it does not need the `client` feature on any target. `mullvad-daemon` needs it only where in-app upgrades exist, which is Windows and macOS.

Every use of `mullvad-update` in the daemon is gated on either `not(target_os = "android")` or `in_app_upgrade`, so Android does not need the crate at all.

This keeps `reqwest`, `hyper-rustls`, `tower-http` and `iri-string` out of the Linux and Android builds, where that feature was their only reason to be built.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11133)
<!-- Reviewable:end -->
