### PR TITLE
Tray optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ Line wrap the file at 100 chars.                                              Th
   pools, so this has not been necessary since 2022.5-beta1.
 
 ### Fixed
+#### Windows
+- Fix OS theme check for the monochromatic tray-icon.
+
 #### Linux
 - Parse the `resolv.conf` format using `resolv-conf` crate. This will lead to fewer false negatives
   when detecting if NetworkManager manages DNS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Line wrap the file at 100 chars.                                              Th
 - Require the post-quantum X25519MLKEM768 key exchange for TLS connections to the Mullvad API.
 - Disable TLS session tickets to reduce the ability to track clients over time.
 - Remove old log files, such as OpenVPN and wireguard-go logs.
+- Set tray-icon to 'connecting' on TrayIconController creation (start), when auto-connect is turned on.
 
 #### Linux
 - Remove dependency on `iproute2` when using GotaTun with IPv6.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Line wrap the file at 100 chars.                                              Th
 - Disable TLS session tickets to reduce the ability to track clients over time.
 - Remove old log files, such as OpenVPN and wireguard-go logs.
 - Set tray-icon to 'connecting' on TrayIconController creation (start), when auto-connect is turned on.
+- Remove tray-icon delay and add follow-up to ensure state change.
 
 #### Linux
 - Remove dependency on `iproute2` when using GotaTun with IPv6.

--- a/desktop/packages/mullvad-vpn/src/main/index.ts
+++ b/desktop/packages/mullvad-vpn/src/main/index.ts
@@ -1,5 +1,5 @@
 import { exec, execFile } from 'child_process';
-import { app, nativeTheme, powerMonitor, session, shell, systemPreferences } from 'electron';
+import { app, powerMonitor, session, shell, systemPreferences } from 'electron';
 import fs from 'fs';
 import * as path from 'path';
 import util from 'util';
@@ -468,14 +468,6 @@ class ApplicationMain
       await this.userInterface?.updateTrayTheme();
 
       this.userInterface?.updateTray(this.account.isLoggedIn(), this.tunnelState.tunnelState);
-
-      if (process.platform === 'win32') {
-        nativeTheme.on('updated', async () => {
-          if (this.settings.gui.monochromaticIcon) {
-            await this.userInterface?.updateTrayTheme();
-          }
-        });
-      }
     });
 
     this.registerIpcListeners();

--- a/desktop/packages/mullvad-vpn/src/main/index.ts
+++ b/desktop/packages/mullvad-vpn/src/main/index.ts
@@ -461,8 +461,12 @@ class ApplicationMain
     );
 
     this.tunnelStateExpectation = new Expectation(async () => {
+      const initialTunnelState = this.settings.gui.autoConnect
+        ? { state: 'connecting' as const, featureIndicators: undefined }
+        : this.tunnelState.tunnelState;
+
       this.userInterface?.createTrayIconController(
-        this.tunnelState.tunnelState,
+        initialTunnelState,
         this.settings.gui.monochromaticIcon,
       );
       await this.userInterface?.updateTrayTheme();

--- a/desktop/packages/mullvad-vpn/src/main/tray-icon-controller.ts
+++ b/desktop/packages/mullvad-vpn/src/main/tray-icon-controller.ts
@@ -17,8 +17,7 @@ export default class TrayIconController {
   private iconSet: NativeImage[] = [];
   private iconParameters: IconParameters;
 
-  private updateThrottlePromise?: Promise<void>;
-
+  private pendingUpdateFollowUp: ReturnType<typeof setTimeout> | null = null;
   private previousNotificationIconReason?: string;
 
   constructor(
@@ -43,16 +42,18 @@ export default class TrayIconController {
   }
 
   public updateTheme(): Promise<void> {
-    // For some reason the icon doesn't update if the iconSet is changed to quickly. Adding a
-    // throttle fixes this issue.
-    this.updateThrottlePromise ??= new Promise((resolve) => {
-      setTimeout(() => {
-        this.updateThrottlePromise = undefined;
-        void this.updateThemeImpl().then(resolve);
-      }, 200);
-    });
+    if (this.pendingUpdateFollowUp !== null) {
+      clearTimeout(this.pendingUpdateFollowUp);
+    }
 
-    return this.updateThrottlePromise;
+    // For some reason the icon doesn't update if the iconSet is changed too quickly.
+    // Scheduling a follow-up fixes this issue.
+    this.pendingUpdateFollowUp = setTimeout(() => {
+      this.pendingUpdateFollowUp = null;
+      void this.updateThemeImpl();
+    }, 200);
+
+    return this.updateThemeImpl();
   }
 
   public setMonochromaticIcon(monochromaticIcon: boolean) {

--- a/desktop/packages/mullvad-vpn/src/main/user-interface.ts
+++ b/desktop/packages/mullvad-vpn/src/main/user-interface.ts
@@ -349,6 +349,11 @@ export default class UserInterface implements WindowControllerDelegate {
             );
         });
 
+        const WM_SETTINGCHANGE = 0x001a;
+        appWindow.hookWindowMessage(WM_SETTINGCHANGE, async () => {
+          await this.updateTrayTheme();
+        });
+
         appWindow.removeMenu();
 
         return appWindow;


### PR DESCRIPTION
### This PR has 3 tray optimizations.

1. A fix for the tray-icon theme detection (dark/light on monochromatic) on Windows. The old check is inconsistent and primarily looks for the app-theme, not the system-theme (which is the one being relevant for the taskbar).

2. The app will start with the 'connecting' tray-icon, when autoConnect is true. This skips the animations from 'disconnected' to 'connecting', which is not necessary.

3. Tray-icon updates were delayed for 200ms, because too fast changes could skip the update. Now it updates instantly and issues a follow-up (of the same update) after 200ms (to ensure change). When a new follow-up is issued, the pending one is getting skipped.


**Change 2 & 3 might also fix the bug, that the tray-icon is invisible until you are connected (with autoConnect).**

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/11139)
<!-- Reviewable:end -->
