### PR TITLE
Change how and when we cache Rust artifacts in CI

### DIFF
--- a/.github/actions/mullvad-build-env/action.yml
+++ b/.github/actions/mullvad-build-env/action.yml
@@ -13,18 +13,11 @@ inputs:
     description: "Token for setup-protoc (defaults to GITHUB_TOKEN)"
     default: "${{ github.token }}"
     required: false
-  rust-cache-targets:
-    description: >-
-      Determines whether workspace `target` directories are cached. If `false`,
-      only the cargo registry will be cached. If `true`, the `target` directories
-      will be cached as well.
-    default: "false"
-    required: false
   cache-rust-targets:
     description: >-
-      Determines whether the Rust cache is set up at all. Set to `false` for jobs
-      that do not compile Rust, where restoring and saving the cache is pure
-      overhead.
+      Determines whether the Rust cache is set up. Caches both the cargo
+      registry and the workspace `target` directories. Set to `false` for jobs
+      that do not compile Rust, where the cache is pure overhead.
     default: "true"
     required: false
 runs:
@@ -58,9 +51,10 @@ runs:
       uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
       with:
         add-job-id-key: "false"  # Preserve cache across jobs
-        cache-directories: >-
-          ${{ inputs.rust-cache-targets == 'true' && env.CARGO_TARGET_DIR || '' }}
-        cache-targets: ${{ inputs.rust-cache-targets }}
+        # rust-cache only caches `<workspace>/target` and never reads
+        # CARGO_TARGET_DIR, so a target directory outside the workspace has to
+        # be named here. Empty, and therefore ignored, when it is unset.
+        cache-directories: ${{ env.CARGO_TARGET_DIR }}
         # `cache-bin` causes `~/.cargo/bin/rustup` to be deleted for self-hosted runners
         # See https://github.com/Swatinem/rust-cache/issues/16
         cache-bin: false

--- a/.github/actions/mullvad-build-env/action.yml
+++ b/.github/actions/mullvad-build-env/action.yml
@@ -46,11 +46,25 @@ runs:
           echo "CARGO_TARGET_DIR=$CARGO_TARGET_DIR" >> $GITHUB_ENV
         fi
 
+    # Each workflow gets its own cache, so the nightly run that populates it
+    # builds exactly the artifacts that workflow needs. `cargo clippy` and
+    # `cargo doc` only emit metadata, while `cargo build` and `cargo test`
+    # emit compiled libraries, and cargo keys the two under different
+    # fingerprints, so a shared cache would serve one of them useless entries.
+    - name: Derive Rust cache key from the calling workflow
+      if: ${{ inputs.cache-rust-targets == 'true' }}
+      id: rust-cache-key
+      shell: bash
+      run: |
+        # GITHUB_WORKFLOW_REF contains owner/repo/.github/workflows/name.yml@refs/...
+        path="${GITHUB_WORKFLOW_REF%%@*}"            # Strip trailing @refs/...
+        echo "key=${path##*/}" >> "$GITHUB_OUTPUT"   # Keep just the workflow filename
+
     - name: Setup Rust cache
       if: ${{ inputs.cache-rust-targets == 'true' }}
       uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
       with:
-        add-job-id-key: "false"  # Preserve cache across jobs
+        shared-key: ${{ steps.rust-cache-key.outputs.key }}
         # rust-cache only caches `<workspace>/target` and never reads
         # CARGO_TARGET_DIR, so a target directory outside the workspace has to
         # be named here. Empty, and therefore ignored, when it is unset.

--- a/.github/actions/mullvad-build-env/action.yml
+++ b/.github/actions/mullvad-build-env/action.yml
@@ -47,7 +47,7 @@ runs:
         fi
 
     - name: Setup Rust cache
-      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
       with:
         add-job-id-key: "false"  # Preserve cache across jobs
         cache-directories: >-

--- a/.github/actions/mullvad-build-env/action.yml
+++ b/.github/actions/mullvad-build-env/action.yml
@@ -20,6 +20,13 @@ inputs:
       will be cached as well.
     default: "false"
     required: false
+  cache-rust-targets:
+    description: >-
+      Determines whether the Rust cache is set up at all. Set to `false` for jobs
+      that do not compile Rust, where restoring and saving the cache is pure
+      overhead.
+    default: "true"
+    required: false
 runs:
   using: "composite"
   steps:
@@ -47,6 +54,7 @@ runs:
         fi
 
     - name: Setup Rust cache
+      if: ${{ inputs.cache-rust-targets == 'true' }}
       uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
       with:
         add-job-id-key: "false"  # Preserve cache across jobs

--- a/.github/actions/mullvad-build-env/action.yml
+++ b/.github/actions/mullvad-build-env/action.yml
@@ -20,6 +20,12 @@ inputs:
       that do not compile Rust, where the cache is pure overhead.
     default: "true"
     required: false
+  workspaces:
+    description: >-
+      Which Cargo workspaces this job builds, one per line, defaulting to the
+      workspace at the repository root.
+    default: ""
+    required: false
 runs:
   using: "composite"
   steps:
@@ -65,6 +71,7 @@ runs:
       uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
       with:
         shared-key: ${{ steps.rust-cache-key.outputs.key }}
+        workspaces: ${{ inputs.workspaces }}
         # rust-cache only caches `<workspace>/target` and never reads
         # CARGO_TARGET_DIR, so a target directory outside the workspace has to
         # be named here. Empty, and therefore ignored, when it is unset.

--- a/.github/actions/mullvad-build-env/action.yml
+++ b/.github/actions/mullvad-build-env/action.yml
@@ -64,6 +64,11 @@ runs:
         # `cache-bin` causes `~/.cargo/bin/rustup` to be deleted for self-hosted runners
         # See https://github.com/Swatinem/rust-cache/issues/16
         cache-bin: false
+        # Only save the cache when on main, where the scheduled runs populate it.
+        # Uploading caches are expensive. Branches can only see caches from
+        # their own branch and the default branch. So uploading in branches
+        # costs a lot of time and does not give much benefit
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Install Protoc
       uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b  # v3.0.0

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -9,6 +9,10 @@ on:
       - '**/Cargo.toml'  # Lint rules defined in toml files
       - '**/*.rs'
       - '**/*.proto'
+  # Runs on main to populate and refresh the Rust cache in mullvad-build-env
+  schedule:
+    - cron: '0 2 * * *'
+      timezone: 'Europe/Stockholm'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -60,7 +60,6 @@ jobs:
       - uses: ./.github/actions/mullvad-build-env
         with:
           rustup-components: clippy
-          rust-cache-targets: ${{ runner.os == 'Windows' }}
 
       - name: Clippy check
         shell: bash

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -106,7 +106,6 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           add-job-id-key: "false"  # Preserve cache across jobs
-          cache-targets: "false"  # Only cache cargo registry
           # Only save the cache when on main, where the scheduled runs populate it.
           # Uploading caches are expensive. Branches can only see caches from
           # their own branch and the default branch. So uploading in branches
@@ -148,8 +147,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - uses: ./.github/actions/mullvad-build-env
-        with:
-          rust-cache-targets: "true"
 
       - name: Build Windows modules (x86_64)
         if: ${{ matrix.config.arch == 'x64' }}

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
-          add-job-id-key: "false"  # Preserve cache across jobs
+          shared-key: daemon-${{ matrix.rust }}
           # Only save the cache when on main, where the scheduled runs populate it.
           # Uploading caches are expensive. Branches can only see caches from
           # their own branch and the default branch. So uploading in branches

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -100,7 +100,7 @@ jobs:
         run: rustup override set ${{ matrix.rust }}
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           add-job-id-key: "false"  # Preserve cache across jobs
           cache-targets: "false"  # Only cache cargo registry

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -106,6 +106,7 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           shared-key: daemon-${{ matrix.rust }}
+          cache-bin: false
           # Only save the cache when on main, where the scheduled runs populate it.
           # Uploading caches are expensive. Branches can only see caches from
           # their own branch and the default branch. So uploading in branches

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -28,7 +28,10 @@ on:
       - "!rustfmt.toml"
       - "!.yamllint"
       - "!**/osv-scanner.toml"
-
+  # Runs on main to populate and refresh the Rust cache in mullvad-build-env
+  schedule:
+    - cron: '0 5 * * *'
+      timezone: 'Europe/Stockholm'
   workflow_dispatch:
     inputs:
       override_container_image:
@@ -104,6 +107,11 @@ jobs:
         with:
           add-job-id-key: "false"  # Preserve cache across jobs
           cache-targets: "false"  # Only cache cargo registry
+          # Only save the cache when on main, where the scheduled runs populate it.
+          # Uploading caches are expensive. Branches can only see caches from
+          # their own branch and the default branch. So uploading in branches
+          # costs a lot of time and does not give much benefit
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Test crates
         run: ci/cargo-ci.sh test --workspace

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
-          shared-key: daemon-${{ matrix.rust }}
+          shared-key: daemon.yml-${{ matrix.rust }}
           cache-bin: false
           # Only save the cache when on main, where the scheduled runs populate it.
           # Uploading caches are expensive. Branches can only see caches from

--- a/.github/workflows/desktop-grpc-bindings.yml
+++ b/.github/workflows/desktop-grpc-bindings.yml
@@ -19,6 +19,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - uses: ./.github/actions/mullvad-build-env
+        with:
+          # This job only generates JS/proto bindings, it compiles no Rust.
+          cache-rust-targets: "false"
 
       - name: Generate bindings
         working-directory: desktop

--- a/.github/workflows/downloader.yml
+++ b/.github/workflows/downloader.yml
@@ -71,6 +71,7 @@ jobs:
           # rust-cache always assumes the target directory is `<workspace>/target`
           # and never reads CARGO_TARGET_DIR, so point it at the real one.
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
+          cache-bin: false
           # Only save the cache when on main, where the scheduled runs populate it.
           # Uploading caches are expensive. Branches can only see caches from
           # their own branch and the default branch. So uploading in branches
@@ -106,6 +107,7 @@ jobs:
           # Own cache key: this workflow builds a different profile and target
           # set than the other Rust workflows.
           shared-key: installer-downloader
+          cache-bin: false
           # Only save the cache when on main, where the scheduled runs populate it.
           # Uploading caches are expensive. Branches can only see caches from
           # their own branch and the default branch. So uploading in branches

--- a/.github/workflows/downloader.yml
+++ b/.github/workflows/downloader.yml
@@ -29,6 +29,7 @@ on:
   schedule:
     - cron: '20 4 * * *'
       timezone: 'Europe/Stockholm'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/downloader.yml
+++ b/.github/workflows/downloader.yml
@@ -25,6 +25,10 @@ on:
       - '!.*ignore'
       - '!prepare-release.sh'
       - '!**/osv-scanner.toml'
+  # Runs on main to populate and refresh the Rust cache
+  schedule:
+    - cron: '20 4 * * *'
+      timezone: 'Europe/Stockholm'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -44,6 +48,10 @@ jobs:
       # If the file is larger than this, a regression has probably been introduced.
       # You should think twice before increasing this limit.
       MAX_BINARY_SIZE: 3370000
+      # On Windows, the checkout is on the D drive, which is very small.
+      # Moving the target directory to the C drive ensures that the runner
+      # doesn't run out of space on the D drive.
+      CARGO_TARGET_DIR: "C:/cargo-target"
     steps:
       # By default, the longest path a filename can have in git on Windows is 260 character.
       - name: Set git config for long paths
@@ -53,13 +61,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+        with:
+          # Own cache key: this workflow builds a different profile and target
+          # set than the other Rust workflows.
+          shared-key: installer-downloader
+          # rust-cache always assumes the target directory is `<workspace>/target`
+          # and never reads CARGO_TARGET_DIR, so point it at the real one.
+          cache-directories: ${{ env.CARGO_TARGET_DIR }}
+          # Only save the cache when on main, where the scheduled runs populate it.
+          # Uploading caches are expensive. Branches can only see caches from
+          # their own branch and the default branch. So uploading in branches
+          # costs a lot of time and does not give much benefit
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
       - name: Build
         shell: bash
-        env:
-          # On Windows, the checkout is on the D drive, which is very small.
-          # Moving the target directory to the C drive ensures that the runner
-          # doesn't run out of space on the D drive.
-          CARGO_TARGET_DIR: "C:/cargo-target"
         run: ./installer-downloader/build.sh
 
       - name: Check file size
@@ -80,6 +98,18 @@ jobs:
 
       - name: Install Rust
         run: rustup target add x86_64-apple-darwin
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+        with:
+          # Own cache key: this workflow builds a different profile and target
+          # set than the other Rust workflows.
+          shared-key: installer-downloader
+          # Only save the cache when on main, where the scheduled runs populate it.
+          # Uploading caches are expensive. Branches can only see caches from
+          # their own branch and the default branch. So uploading in branches
+          # costs a lot of time and does not give much benefit
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build
         run: ./installer-downloader/build.sh

--- a/.github/workflows/downloader.yml
+++ b/.github/workflows/downloader.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           # Own cache key: this workflow builds a different profile and target
           # set than the other Rust workflows.
-          shared-key: installer-downloader
+          shared-key: downloader.yml
           # rust-cache always assumes the target directory is `<workspace>/target`
           # and never reads CARGO_TARGET_DIR, so point it at the real one.
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
@@ -106,7 +106,7 @@ jobs:
         with:
           # Own cache key: this workflow builds a different profile and target
           # set than the other Rust workflows.
-          shared-key: installer-downloader
+          shared-key: downloader.yml
           cache-bin: false
           # Only save the cache when on main, where the scheduled runs populate it.
           # Uploading caches are expensive. Branches can only see caches from

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -33,6 +33,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - uses: ./.github/actions/mullvad-build-env
+        with:
+          # This workflow only runs npm, it compiles no Rust.
+          cache-rust-targets: "false"
 
       - name: Install dependencies
         working-directory: desktop

--- a/.github/workflows/mullvad-nsis.yml
+++ b/.github/workflows/mullvad-nsis.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - mullvad-nsis/**
       - 'ci/cargo-ci.sh'
+  # Runs on main to populate and refresh the Rust cache in mullvad-build-env
+  schedule:
+    - cron: '0 4 * * *'
+      timezone: 'Europe/Stockholm'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/rust-supply-chain.yml
+++ b/.github/workflows/rust-supply-chain.yml
@@ -20,6 +20,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - uses: ./.github/actions/mullvad-build-env
+        with:
+          # `cargo deny` only reads Cargo.lock metadata, it compiles nothing.
+          cache-rust-targets: "false"
 
       - name: Run cargo deny
         uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe  # v2.0.20

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -70,7 +70,6 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           add-job-id-key: "false"  # Preserve cache across jobs
-          cache-targets: "false"  # Only cache cargo registry
           # Only save the cache when on main, where the scheduled runs populate it.
           # Uploading caches are expensive. Branches can only see caches from
           # their own branch and the default branch. So uploading in branches
@@ -103,8 +102,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - uses: ./.github/actions/mullvad-build-env
-        with:
-          rust-cache-targets: "true"
 
       - name: Check rust docs
         shell: bash

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -64,7 +64,7 @@ jobs:
           git submodule update --init --depth=1 dist-assets/binaries
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           add-job-id-key: "false"  # Preserve cache across jobs
           cache-targets: "false"  # Only cache cargo registry

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -70,6 +70,7 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           add-job-id-key: "false"  # Preserve cache across jobs
+          cache-bin: false
           # Only save the cache when on main, where the scheduled runs populate it.
           # Uploading caches are expensive. Branches can only see caches from
           # their own branch and the default branch. So uploading in branches

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
-          add-job-id-key: "false"  # Preserve cache across jobs
+          shared-key: rustdoc.yml
           cache-bin: false
           # Only save the cache when on main, where the scheduled runs populate it.
           # Uploading caches are expensive. Branches can only see caches from

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -9,7 +9,10 @@ on:
       - "rust-toolchain.toml"
       - "rustfmt.toml"
       - "ci/cargo-ci.sh"
-
+  # Runs on main to populate and refresh the Rust cache in mullvad-build-env
+  schedule:
+    - cron: '40 2 * * *'
+      timezone: 'Europe/Stockholm'
   workflow_dispatch:
     inputs:
       override_container_image:
@@ -68,6 +71,11 @@ jobs:
         with:
           add-job-id-key: "false"  # Preserve cache across jobs
           cache-targets: "false"  # Only cache cargo registry
+          # Only save the cache when on main, where the scheduled runs populate it.
+          # Uploading caches are expensive. Branches can only see caches from
+          # their own branch and the default branch. So uploading in branches
+          # costs a lot of time and does not give much benefit
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check rust docs
         run: ci/cargo-ci.sh doc --workspace --document-private-items --no-deps --keep-going

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: ./.github/actions/mullvad-build-env
         with:
           rustup-components: rustfmt
+          # `cargo fmt` does not compile anything, so there is nothing to cache.
+          cache-rust-targets: "false"
 
       - name: Check formatting
         run: |-

--- a/.github/workflows/testframework-clippy.yml
+++ b/.github/workflows/testframework-clippy.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: ./.github/actions/mullvad-build-env
         with:
           rustup-components: clippy
+          workspaces: test
 
       - name: Clippy check
         working-directory: test
@@ -59,6 +60,7 @@ jobs:
       - uses: ./.github/actions/mullvad-build-env
         with:
           rustup-components: clippy
+          workspaces: test
 
       - name: Clippy check
         working-directory: test

--- a/.github/workflows/testframework-clippy.yml
+++ b/.github/workflows/testframework-clippy.yml
@@ -9,6 +9,10 @@ on:
       - 'test/**/Cargo.toml'  # Lint rules defined in toml files
       - clippy.toml
       - 'ci/cargo-ci.sh'
+  # Runs on main to populate and refresh the Rust cache in mullvad-build-env
+  schedule:
+    - cron: '20 3 * * *'
+      timezone: 'Europe/Stockholm'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/testframework.yml
+++ b/.github/workflows/testframework.yml
@@ -28,6 +28,10 @@ on:
       - '!rustfmt.toml'
       - '!.yamllint'
       - '!**/osv-scanner.toml'
+  # Runs on main to populate and refresh the Rust cache in mullvad-build-env
+  schedule:
+    - cron: '0 3 * * *'
+      timezone: 'Europe/Stockholm'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/testframework.yml
+++ b/.github/workflows/testframework.yml
@@ -93,6 +93,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - uses: ./.github/actions/mullvad-build-env
+        with:
+          workspaces: test
 
       - name: Build test runner
         working-directory: test


### PR DESCRIPTION
We had a bunch of problems related to caching of Rust build artifacts. This PR tries to improve there with the aim to save lots of CI minutes for any Rust related workflow.

The first problem was that in many places we cached only the cargo registry, not the build artifacts. From my measurements, this saved us nothing. With the sparse index and all, cargo can fetch the registry very quickly without any cache.

The second problem was that a github workflow can only read caches from its own branch, or from the default branch. And we only uploaded caches from feature branches, never main. This resulted in every new branch/PR always performing a cold build, with no cache. Then spending a lot of time compressing and uploading what it built to the caches. And the only workflow runs that could make use of this cache was subsequent pushes to the same PR.

It turns out that uploading caches is expensive (compressing the archive), but downloading and unpacking caches is cheap. So uploading caches in every PR branch build was expensive. This PR inverts that by building and uploading Rust caches only on nightly runs on `main`. Then PR branches only download the caches, never upload.

This PR is easiest to review commit for commit, since it changes a few different things and tries to do it incrementally in a nice way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11136)
<!-- Reviewable:end -->
